### PR TITLE
flamegraph: burn: use statically linked burn v1.0.1(g2)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -23,9 +23,7 @@ curl -fL https://github.com/Granulate/linux/releases/download/v5.6-perf/perf -z 
 chmod +x gprofiler/resources/perf
 
 # burn
-curl -fL https://github.com/Granulate/burn/releases/download/v1.0.1g1/burn-v1.0.1g1.tar.gz \
- -z build/burn-v1.0.1g1.tar.gz -o build/burn-v1.0.1g1.tar.gz
-tar -xzf build/burn-v1.0.1g1.tar.gz -C gprofiler/resources burn
+curl -fL https://github.com/Granulate/burn/releases/download/v1.0.1g2/burn -z gprofiler/resources/burn -o gprofiler/resources/burn
 chmod +x gprofiler/resources/burn
 
 rm -r build


### PR DESCRIPTION
## Description
Update `burn` binary to "burn v1.0.1(g2)" - statically linked.

## Motivation and Context
Use statically linked burn as part of used binaries to support systems without the need for all native DSO.

## How Has This Been Tested?
- Successfully built gProfiler docker image.
- Ran the docker image and validated the new `burn` works properly and produces the same flamegraphs.

## Screenshots (if appropriate):
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
