### PR TITLE
Revert "Update perf to a newer release (#3)"

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,7 @@ curl -fL https://github.com/Granulate/py-spy/releases/download/v0.3.5g1/py-spy -
 chmod +x gprofiler/resources/python/py-spy
 
 # perf
-curl -fL https://github.com/Granulate/linux/releases/download/v5.6g2-perf/perf -z gprofiler/resources/perf -o gprofiler/resources/perf
+curl -fL https://github.com/Granulate/linux/releases/download/v5.6-perf/perf -z gprofiler/resources/perf -o gprofiler/resources/perf
 chmod +x gprofiler/resources/perf
 
 # burn


### PR DESCRIPTION
## Description
This reverts commit cfa8d59928a32fb653d37ac00925bbfd5b4e3741.

This new release has caused some unwanted side effects on old kernels - we've
used the incorrect "comm" for certain threads.

We suspect it's related to `PERF_RECORD_MISC_COMM_EXEC` not being available in <3.16 (see https://github.com/Granulate/linux/pull/1/commits/8c3e6c8aff99a6d341eeea41abe67eab92f6a417 for the change we are reverting here)

## Motivation and Context
Fixes `perf` stacks in old kernels.

## How Has This Been Tested?
We merely revert to the old version, which was tested.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
