### PR TITLE
utils: Fix get_libc_version() on RHEL

### DIFF
--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -202,6 +202,10 @@ def get_libc_version() -> Tuple[str, bytes]:
     m = re.search(br"GLIBC (.*?)\)", ldd_version)
     if m is not None:
         return ("glibc", m.group(1))
+    # catches GNU libc
+    m = re.search(br"\(GNU libc\) (.*?)\n", ldd_version)
+    if m is not None:
+        return ("glibc", m.group(1))
     # musl
     m = re.search(br"musl libc.*?\nVersion (.*?)\n", ldd_version, re.M)
     if m is not None:

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -192,18 +192,18 @@ def assert_program_installed(program: str):
         raise ProgramMissingException(program)
 
 
-def get_libc_version() -> Tuple[str, str]:
+def get_libc_version() -> Tuple[str, bytes]:
     # platform.libc_ver fails for musl, sadly (produces empty results).
     # so we'll run "ldd --version" and extract the version string from it.
-    ldd_version = subprocess.run(
-        ["ldd", "--version"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding="ascii"
-    ).stdout
+    # not passing "encoding"/"text" - this runs in a different mount namespace, and Python fails to
+    # load the files it needs for those encodings (getting LookupError: unknown encoding: ascii)
+    ldd_version = subprocess.run(["ldd", "--version"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT).stdout
     # catches GLIBC & EGLIBC
-    m = re.search(r"GLIBC (.*?)\)", ldd_version)
+    m = re.search(br"GLIBC (.*?)\)", ldd_version)
     if m is not None:
         return ("glibc", m.group(1))
     # musl
-    m = re.search(r"musl libc.*?\nVersion (.*?)\n", ldd_version, re.M)
+    m = re.search(br"musl libc.*?\nVersion (.*?)\n", ldd_version, re.M)
     if m is not None:
         return ("musl", m.group(1))
 

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -8,7 +8,7 @@ from glob import glob
 from pathlib import Path
 from subprocess import Popen
 
-import pytest
+import pytest  # type: ignore
 from docker import DockerClient
 from docker.models.images import Image
 


### PR DESCRIPTION
## Description
This fixes 2 points:
1. When passing `encoding=...`, Python tries to load the encoding file (a part of the standard library) if it's not loaded yet. See `_PyCodec_Lookup`. We've already changed the mount namespace so the files are not available anymore. It worked for me before because my host box is Ubuntu 20.04 (same as the container image :sweat_smile: ). After this fix, the function runs successfully on RHEL.
2. Parsing of another variant of glibc version string.

## Motivation and Context
Get `get_libc_version()` working on more OSes.

## How Has This Been Tested?
Manually on an AmazonLinux2 machine. And again on my Ubuntu.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
