### PR TITLE
java: Explicitly chmod() libasyncProfiler.so in its target directory

### DIFF
--- a/gprofiler/java.py
+++ b/gprofiler/java.py
@@ -152,6 +152,8 @@ class JavaProfiler:
         libasyncprofiler_path_process = remove_prefix(libasyncprofiler_path_host, process_root)
         if not os.path.exists(libasyncprofiler_path_host):
             shutil.copy(resource_path("java/libasyncProfiler.so"), libasyncprofiler_path_host)
+            # explicitly chmod to allow access for non-root users
+            os.chmod(libasyncprofiler_path_host, 0o755)
 
         log_path_host = os.path.join(storage_dir_host, f"async-profiler-{process.pid}.log")
         touch_path(log_path_host, 0o666)  # make it writable for all, so target process can write


### PR DESCRIPTION
## Description
We'll allow deploying gprofiler as a standalone executable; in that case, its files
will be extracted to the filesystem by another component (e.g: pyinstaller) and may have
improper permissions, so we can't rely on them when copying. This ensures the permissions
are okay.

## Motivation and Context
Preparation for executable deployment.

## How Has This Been Tested?
Our tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
