### PR TITLE
Log and continue on runtime profiler errors

### DIFF
--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -108,7 +108,11 @@ class GProfiler:
             try:
                 for future in concurrent.futures.as_completed(futures):
                     if futures[future] in ["java", "python"]:
-                        process_perfs.update(future.result())
+                        # if either of these fail - log it, and continue.
+                        try:
+                            process_perfs.update(future.result())
+                        except Exception:
+                            logger.exception(f"{futures[future]} profiling failed")
                     else:
                         system_perf = future.result()
             except KeyboardInterrupt:

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -114,11 +114,11 @@ def pgrep_maps(match: str) -> List[Process]:
         f"grep -lP '{match}' /proc/*/maps", stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, shell=True
     )
     # might get 2 (which 'grep' exits with, if some files were unavailable, because processes have exited)
-    assert result.returncode in (0, 2)
+    assert result.returncode in (0, 2), f"unexpected 'grep' exit code: {result.returncode}"
 
     processes: List[Process] = []
     for line in result.stdout.splitlines():
-        assert line.startswith(b"/proc/") and line.endswith(b"/maps")
+        assert line.startswith(b"/proc/") and line.endswith(b"/maps"), f"unexpected 'grep' line: {line!r}"
         pid = int(line[len(b"/proc/") : -len(b"/maps")])
         processes.append(Process(pid))
 


### PR DESCRIPTION
## Description
If Java profiling fails, it should fail the Python one. Same goes the other way.

## Motivation and Context
Do not unnecessarily fail the run.

## How Has This Been Tested?
1. CI
2. I manually injected errors into the Python profiler and verified that I get the log `gprofiler: python profiling failed`, while gprofiler continues.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
