### PR TITLE
CI error while running cmp_tags.sh fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Get and verify tag value
         run: |
           echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
@@ -37,6 +39,8 @@ jobs:
    steps:
      - name: Checkout Code
        uses: actions/checkout@v2
+       with:
+         fetch-depth: 0
      - name: Get and verify tag value
        run: |
          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV

--- a/cmp_tags.sh
+++ b/cmp_tags.sh
@@ -9,13 +9,12 @@ set -ue
 # Using python package 'cmp_version' to do the compare work
 
 pip install cmp_version
-git fetch origin
-TAGS=$(git describe --tags $(git rev-list --tags --max-count=2)) # gets tags across all branches
+TAGS=$(git tag --sort=creatordate | tail -2)
 
 tags_array=(${TAGS//\n/ })
 
-NEW_TAG=${tags_array[0]}
-LATEST_TAG=${tags_array[1]}
+LATEST_TAG=${tags_array[0]}
+NEW_TAG=${tags_array[1]}
 
 
 if [ "$(cmp-version "$LATEST_TAG" "$NEW_TAG")" == "1" ]; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
CI was [failed](https://github.com/Granulate/gprofiler/runs/2336547782?check_suite_focus=true) while running `cmp_tags` script. I think the reason is that the checkout step is fetch only a single commit by default.
I added an option of `fetch-depth: 0` to checkout step, which should fetch the whole history and tags.
`git fetch origin` command was removed from `cmp_tags` script 
<!--- Describe your changes in detail -->
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Make the CI work
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Push test tag in different branch and test that this step is passed 
## Screenshots (if appropriate):
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the relevant documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
