### PR TITLE
utils: Include command in run_process() logs

### DIFF
--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -63,7 +63,8 @@ def get_process_nspid(pid: int) -> int:
 def run_process(
     cmd: Union[str, List[str]], stop_event: Event = None, suppress_log: bool = False, **kwargs
 ) -> CompletedProcess:
-    logger.debug(f'Running command: {" ".join(cmd) if isinstance(cmd, list) else cmd}')
+    cmd_text = " ".join(cmd) if isinstance(cmd, list) else cmd
+    logger.debug(f'Running command: ({cmd_text})')
     if isinstance(cmd, str):
         cmd = [cmd]
     with Popen(
@@ -92,12 +93,12 @@ def run_process(
         assert retcode is not None  # only None if child has not terminated
     result: CompletedProcess = CompletedProcess(process.args, retcode, stdout, stderr)
 
-    logger.debug(f"returncode: {result.returncode}")
+    logger.debug(f"({cmd_text}) returncode: {result.returncode}")
     if not suppress_log:
         if result.stdout:
-            logger.debug(f"stdout: {result.stdout}")
+            logger.debug(f"({cmd_text}) stdout: {result.stdout}")
         if result.stderr:
-            logger.debug(f"stderr: {result.stderr}")
+            logger.debug(f"({cmd_text}) stderr: {result.stderr}")
     if retcode:
         raise CalledProcessError(retcode, process.args, output=stdout, stderr=stderr)
     return result

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -93,7 +93,7 @@ def run_process(
         assert retcode is not None  # only None if child has not terminated
     result: CompletedProcess = CompletedProcess(process.args, retcode, stdout, stderr)
 
-    logger.debug(f"({cmd_text}) returncode: {result.returncode}")
+    logger.debug(f"({cmd_text}) exit code: {result.returncode}")
     if not suppress_log:
         if result.stdout:
             logger.debug(f"({cmd_text}) stdout: {result.stdout}")


### PR DESCRIPTION
## Description
run_process() only logged the command upon entry. If multiple commands are
executed concurrently, it's hard to correlate the exit codes / outputs with
the command that generated them.

## Motivation and Context
Make it easier to read the logs.

## How Has This Been Tested?
Manually.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
