### PR TITLE
Change python version to 3.8.5 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8.5]
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Description
There is a bug with `py-spy --gil` and python 3.8.8:
https://github.com/benfred/py-spy/issues/357

Changing the version in CI to avoid it until it is fixed