### PR TITLE
Fix timestamp formatting into the generated flamegraph

### DIFF
--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -28,7 +28,7 @@ from .perf import SystemProfiler
 from .python import PythonProfiler
 from .utils import is_root, run_process, get_iso8061_format_time, resource_path
 
-logger: Optional[Logger] = None
+logger: Logger
 
 TEMPORARY_STORAGE_PATH = "/tmp/gprofiler"
 
@@ -60,10 +60,12 @@ class GProfiler:
     def close(self):
         self._system_modifications_stack.close()
 
-    def _generate_output_files(self, collapsed_data):
-        base_filename = os.path.join(
-            self._output_dir, "profile_{}".format(get_iso8061_format_time(datetime.datetime.now()))
-        )
+    def _generate_output_files(
+        self, collapsed_data: str, local_start_time: datetime.datetime, local_end_time: datetime.datetime
+    ) -> None:
+        start_ts = get_iso8061_format_time(local_start_time)
+        end_ts = get_iso8061_format_time(local_end_time)
+        base_filename = os.path.join(self._output_dir, "profile_{}".format(end_ts))
         collapsed_path = base_filename + ".col"
         Path(collapsed_path).write_text(collapsed_data)
 
@@ -77,6 +79,8 @@ class GProfiler:
                     [resource_path("burn"), "convert", "--type=folded", collapsed_path], suppress_log=True
                 ).stdout.decode(),
             )
+            .replace("{{{START_TIME}}}", start_ts)
+            .replace("{{{END_TIME}}}", end_ts)
         )
         Path(flamegraph_path).write_text(flamegraph)
         logger.info(f"Saved flamegraph to {flamegraph_path}")
@@ -113,16 +117,14 @@ class GProfiler:
                 self._stop_event.set()
                 raise
 
+            local_end_time = local_start_time + datetime.timedelta(seconds=(time.monotonic() - monotonic_start_time))
             merged_result = merge.merge_perfs(system_perf, process_perfs)
 
             if self._output_dir:
-                self._generate_output_files(merged_result)
+                self._generate_output_files(merged_result, local_start_time, local_end_time)
 
             if self._client:
                 try:
-                    local_end_time = local_start_time + datetime.timedelta(
-                        seconds=(time.monotonic() - monotonic_start_time)
-                    )
                     self._client.submit_profile(local_start_time, local_end_time, gethostname(), merged_result)
                 except Timeout:
                     logger.error("Upload of profile to server timed out.")

--- a/gprofiler/resources/flamegraph/flamegraph_template.html
+++ b/gprofiler/resources/flamegraph/flamegraph_template.html
@@ -37,7 +37,7 @@
     }
     </style>
 
-    <title>gProfiler Result {{{TIMESTAMP}}}</title>
+    <title>gProfiler Result {{{START_TIME}}}</title>
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>


### PR DESCRIPTION
## Description
Fixes timestamp formatting in generated flamegraphs.

## Motivation and Context
See screenshots.

## How Has This Been Tested?
I ran the profiler locally and verified that timestamps are now being formatted in correctly.

## Screenshots (if appropriate):
Was:
![Screenshot from 2021-03-30 19-47-22](https://user-images.githubusercontent.com/8831572/113025578-c583cf00-9190-11eb-8b5a-3ca24524a5d9.png)
![Screenshot from 2021-03-30 19-47-18](https://user-images.githubusercontent.com/8831572/113025584-c74d9280-9190-11eb-8f2d-689e04844002.png)

Now:
![Screenshot from 2021-03-30 19-44-27](https://user-images.githubusercontent.com/8831572/113025505-b270ff00-9190-11eb-92cf-feb2ff85fe53.png)
![Screenshot from 2021-03-30 19-44-21](https://user-images.githubusercontent.com/8831572/113025525-b56bef80-9190-11eb-9d12-8de0e12954c7.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
