### PR TITLE
Support other profiler output formats

### DIFF
--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -106,11 +106,9 @@ class GProfiler:
             try:
                 for future in concurrent.futures.as_completed(futures):
                     if futures[future] in ["java", "python"]:
-                        for pid, collapsed_file in future.result().items():
-                            if collapsed_file is not None:
-                                process_perfs[pid] = Path(collapsed_file).read_text()
+                        process_perfs.update(future.result())
                     else:
-                        system_perf = Path(future.result()).read_text()
+                        system_perf = future.result()
             except KeyboardInterrupt:
                 self._stop_event.set()
                 raise

--- a/gprofiler/perf.py
+++ b/gprofiler/perf.py
@@ -4,12 +4,14 @@
 #
 import logging
 import os
+from pathlib import Path
 from tempfile import NamedTemporaryFile
 from threading import Event
 
 import psutil
 
 from .utils import run_process, resource_path
+from .merge import parse_perf_script
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +56,7 @@ class SystemProfiler:
         logger.info("Running global perf...")
         result = self.run_perf("global")
         logger.info("Finished running global perf")
-        return result
+        return parse_perf_script(Path(result).read_text())
 
         # TODO: run dwarf in parallel, after supporting it in merge.py
         # Alternatively: fix golang dwarf problems and the run just dwarf

--- a/gprofiler/python.py
+++ b/gprofiler/python.py
@@ -5,9 +5,11 @@
 import concurrent.futures
 import logging
 import os
+from pathlib import Path
 from threading import Event
 from typing import Dict
 
+from .merge import parse_collapsed
 from .exceptions import StopEventSetException, ProcessStoppedException
 from .utils import pgrep_exe, run_process, resource_path
 
@@ -64,7 +66,7 @@ class PythonProfiler:
             raise StopEventSetException
 
         logger.info(f"Finished profiling process {pid}")
-        return local_output_path
+        return parse_collapsed(Path(local_output_path).read_text())
 
     def find_python_processes_to_profile(self) -> Dict[str, str]:
         filtered_procs = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from subprocess import Popen, run
 from threading import Event
 from time import sleep
-from typing import Callable, List, Union, Dict, Generator
+from typing import Callable, List, Union, Dict, Generator, Mapping
 
 import docker
 from docker import DockerClient
@@ -105,15 +105,14 @@ def profiler(tmp_path: Path, runtime: str) -> Union[JavaProfiler, PythonProfiler
 
 
 @fixture(scope="session")
-def assert_collapsed(runtime: str) -> Callable[[str], None]:
+def assert_collapsed(runtime: str) -> Callable[[Mapping[str, int]], None]:
     function_name = {
         "java": "Fibonacci.main",
         "python": "fibonacci",
     }[runtime]
 
-    def assert_collapsed(collapsed_path: str) -> None:
-        assert collapsed_path is not None
-        collapsed = Path(collapsed_path).read_text()
-        assert function_name in collapsed
+    def assert_collapsed(collapsed: Mapping[str, int]) -> None:
+        assert collapsed is not None
+        assert any((function_name in record) for record in collapsed.keys())
 
     return assert_collapsed


### PR DESCRIPTION
Preliminary support for defining a profiler which outputs stack-collapsed records in a format different from py-spy and async-profiler.

## Description
Move parsing logic from `main` to each profiler so additional profilers can implement parsing for their own formats.

## Motivation and Context
Current architecture requires all runtime profilers to dump samples in a file in a fixed stack-collapsed format. This PR relaxes this requirement to allow for compatibility with other profilers that output samples in their own custom formats. This allows integrating other profilers more cleanly and easily.

## How Has This Been Tested?
This is a purely architectural change, so relying only on CI tests.

## Screenshots (if appropriate):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
