### PR TITLE
python: Upgrade py-spy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8.5]
+        python-version: [3.6, 3.7, 3.8]
 
     runs-on: ubuntu-latest
 

--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ tar -xzf build/async-profiler-1.8.3-linux-x64.tar.gz -C gprofiler/resources/java
 
 # py-spy
 mkdir -p gprofiler/resources/python
-curl -fL https://github.com/Granulate/py-spy/releases/download/v0.3.4g1/py-spy -o gprofiler/resources/python/py-spy
+curl -fL https://github.com/Granulate/py-spy/releases/download/v0.3.5g1/py-spy -o gprofiler/resources/python/py-spy
 chmod +x gprofiler/resources/python/py-spy
 
 # perf

--- a/gprofiler/python.py
+++ b/gprofiler/python.py
@@ -59,6 +59,7 @@ class PythonProfiler:
                     local_output_path,
                     "-p",
                     str(pid),
+                    "--full-filenames",
                 ],
                 stop_event=self._stop_event,
             )


### PR DESCRIPTION
## Description
Upgrade py-spy to its latest release. Also, reverted the change from https://github.com/Granulate/gprofiler/pull/4.

## Motivation and Context
Latest release handles more CPython versions, and exposes the `--full-filenames` flag which is useful for system-wide profiling.

## How Has This Been Tested?
I have run the profiler locally and saw that Python stacks now have full filenames. Additionally, I have run the tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
