### PR TITLE
utils: Provide a more performant implementation of pgrep_maps()

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 120
+# options for compatibility with black - see https://black.readthedocs.io/en/stable/compatible_configs.html#flake8
+extend-ignore = E203, W503

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -105,9 +105,21 @@ def pgrep_exe(match: str) -> Iterator[Process]:
     return (process for process in psutil.process_iter() if pattern.match(process.exe()))
 
 
-def pgrep_maps(match: str) -> Iterator[Process]:
-    pattern = re.compile(match)
-    return (process for process in psutil.process_iter() if any(pattern.match(m.path) for m in process.memory_maps()))
+def pgrep_maps(match: str) -> List[Process]:
+    # this is much faster than iterating over processes' maps with psutil.
+    result = subprocess.run(
+        f"grep -lP '{match}' /proc/*/maps", stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, shell=True
+    )
+    # might get 2 (which 'grep' exits with, if some files were unavailable, because processes have exited)
+    assert result.returncode in (0, 2)
+
+    processes: List[Process] = []
+    for line in result.stdout.splitlines():
+        assert line.startswith(b"/proc/") and line.endswith(b"/maps")
+        pid = int(line[len(b"/proc/") : -len(b"/maps")])
+        processes.append(Process(pid))
+
+    return processes
 
 
 def get_iso8061_format_time(time: datetime.datetime) -> str:

--- a/lint.sh
+++ b/lint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-flake8 . --max-line-length=120
+flake8 --config .flake8 .
 black . --line-length 120 --check
 mypy .

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ import docker
 from docker import DockerClient
 from docker.models.containers import Container
 from docker.models.images import Image
-from pytest import fixture
+from pytest import fixture  # type: ignore
 
 from gprofiler.java import JavaProfiler
 from gprofiler.python import PythonProfiler

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -4,7 +4,7 @@
 #
 from docker import DockerClient
 from docker.models.images import Image
-import pytest
+import pytest  # type: ignore
 
 from gprofiler.python import PythonProfiler
 


### PR DESCRIPTION
## Description
Provide a faster implementation of `pgrep_maps` from https://github.com/Granulate/gprofiler/pull/9.

According to the tests I conducted in that PR, the old `pgrep_maps` wasn't the core issue in gprofiler. However, as the benchmarks here show, it is very slow (compared to what we could get):
```
root@0728b99acd88:/# cat bench.py 
from __future__ import annotations
import subprocess
import sys
from psutil import Process
import re
import psutil

if sys.argv[1] == "new":
    def pgrep_maps(match: str) -> List[Process]:
        # this is much faster than iterating over processes' maps, comparing to psutil.
        result = subprocess.run(
            f"grep -lE '{match}' /proc/*/maps", stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, shell=True, text=True
        )
        # might get 2 (which 'grep' exits with, if some files were unavailable, because processes have exited)
        assert result.returncode in (0, 2)

        processes: List[Process] = []
        for line in result.stdout.splitlines():
            assert line.startswith("/proc/") and line.endswith("/maps")
            pid = int(line[len("/proc/") : -len("/maps")])
            processes.append(Process(pid))

        return processes
else:
    def pgrep_maps(match: str) -> Iterator[Process]:
        pattern = re.compile(match)
        return (process for process in psutil.process_iter() if any(pattern.match(m.path) for m in process.memory_maps()))

for i in range(5):
    print(list(pgrep_maps(r"^.+/(?:lib)?python[^/]*$")))

root@0728b99acd88:/# time python bench.py old
....

real	0m29.349s
user	0m25.708s
sys	0m3.636s
root@0728b99acd88:/# time python bench.py new
....

real	0m0.400s
user	0m0.069s
sys	0m0.333s
```

(I redacted the printed stuff, in both cases it's the same set of processes)

Sometimes it's better to microbenchmark instead of checking the total effect, I guess (as I did in #9 )

## Motivation and Context
Reducing gprofiler's overhead.

## How Has This Been Tested?
I ran it locally, and ran the tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
