### PR TITLE
java: Improve profiler robustness

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,9 +9,9 @@ mkdir -p build
 
 # async-profiler
 mkdir -p gprofiler/resources/java
-curl -fL https://github.com/Granulate/async-profiler/releases/download/v1.8.3g1/async-profiler-1.8.3-linux-x64.tar.gz \
-   -z build/async-profiler-1.8.3-linux-x64.tar.gz -o build/async-profiler-1.8.3-linux-x64.tar.gz
-tar -xzf build/async-profiler-1.8.3-linux-x64.tar.gz -C gprofiler/resources/java --strip-components=2 async-profiler-1.8.3-linux-x64/build
+curl -fL https://github.com/Granulate/async-profiler/releases/download/v2.0g1/async-profiler-2.0-linux-x64.tar.gz \
+   -z build/async-profiler-2.0-linux-x64.tar.gz -o build/async-profiler-2.0-linux-x64.tar.gz
+tar -xzf build/async-profiler-2.0-linux-x64.tar.gz -C gprofiler/resources/java --strip-components=2 async-profiler-2.0-linux-x64/build
 
 # py-spy
 mkdir -p gprofiler/resources/python

--- a/gprofiler/java.py
+++ b/gprofiler/java.py
@@ -113,7 +113,9 @@ class JavaProfiler:
             return None
 
         process_root = f"/proc/{process.pid}/root"
-        storage_dir_host = resolve_proc_root_links(process_root, self._storage_dir)
+        # we'll use separated storage directories per process: since multiple processes may run in the
+        # same namespace, one may accidentally delete the storage directory of another.
+        storage_dir_host = resolve_proc_root_links(process_root, os.path.join(self._storage_dir, str(process.pid)))
 
         try:
             os.makedirs(storage_dir_host)

--- a/gprofiler/java.py
+++ b/gprofiler/java.py
@@ -17,7 +17,7 @@ from psutil import Process
 
 from .merge import parse_collapsed
 from .exceptions import StopEventSetException
-from .utils import run_process, pgrep_exe, get_self_container_id, resource_path, resolve_proc_root_links, remove_prefix
+from .utils import run_process, pgrep_exe, resource_path, resolve_proc_root_links, remove_prefix
 
 logger = logging.getLogger(__name__)
 
@@ -36,8 +36,6 @@ class JavaProfiler:
         self._use_itimer = use_itimer
         self._stop_event = stop_event
         self._storage_dir = storage_dir
-
-        self._self_container_id = get_self_container_id()
 
     def __enter__(self):
         return self

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -26,11 +26,9 @@ from .client import APIClient, APIError, GRANULATE_SERVER_HOST, DEFAULT_UPLOAD_T
 from .java import JavaProfiler
 from .perf import SystemProfiler
 from .python import PythonProfiler
-from .utils import is_root, run_process, get_iso8061_format_time, resource_path
+from .utils import is_root, run_process, get_iso8061_format_time, resource_path, TEMPORARY_STORAGE_PATH
 
 logger: Logger
-
-TEMPORARY_STORAGE_PATH = "/tmp/gprofiler"
 
 DEFAULT_LOG_FILE = "/var/log/gprofiler/gprofiler.log"
 DEFAULT_LOG_MAX_SIZE = 1024 * 1024 * 5

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -16,7 +16,6 @@ from pathlib import Path
 from socket import gethostname
 from tempfile import TemporaryDirectory
 from threading import Event
-from typing import Optional
 
 import configargparse
 from requests import RequestException, Timeout

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -11,6 +11,7 @@ from functools import lru_cache
 from subprocess import CompletedProcess, Popen, TimeoutExpired
 from threading import Event
 from typing import Iterator, Union, List, Optional
+from pathlib import Path
 
 import importlib_resources
 import psutil
@@ -124,3 +125,32 @@ def pgrep_maps(match: str) -> List[Process]:
 
 def get_iso8061_format_time(time: datetime.datetime) -> str:
     return time.replace(microsecond=0).isoformat()
+
+
+def resolve_proc_root_links(proc_root: str, ns_path: str) -> str:
+    """
+    Resolves "ns_path" which (possibly) resides in another mount namespace.
+
+    If ns_path contains absolute symlinks, it can't be accessed merely by /proc/pid/root/ns_path,
+    because the resolved absolute symlinks will "escape" the /proc/pid/root base.
+
+    To work around that, we resolve the path component by component; if any component "escapes", we
+    add the /proc/pid/root prefix once again.
+    """
+    parts = Path(ns_path).parts
+    assert parts[0] == "/", f"expected {ns_path!r} to be absolute"
+
+    path = proc_root
+    for part in parts[1:]:  # skip the /
+        next_path = os.path.join(path, part)
+        if os.path.islink(next_path):
+            link = os.readlink(next_path)
+            if os.path.isabs(link):
+                # absolute - prefix with proc_root
+                next_path = proc_root + link
+            else:
+                # relative: just join
+                next_path = os.path.join(path, link)
+        path = next_path
+
+    return path

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -154,3 +154,9 @@ def resolve_proc_root_links(proc_root: str, ns_path: str) -> str:
         path = next_path
 
     return path
+
+
+def remove_prefix(s: str, prefix: str) -> str:
+    # like str.removeprefix of Python 3.9, but this also ensures the prefix exists.
+    assert s.startswith(prefix)
+    return s[len(prefix) :]

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -160,3 +160,9 @@ def remove_prefix(s: str, prefix: str) -> str:
     # like str.removeprefix of Python 3.9, but this also ensures the prefix exists.
     assert s.startswith(prefix)
     return s[len(prefix) :]
+
+
+def touch_path(path: str, mode: int) -> None:
+    Path(path).touch()
+    # chmod() afterwards (can't use 'mode' in touch(), because it's affected by umask)
+    os.chmod(path, mode)

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -166,3 +166,7 @@ def touch_path(path: str, mode: int) -> None:
     Path(path).touch()
     # chmod() afterwards (can't use 'mode' in touch(), because it's affected by umask)
     os.chmod(path, mode)
+
+
+def is_same_ns(pid: int, nstype: str) -> bool:
+    return os.stat(f"/proc/self/ns/{nstype}").st_ino == os.stat(f"/proc/{pid}/ns/{nstype}").st_ino

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -21,6 +21,8 @@ from gprofiler.exceptions import CalledProcessError, ProcessStoppedException
 
 logger = logging.getLogger(__name__)
 
+TEMPORARY_STORAGE_PATH = "/tmp/gprofiler"
+
 
 def resource_path(relative_path: str = "") -> str:
     *relative_directory, basename = relative_path.split("/")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,7 +76,7 @@ def application_docker_image(docker_client: DockerClient, runtime: str) -> Image
 
 @fixture
 def application_docker_container(docker_client: DockerClient, application_docker_image: Image) -> Container:
-    container: Container = docker_client.containers.run(application_docker_image, detach=True)
+    container: Container = docker_client.containers.run(application_docker_image, detach=True, user="5555:6666")
     while container.status != "running":
         sleep(1)
         container.reload()


### PR DESCRIPTION
## Description

This PR improves the robustness of the Java profiler.

* Upgrade to async-profiler v2.0
* Use async-profiler's log option to capture errors & warnings, and print them on profiling failure.
* If load fails, check if libasyncProfiler.so was loaded to the target process, and log it accordingly.
* Handle absolute symlinks in other namespaces (resolve part by part in usermode, so it works over /proc/pid/root)
* Use separate temporary directories per profiled process, to avoid possible races when copying libasyncProfiler.so
  and when removing the directories after profiling is done (if the same directory is used by multiple profile_process threads).
* tests: Run Java container as non-root - ensures we give correct permissions to output paths, etc.

## Motivation and Context

Improve the robustness of the Java profiler.

## How Has This Been Tested?
* Our tests
* Injected errors into async-profiler's execution (e.g: using `cpu` mode which is unavailable due to permissions) - errors are printed correctly.
* Tested a container where `/tmp` is a symlink to `/var/tmp`. It runs fine now, but didn't work before this PR.
* Test that async-profiler's existence in `/proc/pid/maps` is printed correctly (on error).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
