### PR TITLE
python: Select processes to profile based on python/libpython in their maps

### DIFF
--- a/gprofiler/python.py
+++ b/gprofiler/python.py
@@ -11,7 +11,7 @@ from typing import Dict
 
 from .merge import parse_collapsed
 from .exceptions import StopEventSetException, ProcessStoppedException
-from .utils import pgrep_exe, run_process, resource_path
+from .utils import pgrep_maps, run_process, resource_path
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +70,7 @@ class PythonProfiler:
 
     def find_python_processes_to_profile(self) -> Dict[str, str]:
         filtered_procs = {}
-        for process in pgrep_exe(r"^.+/python[^/]*$"):
+        for process in pgrep_maps(r"^.+/(?:lib)?python[^/]*$"):
             try:
                 if process.pid == os.getpid():
                     continue

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -105,5 +105,10 @@ def pgrep_exe(match: str) -> Iterator[Process]:
     return (process for process in psutil.process_iter() if pattern.match(process.exe()))
 
 
+def pgrep_maps(match: str) -> Iterator[Process]:
+    pattern = re.compile(match)
+    return (process for process in psutil.process_iter() if any(pattern.match(m.path) for m in process.memory_maps()))
+
+
 def get_iso8061_format_time(time: datetime.datetime) -> str:
     return time.replace(microsecond=0).isoformat()

--- a/tests/containers/python/Dockerfile.libpython
+++ b/tests/containers/python/Dockerfile.libpython
@@ -1,0 +1,10 @@
+FROM python:3.6-alpine
+
+WORKDIR /app
+ADD fibonacci.py /app
+# this is used to test that we identify Python processes to profile based on "libpython" in their "/proc/pid/maps".
+# so we'll run a Python script using non-"python" executable ("shmython" instead) but it'll have "libpython"
+# loaded.
+RUN ln /usr/local/bin/python3.6 /usr/local/bin/shmython && ! test -L /usr/local/bin/shmython && ldd /usr/local/bin/shmython | grep libpython > /dev/null
+
+CMD ["/usr/local/bin/shmython", "/app/fibonacci.py"]

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1,0 +1,38 @@
+#
+# Copyright (c) Granulate. All rights reserved.
+# Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
+#
+from docker import DockerClient
+from docker.models.images import Image
+import pytest
+
+from gprofiler.python import PythonProfiler
+
+from tests.conftest import CONTAINERS_DIRECTORY  # type: ignore
+
+
+@pytest.fixture(scope="session")
+def application_docker_image(docker_client: DockerClient, runtime: str) -> Image:
+    dockerfile = CONTAINERS_DIRECTORY / runtime / "Dockerfile.libpython"
+    image: Image = docker_client.images.build(path=str(dockerfile.parent), dockerfile=str(dockerfile))[0]
+    yield image
+    docker_client.images.remove(image.id, force=True)
+
+
+@pytest.fixture(scope="session")
+def runtime(request) -> str:
+    return "python"
+
+
+def test_python_select_by_libpython(
+    profiler: PythonProfiler,
+    application_docker_container,
+    output_directory,
+    assert_collapsed,
+) -> None:
+    """
+    Tests that profiling of processes running Python, whose basename(readlink("/proc/pid/exe")) isn't "python".
+    (for example, uwsgi). We expect to select these because they have "libpython" in their "/proc/pid/maps".
+    """
+    process_collapsed = profiler.profile_processes()
+    assert_collapsed(process_collapsed.get(application_docker_container.attrs["State"]["Pid"]))

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -17,7 +17,7 @@ from gprofiler.merge import parse_collapsed
 def test_from_host(
     application_pid: int,
     profiler: Union[JavaProfiler, PythonProfiler],
-    assert_collapsed: Callable[[Mapping[str, int]], None]
+    assert_collapsed: Callable[[Mapping[str, int]], None],
 ) -> None:
     process_collapsed = profiler.profile_processes()
     assert_collapsed(process_collapsed.get(application_pid))


### PR DESCRIPTION
## Description

In 3e9381bc4ff7 I suggested this change as an improvement, but it's actually required
because we currently miss executables which load libpython, such as uwsgi.

This change means that we'll prefer the Python samples from *any* process which has
libpython loaded, even if it doesn't even run Python code now. We might need to address
that later, by making smarter decisions on the source for our samples.

Fixes: 3e9381bc4ff7

## Motivation and Context

To enable profiling of processes whose basename isn't `python`, such as `uwsgi`.

## How Has This Been Tested?
1. By running `uwsgi` on my box and seeing it "get caught" in the profiler.
2. By the new test `test_python_select_by_libpython`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
