### PR TITLE
python: Select processes to profile based on "python*" in their exe's basename

### DIFF
--- a/gprofiler/java.py
+++ b/gprofiler/java.py
@@ -15,7 +15,7 @@ import psutil
 from psutil import Process
 
 from .exceptions import StopEventSetException
-from .utils import run_process, pgrep, get_self_container_id, resource_path
+from .utils import run_process, pgrep_exe, get_self_container_id, resource_path
 
 logger = logging.getLogger(__name__)
 
@@ -149,7 +149,7 @@ class JavaProfiler:
     def profile_processes(self):
         futures = []
         results = {}
-        processes = pgrep("^java$")
+        processes = list(pgrep_exe(r"^.+/java$"))
         if not processes:
             return {}
         with concurrent.futures.ThreadPoolExecutor(max_workers=len(processes)) as executor:

--- a/gprofiler/python.py
+++ b/gprofiler/python.py
@@ -9,7 +9,7 @@ from threading import Event
 from typing import Dict
 
 from .exceptions import StopEventSetException, ProcessStoppedException
-from .utils import pgrep, run_process, resource_path
+from .utils import pgrep_exe, run_process, resource_path
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +18,6 @@ PYTHON_PROFILER_MAX_FREQUENCY = 10
 
 class PythonProfiler:
     BLACKLISTED_PYTHON_PROCS = ["unattended-upgrades", "networkd-dispatcher", "supervisord", "tuned"]
-    PYTHON_KNOWN_PROCS = ["python", "uwsgi", "gunicorn", "celery", "ipython", "python3"]
 
     def __init__(self, frequency: int, duration: int, stop_event: Event, storage_dir: str):
         self._frequency = min(frequency, PYTHON_PROFILER_MAX_FREQUENCY)
@@ -69,7 +68,7 @@ class PythonProfiler:
 
     def find_python_processes_to_profile(self) -> Dict[str, str]:
         filtered_procs = {}
-        for process in pgrep("^{}$".format("|".join(self.PYTHON_KNOWN_PROCS))):
+        for process in pgrep_exe(r"^.+/python[^/]*$"):
             try:
                 if process.pid == os.getpid():
                     continue

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -10,7 +10,7 @@ import subprocess
 from functools import lru_cache
 from subprocess import CompletedProcess, Popen, TimeoutExpired
 from threading import Event
-from typing import Union, List, Optional
+from typing import Iterator, Union, List, Optional
 
 import importlib_resources
 import psutil
@@ -103,6 +103,11 @@ def run_process(
 def pgrep(match: str) -> List[Process]:
     pattern = re.compile(match)
     return [process for process in psutil.process_iter() if pattern.match(process.name())]
+
+
+def pgrep_exe(match: str) -> Iterator[Process]:
+    pattern = re.compile(match)
+    return (process for process in psutil.process_iter() if pattern.match(process.exe()))
 
 
 def get_iso8061_format_time(time: datetime.datetime) -> str:

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -100,11 +100,6 @@ def run_process(
     return result
 
 
-def pgrep(match: str) -> List[Process]:
-    pattern = re.compile(match)
-    return [process for process in psutil.process_iter() if pattern.match(process.name())]
-
-
 def pgrep_exe(match: str) -> Iterator[Process]:
     pattern = re.compile(match)
     return (process for process in psutil.process_iter() if pattern.match(process.exe()))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,8 @@ def java_command_line(class_path: Path) -> List:
 def command_line(tmp_path: Path, runtime: str) -> List:
     return {
         "java": java_command_line(tmp_path / "java"),
+        # note: here we run "python /path/to/fibonacci.py" while in the container test we have
+        # "CMD /path/to/fibonacci.py", to test processes with non-python /proc/pid/comm
         "python": ["python3", CONTAINERS_DIRECTORY / "python/fibonacci.py"],
     }[runtime]
 

--- a/tests/containers/python/Dockerfile
+++ b/tests/containers/python/Dockerfile
@@ -3,4 +3,4 @@ FROM python:3.6-alpine
 WORKDIR /app
 ADD fibonacci.py /app
 
-CMD ["python", "/app/fibonacci.py"]
+CMD ["/app/fibonacci.py"]

--- a/tests/containers/python/fibonacci.py
+++ b/tests/containers/python/fibonacci.py
@@ -1,3 +1,4 @@
+#!/usr/local/bin/python
 #
 # Copyright (c) Granulate. All rights reserved.
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.


### PR DESCRIPTION
## Description
This is more accurate than "pgrep python", because a Python script exec'd directly won't
have "python" in its comm (hence the different PYTHON_KNOWN_PROCS we pgrep'd for).
This new approach is more accurate, and it can be taken to further to actually finding
processes with ".*python.*" in their /proc/pid/maps file.

## Motivation and Context
Catch more processes we used to miss.

## How Has This Been Tested?
By running the existing tests + I'll add a test for a Python script with a shebang.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
