### PR TITLE
Update perf to a newer release

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,7 @@ curl -fL https://github.com/Granulate/py-spy/releases/download/v0.3.4g1/py-spy -
 chmod +x gprofiler/resources/python/py-spy
 
 # perf
-curl -fL https://github.com/Granulate/linux/releases/download/v5.6-perf/perf -z gprofiler/resources/perf -o gprofiler/resources/perf
+curl -fL https://github.com/Granulate/linux/releases/download/v5.6g2-perf/perf -z gprofiler/resources/perf -o gprofiler/resources/perf
 chmod +x gprofiler/resources/perf
 
 # burn


### PR DESCRIPTION
## Description
We released a new version of [perf](https://github.com/Granulate/linux/releases/tag/v5.6g2-perf), updating `build.sh` to download it
## Motivation and Context
This perf update will mean that the root stack is the process name instead of the thread name, which is much clearer