### PR TITLE
Remove whitespace after process names

### DIFF
--- a/gprofiler/merge.py
+++ b/gprofiler/merge.py
@@ -10,7 +10,7 @@ from typing import Dict
 logger = logging.getLogger(__name__)
 
 SAMPLE_REGEX = re.compile(
-    r"\s*(?P<comm>.+)\s+(?P<pid>[\d-]+)/(?P<tid>[\d-]+)(?:\s+\[(?P<cpu>\d+)])?\s+(?P<time>\d+\.\d+):\s+"
+    r"\s*(?P<comm>.+?)\s+(?P<pid>[\d-]+)/(?P<tid>[\d-]+)(?:\s+\[(?P<cpu>\d+)])?\s+(?P<time>\d+\.\d+):\s+"
     r"(?:(?P<freq>\d+)\s+)?(?P<event_family>[\w-]+):(?:(?P<event>[\w-]+):)?(?P<suffix>[^\n]*)(?:\n(?P<stack>.*))?",
     re.MULTILINE | re.DOTALL,
 )


### PR DESCRIPTION
## Description
By turning the <comm> to non-greedy, it would not contain the whitespace that comes after it.
The whitespace is of different length depending on how many digits the pid is so we get stacks
that are "the same" but are not merged because the process name differs

## Motivation and Context
We are seeing flamegraphs where stacks from the same process are not merged, see image below

## How Has This Been Tested?
I looked at collapsed files before the change and after it, the bug is clearly fixed
All existing tests pass

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/3260178/110541270-3145bf80-8130-11eb-8641-1f19791af762.png)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have updated the relevant documentation.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
