### PR TITLE
Check for availability of "nsenter" before attempting to use it

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ To upload results, you will have to register and generate a token on the website
 
 ## Requirements
 gProfiler works on **Linux** and requires **Python 3.6+** to run.
+
+The `nsenter` program needs to be installed for Java profiling. For Debian/Ubuntu, install the `util-linux` package.
+
 It can produce specialized stack traces for the following runtimes:
 * Java runtimes (version 7+) based on the HotSpot JVM,
 including the Oracle JDK and other builds of OpenJDK like AdoptOpenJDK and Azul Zulu.

--- a/gprofiler/exceptions.py
+++ b/gprofiler/exceptions.py
@@ -26,3 +26,8 @@ class CalledProcessError(subprocess.CalledProcessError):
                 f"Command '{self.cmd}' returned non-zero exit status {self.returncode}. "
                 f"stderr: {self.stderr}, stdout: {self.stdout}"
             )
+
+
+class ProgramMissingException(Exception):
+    def __init__(self, program: str):
+        super().__init__(f"The program {program!r} is missing! Please install it")

--- a/gprofiler/java.py
+++ b/gprofiler/java.py
@@ -24,6 +24,7 @@ from .utils import (
     remove_prefix,
     touch_path,
     is_same_ns,
+    assert_program_installed,
     TEMPORARY_STORAGE_PATH,
 )
 
@@ -99,6 +100,8 @@ class JavaProfiler:
 
     def profile_process(self, process: Process) -> Optional[Mapping[str, int]]:
         logger.info(f"Profiling java process {process.pid}...")
+
+        assert_program_installed("nsenter")
 
         # Get Java version
         try:

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -6,6 +6,7 @@ import datetime
 import logging
 import os
 import re
+import shutil
 import subprocess
 from functools import lru_cache
 from subprocess import CompletedProcess, Popen, TimeoutExpired
@@ -17,7 +18,7 @@ import importlib_resources
 import psutil
 from psutil import Process
 
-from gprofiler.exceptions import CalledProcessError, ProcessStoppedException
+from gprofiler.exceptions import CalledProcessError, ProcessStoppedException, ProgramMissingException
 
 logger = logging.getLogger(__name__)
 
@@ -172,3 +173,16 @@ def touch_path(path: str, mode: int) -> None:
 
 def is_same_ns(pid: int, nstype: str) -> bool:
     return os.stat(f"/proc/self/ns/{nstype}").st_ino == os.stat(f"/proc/{pid}/ns/{nstype}").st_ino
+
+
+_INSTALLED_PROGRAMS_CACHE: List[str] = []
+
+
+def assert_program_installed(program: str):
+    if program in _INSTALLED_PROGRAMS_CACHE:
+        return
+
+    if shutil.which(program) is not None:
+        _INSTALLED_PROGRAMS_CACHE.append(program)
+    else:
+        raise ProgramMissingException(program)


### PR DESCRIPTION
## Description
Check whether `nsenter` is installed or not, and raise a descriptive error if not.

## Motivation and Context
Makes it more more clear that you need to install `nsenter`, when compared to `FileNotFoundError: [Errno 2] No such file or directory: 'nsenter'`.

## How Has This Been Tested?
Ran the container normally - it works fine & profiles Java, because `nsenter` exists.

Then I added some logic to remove `/usr/bin/nsenter` and I got the nice exception.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
