### PR TITLE
tests: More fine-grained testing for specific runtimes or profilers.

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,9 @@
+#
+# Copyright (c) Granulate. All rights reserved.
+# Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
+#
+from pathlib import Path
+
+HERE = Path(__file__).parent
+PARENT = HERE.parent
+CONTAINERS_DIRECTORY = HERE / "containers"

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -2,11 +2,10 @@
 # Copyright (c) Granulate. All rights reserved.
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
-import pytest
+import pytest  # type: ignore
 from docker import DockerClient
 from docker.models.images import Image
 from threading import Event
-import pytest  # type: ignore
 
 from gprofiler.python import PythonProfiler
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -2,30 +2,33 @@
 # Copyright (c) Granulate. All rights reserved.
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
+import pytest
 from docker import DockerClient
 from docker.models.images import Image
+from threading import Event
 import pytest  # type: ignore
 
 from gprofiler.python import PythonProfiler
 
-from tests.conftest import CONTAINERS_DIRECTORY  # type: ignore
+from tests import CONTAINERS_DIRECTORY  # type: ignore
+
+
+@pytest.fixture
+def runtime() -> str:
+    return "python"
 
 
 @pytest.fixture(scope="session")
-def application_docker_image(docker_client: DockerClient, runtime: str) -> Image:
-    dockerfile = CONTAINERS_DIRECTORY / runtime / "Dockerfile.libpython"
+def application_docker_image(docker_client: DockerClient) -> Image:
+    dockerfile = CONTAINERS_DIRECTORY / 'python' / "Dockerfile.libpython"
     image: Image = docker_client.images.build(path=str(dockerfile.parent), dockerfile=str(dockerfile))[0]
     yield image
     docker_client.images.remove(image.id, force=True)
 
 
-@pytest.fixture(scope="session")
-def runtime(request) -> str:
-    return "python"
-
-
+@pytest.mark.parametrize('in_container', [True])
 def test_python_select_by_libpython(
-    profiler: PythonProfiler,
+    tmp_path,
     application_docker_container,
     output_directory,
     assert_collapsed,
@@ -34,5 +37,6 @@ def test_python_select_by_libpython(
     Tests that profiling of processes running Python, whose basename(readlink("/proc/pid/exe")) isn't "python".
     (for example, uwsgi). We expect to select these because they have "libpython" in their "/proc/pid/maps".
     """
+    profiler = PythonProfiler(1000, 1, Event(), str(tmp_path))
     process_collapsed = profiler.profile_processes()
     assert_collapsed(process_collapsed.get(application_docker_container.attrs["State"]["Pid"]))


### PR DESCRIPTION
## Description
The `profiler` fixture assumes only a single profiler implementation for a
particular runtime. This change inlines it and requires unit tests to be
written for a particular implementation. The existing test for the gprofiler
docker image remains the same. In addition, we now no longer execute test
applications of runtimes that are not being tested, and we don't execute an
application both within a container and on the host for the same test
permutation.

After this change, it is easier to write tests for a particular profiler
implementation, or for a particular application runtime.

## How Has This Been Tested?
CI.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
