### PR TITLE
Improve logs experience

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,10 +65,10 @@ jobs:
                       'debian:9', 'debian:10' ]
     runs-on: ubuntu-20.04
     steps:
-      - name: Set up Python 3.6
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.8.8
 
       - name: Install Java
         uses: actions/setup-java@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   lint:
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     runs-on: ubuntu-latest
 
@@ -31,7 +31,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8.8, 3.9.2]
 
     runs-on: ubuntu-latest
 
@@ -56,7 +56,7 @@ jobs:
         sudo env "PATH=$PATH" python -m pip install --upgrade pip
         sudo env "PATH=$PATH" pip install -r dev-requirements.txt
         sudo env "PATH=$PATH" pip install -r requirements.txt
-        ./build.sh
+        ./scripts/build.sh
 
     - name: Run tests
       run: sudo env "PATH=$PATH" python -m pytest -v tests/ --ignore=tests/test_executable.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ This above commands installs all packages required for building, developing and 
 ### Standard build
 The step of building essentialy downloads external dependencies required for the project. You can run those through:
 ```bash
-./build.sh
+./scripts/build.sh
 ```
 
 The above command will download all dependencies to `bin` directory.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,33 @@
+FROM ubuntu:20.04 as bcc-builder
+
+RUN apt-get update
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y git build-essential iperf llvm-9-dev libclang-9-dev \
+  cmake python3 flex bison libelf-dev libz-dev
+
+WORKDIR /bcc
+
+RUN git clone --depth 1 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 119d71bf9681182759eb76d40660c0ec19f3fc42
+RUN mkdir bcc/build && cd bcc/build && \
+  cmake -DPYTHON_CMD=python3 -DINSTALL_CPP_EXAMPLES=y -DCMAKE_INSTALL_PREFIX=/bcc/root .. && \
+  make -C examples/cpp/pyperf -j -l VERBOSE=1 install
+
+
 FROM ubuntu:20.04
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y curl python3-pip
+# kmod - for modprobe kheaders if it's available
+RUN apt-get update && apt-get install -y curl python3-pip kmod
 
-COPY build.sh build.sh
-RUN ./build.sh
+COPY --from=bcc-builder /bcc/root/share/bcc/examples/cpp/PyPerf gprofiler/resources/python/pyperf/
+# copy licenses and notice file.
+COPY --from=bcc-builder /bcc/bcc/LICENSE.txt gprofiler/resources/python/pyperf/
+COPY --from=bcc-builder /bcc/bcc/licenses gprofiler/resources/python/pyperf/licenses
+COPY --from=bcc-builder /bcc/bcc/NOTICE gprofiler/resources/python/pyperf/
+
+COPY scripts/build.sh scripts/build.sh
+RUN ./scripts/build.sh
 
 COPY requirements.txt requirements.txt
 RUN pip3 install --no-cache-dir -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN python3 setup.py install
 
 STOPSIGNAL SIGINT
 
-ENTRYPOINT [ "python3", "-m", "gprofiler", "-v" ]
+ENTRYPOINT [ "python3", "-m", "gprofiler"]

--- a/deploy/k8s/gprofiler.yaml
+++ b/deploy/k8s/gprofiler.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: granulate
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: granulate-gprofiler
+  namespace: granulate
+  labels:
+    app: granulate-gprofiler
+spec:
+  selector:
+    matchLabels:
+      app: granulate-gprofiler
+  template:
+    metadata:
+      labels:
+        app: granulate-gprofiler
+    spec:
+      hostPID: true
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+      restartPolicy: Always
+      containers:
+        - name: gprofiler
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256m
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          image: index.docker.io/granulate/gprofiler:latest
+          imagePullPolicy: Always
+          args:
+            - -cu
+            - --token
+            - $(GPROFILER_TOKEN)
+            - --service-name
+            - $(GPROFILER_SERVICE)
+          env:
+            - name: GPROFILER_TOKEN
+              value: @insert your token here@
+            - name: GPROFILER_SERVICE
+              value: @insert service name here@

--- a/gprofiler/client.py
+++ b/gprofiler/client.py
@@ -46,6 +46,7 @@ class APIClient:
 
         # Raises on failure
         self.get_health()
+        logger.info("Connection to server successfully established")
 
     def get_base_url(self) -> str:
         return "{}/{}/{}".format(self._host.rstrip("/"), self.BASE_PATH, self._version)

--- a/gprofiler/java.py
+++ b/gprofiler/java.py
@@ -14,7 +14,7 @@ from typing import Mapping, Optional
 import psutil
 from psutil import Process
 
-from .merge import parse_collapsed
+from .merge import parse_one_collapsed
 from .exceptions import StopEventSetException
 from .utils import (
     run_process,
@@ -47,14 +47,18 @@ class JavaProfiler:
         self._stop_event = stop_event
         self._storage_dir = storage_dir
 
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
     def __enter__(self):
+        self.start()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.close()
-
-    def close(self):
-        pass
+        self.stop()
 
     def is_jdk_version_supported(self, java_version_cmd_output: str) -> bool:
         return all(exclusion not in java_version_cmd_output for exclusion in self.JDK_EXCLUSIONS)
@@ -205,28 +209,27 @@ class JavaProfiler:
             raise StopEventSetException()
 
         logger.info(f"Finished profiling process {process.pid}")
-        return parse_collapsed(Path(output_path_host).read_text())
+        return parse_one_collapsed(Path(output_path_host).read_text())
 
-    def profile_processes(self):
-        futures = []
-        results = {}
+    def snapshot(self) -> Mapping[int, Mapping[str, int]]:
         processes = list(pgrep_exe(r"^.+/(java|jsvc)$"))
         if not processes:
             return {}
-        with concurrent.futures.ThreadPoolExecutor(max_workers=len(processes)) as executor:
-            for process in processes:
-                future = executor.submit(self.profile_process, process)
-                future.pid = process.pid
-                futures.append(future)
 
+        with concurrent.futures.ThreadPoolExecutor(max_workers=len(processes)) as executor:
+            futures = {}
+            for process in processes:
+                futures[executor.submit(self.profile_process, process)] = process.pid
+
+            results = {}
             for future in concurrent.futures.as_completed(futures):
                 try:
                     result = future.result()
                     if result is not None:
-                        results[future.pid] = result
+                        results[futures[future]] = result
                 except StopEventSetException:
                     raise
                 except Exception:
-                    logger.exception(f"Failed to profile Java process {future.pid}")
+                    logger.exception(f"Failed to profile Java process {futures[future]}")
 
         return results

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -134,6 +134,7 @@ class GProfiler:
                     logger.error(f"Error occurred sending profile to server: {e}")
                 except RequestException:
                     logger.exception("Error occurred sending profile to server")
+                logger.info("Successfully upload profile to server")
 
     def run_continuous(self, interval):
         while not self._stop_event.is_set():
@@ -284,6 +285,7 @@ def main():
         except RequestException as e:
             logger.error(f"Failed to connect to server: {e}")
             return
+        logger.info("gProfiler initialized and ready to start profiling")
         with GProfiler(args.frequency, args.duration, args.output_dir, client) as gprofiler:
             if args.continuous:
                 gprofiler.run_continuous(args.continuous_profiling_interval)

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -25,7 +25,7 @@ from . import merge
 from .client import APIClient, APIError, GRANULATE_SERVER_HOST, DEFAULT_UPLOAD_TIMEOUT
 from .java import JavaProfiler
 from .perf import SystemProfiler
-from .python import PythonProfiler
+from .python import get_python_profiler
 from .utils import is_root, run_process, get_iso8061_format_time, resource_path, log_system_info, TEMPORARY_STORAGE_PATH
 
 logger: Logger

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -10,12 +10,12 @@ import logging.handlers
 import os
 import sys
 import time
-from contextlib import ExitStack
 from logging import Logger
 from pathlib import Path
 from socket import gethostname
 from tempfile import TemporaryDirectory
 from threading import Event
+from typing import Dict
 
 import configargparse
 from requests import RequestException, Timeout
@@ -45,18 +45,25 @@ class GProfiler:
         self._duration = duration
         self._output_dir = output_dir
         self._client = client
-
         self._stop_event = Event()
-        self._system_modifications_stack = ExitStack()
+        self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=10)
+        self._temp_storage_dir = TemporaryDirectory(dir=TEMPORARY_STORAGE_PATH)
+        self.python_profiler = get_python_profiler(
+            self._frequency, self._duration, self._stop_event, self._temp_storage_dir.name
+        )
+        self.java_profiler = JavaProfiler(
+            self._frequency, self._duration, True, self._stop_event, self._temp_storage_dir.name
+        )
+        self.system_profiler = SystemProfiler(
+            self._frequency, self._duration, self._stop_event, self._temp_storage_dir.name
+        )
 
     def __enter__(self):
+        self.start()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.close()
-
-    def close(self):
-        self._system_modifications_stack.close()
+        self.stop()
 
     def _generate_output_files(
         self, collapsed_data: str, local_start_time: datetime.datetime, local_end_time: datetime.datetime
@@ -83,68 +90,77 @@ class GProfiler:
         Path(flamegraph_path).write_text(flamegraph)
         logger.info(f"Saved flamegraph to {flamegraph_path}")
 
-    def run_profilers(self):
+    def start(self):
+        self._stop_event.clear()
+
+        for prof in (
+            self.python_profiler,
+            self.java_profiler,
+            self.system_profiler,
+        ):
+            prof.start()
+
+    def stop(self):
+        logger.info("Stopping gprofiler...")
+        self._stop_event.set()
+
+        for prof in (
+            self.python_profiler,
+            self.java_profiler,
+            self.system_profiler,
+        ):
+            prof.stop()
+
+    def _snapshot(self):
         local_start_time = datetime.datetime.utcnow()
         monotonic_start_time = time.monotonic()
-        futures = {}
 
-        with TemporaryDirectory(dir=TEMPORARY_STORAGE_PATH) as tempdir, concurrent.futures.ThreadPoolExecutor(
-            max_workers=10
-        ) as executor, JavaProfiler(
-            self._frequency, self._duration, True, self._stop_event, tempdir
-        ) as java_profiler, PythonProfiler(
-            self._frequency, self._duration, self._stop_event, tempdir
-        ) as python_profiler, SystemProfiler(
-            self._frequency, self._duration, self._stop_event, tempdir
-        ) as system_profiler:
-            os.chmod(tempdir, 0o777)
+        java_future = self._executor.submit(self.java_profiler.snapshot)
+        java_future.name = "java"
+        python_future = self._executor.submit(self.python_profiler.snapshot)
+        python_future.name = "python"
+        system_future = self._executor.submit(self.system_profiler.snapshot)
+        system_future.name = "system"
 
-            futures[executor.submit(java_profiler.profile_processes)] = "java"
-            futures[executor.submit(python_profiler.profile_processes)] = "python"
-            futures[executor.submit(system_profiler.profile)] = "system"
-
-            process_perfs = {}
-            system_perf = None
+        process_perfs: Dict[int, Dict[str, int]] = {}
+        for future in concurrent.futures.as_completed([java_future, python_future]):
+            # if either of these fail - log it, and continue.
             try:
-                for future in concurrent.futures.as_completed(futures):
-                    if futures[future] in ["java", "python"]:
-                        # if either of these fail - log it, and continue.
-                        try:
-                            process_perfs.update(future.result())
-                        except Exception:
-                            logger.exception(f"{futures[future]} profiling failed")
-                    else:
-                        system_perf = future.result()
-            except KeyboardInterrupt:
-                self._stop_event.set()
-                raise
+                process_perfs.update(future.result())
+            except Exception:
+                logger.exception(f"{future.name} profiling failed")
 
-            local_end_time = local_start_time + datetime.timedelta(seconds=(time.monotonic() - monotonic_start_time))
-            merged_result = merge.merge_perfs(system_perf, process_perfs)
+        local_end_time = local_start_time + datetime.timedelta(seconds=(time.monotonic() - monotonic_start_time))
+        merged_result = merge.merge_perfs(system_future.result(), process_perfs)
 
-            if self._output_dir:
-                self._generate_output_files(merged_result, local_start_time, local_end_time)
+        if self._output_dir:
+            self._generate_output_files(merged_result, local_start_time, local_end_time)
 
-            if self._client:
-                try:
-                    self._client.submit_profile(local_start_time, local_end_time, gethostname(), merged_result)
-                except Timeout:
-                    logger.error("Upload of profile to server timed out.")
-                except APIError as e:
-                    logger.error(f"Error occurred sending profile to server: {e}")
-                except RequestException:
-                    logger.exception("Error occurred sending profile to server")
-                logger.info("Successfully upload profile to server")
+        if self._client:
+            try:
+                self._client.submit_profile(local_start_time, local_end_time, gethostname(), merged_result)
+            except Timeout:
+                logger.error("Upload of profile to server timed out.")
+            except APIError as e:
+                logger.error(f"Error occurred sending profile to server: {e}")
+            except RequestException:
+                logger.exception("Error occurred sending profile to server")
+            logger.info("Successfully upload profile to server")
+
+    def run_single(self):
+        with self:
+            self._snapshot()
 
     def run_continuous(self, interval):
-        while not self._stop_event.is_set():
-            start_time = time.monotonic()
-            try:
-                self.run_profilers()
-            except Exception:
-                logger.exception("Profiling run failed!")
-            time_spent = time.monotonic() - start_time
-            self._stop_event.wait(max(interval * 60 - time_spent, 0))
+        with self:
+            while not self._stop_event.is_set():
+                start_time = time.monotonic()
+                try:
+                    self._snapshot()
+                except Exception:
+                    logger.exception("Profiling run failed!")
+                time_spent = time.monotonic() - start_time
+                self._stop_event.wait(max(interval * 60 - time_spent, 0))
 
 
 def setup_logger(stream_level: int = logging.INFO, log_file_path: str = None):
@@ -285,16 +301,19 @@ def main():
         except RequestException as e:
             logger.error(f"Failed to connect to server: {e}")
             return
+
+        gprofiler = GProfiler(args.frequency, args.duration, args.output_dir, client)
         logger.info("gProfiler initialized and ready to start profiling")
-        with GProfiler(args.frequency, args.duration, args.output_dir, client) as gprofiler:
-            if args.continuous:
-                gprofiler.run_continuous(args.continuous_profiling_interval)
-            else:
-                gprofiler.run_profilers()
+
+        if args.continuous:
+            gprofiler.run_continuous(args.continuous_profiling_interval)
+        else:
+            gprofiler.run_single()
+
+    except KeyboardInterrupt:
+        pass
     except Exception:
         logger.exception("Unexpected error occurred")
-    except KeyboardInterrupt:
-        logger.info("Stopping gprofiler...")
 
 
 if __name__ == "__main__":

--- a/gprofiler/merge.py
+++ b/gprofiler/merge.py
@@ -4,7 +4,7 @@
 #
 import logging
 import re
-from collections import Counter
+from collections import defaultdict, Counter
 from typing import Iterable, Mapping, MutableMapping
 
 logger = logging.getLogger(__name__)
@@ -21,7 +21,7 @@ SAMPLE_REGEX = re.compile(
 FRAME_REGEX = re.compile(r"^\s*[0-9a-f]+ (.*?) \((.*)\)$")
 
 
-def parse_collapsed(collapsed: str) -> Mapping[str, int]:
+def parse_one_collapsed(collapsed: str) -> Mapping[str, int]:
     """
     Parse a stack-collapsed listing where all stacks are from the same process.
     """
@@ -37,6 +37,30 @@ def parse_collapsed(collapsed: str) -> Mapping[str, int]:
         except Exception:
             logger.exception(f'bad stack - line="{line}"')
     return dict(stacks)
+
+
+def parse_many_collapsed(text: str) -> Mapping[int, Mapping[str, int]]:
+    """
+    Parse a stack-collapsed listing where stacks are prefixed with the command and pid/tid of their
+    origin.
+    """
+    results: MutableMapping[int, MutableMapping[str, int]] = defaultdict(Counter)
+    bad_lines = []
+
+    for line in text.splitlines():
+        try:
+            stack, count = line.rsplit(" ", maxsplit=1)
+            head, tail = stack.split(";", maxsplit=1)
+            _, pid_tid = head.rsplit("-", maxsplit=1)
+            pid = int(pid_tid.split("/")[0])
+            results[pid][tail] += int(count)
+        except ValueError:
+            bad_lines.append(line)
+
+    if bad_lines:
+        logger.warning(f"Got {len(bad_lines)} bad lines when parsing (showing up to 8):\n" + "\n".join(bad_lines[:8]))
+
+    return results
 
 
 def collapse_stack(stack: str, comm: str) -> str:

--- a/gprofiler/python.py
+++ b/gprofiler/python.py
@@ -5,72 +5,89 @@
 import concurrent.futures
 import logging
 import os
+import signal
+import glob
 from pathlib import Path
 from threading import Event
-from typing import Dict
+from typing import List, Mapping, Optional, Union
 
-from .merge import parse_collapsed
-from .exceptions import StopEventSetException, ProcessStoppedException
-from .utils import pgrep_maps, run_process, resource_path
+from psutil import Process
+
+from .merge import parse_one_collapsed, parse_many_collapsed
+from .exceptions import StopEventSetException, ProcessStoppedException, CalledProcessError
+from .utils import pgrep_maps, start_process, poll_process, run_process, resource_path
 
 logger = logging.getLogger(__name__)
 
-PYTHON_PROFILER_MAX_FREQUENCY = 10
 
+class PythonProfilerBase:
+    MAX_FREQUENCY = 100
 
-class PythonProfiler:
-    BLACKLISTED_PYTHON_PROCS = ["unattended-upgrades", "networkd-dispatcher", "supervisord", "tuned"]
-
-    def __init__(self, frequency: int, duration: int, stop_event: Event, storage_dir: str):
-        self._frequency = min(frequency, PYTHON_PROFILER_MAX_FREQUENCY)
+    def __init__(self, frequency: int, duration: int, stop_event: Optional[Event], storage_dir: str):
+        self._frequency = min(frequency, self.MAX_FREQUENCY)
         self._duration = duration
-        self._stop_event = stop_event
+        self._stop_event = stop_event or Event()
         self._storage_dir = storage_dir
         logger.info(f"Initializing Python profiler (frequency: {self._frequency}hz, duration: {duration}s)")
 
+    def start(self):
+        pass
+
+    def snapshot(self) -> Mapping[int, Mapping[str, int]]:
+        """
+        :returns: Mapping from pid to stacks and their counts.
+        """
+        raise NotImplementedError
+
+    def stop(self):
+        pass
+
     def __enter__(self):
+        self.start()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.close()
+        self.stop()
 
-    def close(self):
-        pass
 
-    def profile_process(self, pid: int, cmdline: str):
-        logger.info(f"Profiling process {pid} ({cmdline})")
+class PySpyProfiler(PythonProfilerBase):
+    MAX_FREQUENCY = 10
+    BLACKLISTED_PYTHON_PROCS = ["unattended-upgrades", "networkd-dispatcher", "supervisord", "tuned"]
 
-        local_output_path = os.path.join(self._storage_dir, f"{pid}.py.col.dat")
+    def _make_command(self, pid: int, output_path: str):
+        return [
+            resource_path("python/py-spy"),
+            "record",
+            "-r",
+            str(self._frequency),
+            "-d",
+            str(self._duration),
+            "--nonblocking",
+            "--format",
+            "raw",
+            "-F",
+            "--gil",
+            "--output",
+            output_path,
+            "-p",
+            str(pid),
+            "--full-filenames",
+        ]
+
+    def profile_process(self, process: Process):
+        logger.info(f"Profiling process {process.pid} ({process.cmdline()})")
+
+        local_output_path = os.path.join(self._storage_dir, f"{process.pid}.py.col.dat")
         try:
-            run_process(
-                [
-                    resource_path("python/py-spy"),
-                    "record",
-                    "-r",
-                    str(self._frequency),
-                    "-d",
-                    str(self._duration),
-                    "--nonblocking",
-                    "--format",
-                    "raw",
-                    "-F",
-                    "--gil",
-                    "--output",
-                    local_output_path,
-                    "-p",
-                    str(pid),
-                    "--full-filenames",
-                ],
-                stop_event=self._stop_event,
-            )
+            run_process(self._make_command(process.pid, local_output_path), stop_event=self._stop_event)
         except ProcessStoppedException:
             raise StopEventSetException
 
-        logger.info(f"Finished profiling process {pid}")
-        return parse_collapsed(Path(local_output_path).read_text())
+        logger.info(f"Finished profiling process {process.pid} with py-spy")
+        return parse_one_collapsed(Path(local_output_path).read_text())
 
-    def find_python_processes_to_profile(self) -> Dict[str, str]:
-        filtered_procs = {}
+    def find_python_processes_to_profile(self) -> List[Process]:
+        filtered_procs = []
         for process in pgrep_maps(r"^.+/(?:lib)?python[^/]*$"):
             try:
                 if process.pid == os.getpid():
@@ -80,30 +97,172 @@ class PythonProfiler:
                 if any(item in cmdline for item in self.BLACKLISTED_PYTHON_PROCS):
                     continue
 
-                filtered_procs[process.pid] = cmdline
+                filtered_procs.append(process)
             except Exception:
                 logger.exception(f"Couldn't add pid {process.pid} to list")
 
         return filtered_procs
 
-    def profile_processes(self):
-        pids_to_profile = self.find_python_processes_to_profile()
-        if not pids_to_profile:
+    def snapshot(self) -> Mapping[int, Mapping[str, int]]:
+        processes_to_profile = self.find_python_processes_to_profile()
+        if not processes_to_profile:
             return {}
-        with concurrent.futures.ThreadPoolExecutor(max_workers=len(pids_to_profile)) as executor:
-            futures = []
-            for pid, cmdline in pids_to_profile.items():
-                future = executor.submit(self.profile_process, pid, cmdline)
-                future.pid = pid
-                futures.append(future)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=len(processes_to_profile)) as executor:
+            futures = {}
+            for process in processes_to_profile:
+                futures[executor.submit(self.profile_process, process)] = process.pid
 
             results = {}
             for future in concurrent.futures.as_completed(futures):
                 try:
-                    results[future.pid] = future.result()
+                    results[futures[future]] = future.result()
                 except StopEventSetException:
                     raise
                 except Exception:
-                    logger.exception(f"Failed to profile Python process {future.pid}")
+                    logger.exception(f"Failed to profile Python process {futures[future]}")
 
         return results
+
+
+class PythonEbpfProfiler(PythonProfilerBase):
+    PYPERF_RESOURCE = "python/pyperf/PyPerf"
+    dump_signal = signal.SIGUSR2
+    poll_timeout = 10  # seconds
+
+    def __init__(self, frequency: int, duration: int, stop_event: Optional[Event], storage_dir: str):
+        super().__init__(frequency, duration, stop_event, storage_dir)
+        self.process = None
+        self.output_path = Path(self._storage_dir) / "py.col.dat"
+
+    @classmethod
+    def _check_missing_headers(cls, stdout) -> bool:
+        if "Unable to find kernel headers." in stdout:
+            print()
+            print("Unable to find kernel headers. Make sure the package is installed for your distribution.")
+            print("If you are using Ubuntu, you can install the required package using:")
+            print()
+            print("    apt install linux-headers-$(uname -r)")
+            print()
+            print("If you are still getting this error and you are running gProfiler as a docker container,")
+            print("make sure /lib/modules and /usr/src are mapped into the container.")
+            print("See the README for further details.")
+            print()
+            return True
+        else:
+            return False
+
+    @classmethod
+    def _check_output(cls, process, output_path):
+        if not glob.glob(f"{str(output_path)}.*"):
+            stdout = process.stdout.read().decode()
+            stderr = process.stderr.read().decode()
+            cls._check_missing_headers(stdout)
+            raise CalledProcessError(process.returncode, process.args, stdout, stderr)
+
+    @classmethod
+    def test(cls, storage_dir: str, stop_event: Optional[Event]):
+        test_path = Path(storage_dir) / ".test"
+        for f in glob.glob(f"{str(test_path)}.*"):
+            os.unlink(f)
+
+        # Run the process and check if the output file is properly created.
+        # Wait up to 10sec for the process to terminate.
+        # Allow cancellation via the stop_event.
+        cmd = [resource_path(cls.PYPERF_RESOURCE), "--output", str(test_path), "-F", "1", "--duration", "1"]
+        process = start_process(cmd)
+        try:
+            poll_process(process, cls.poll_timeout, stop_event)
+        except TimeoutError:
+            process.kill()
+            raise
+        else:
+            cls._check_output(process, test_path)
+
+    def start(self):
+        logger.info("Starting profiling of Python processes with PyPerf")
+        cmd = [
+            resource_path(self.PYPERF_RESOURCE),
+            "--output",
+            str(self.output_path),
+            "-F",
+            str(self._frequency),
+            # Duration is irrelevant here, we want to run continuously.
+        ]
+        process = start_process(cmd)
+        try:
+            poll_process(process, self.poll_timeout, self._stop_event)
+        except TimeoutError:
+            # Process is alive. So far, so good...
+            if not self.output_path.exists():
+                process.kill()
+                stdout = process.stdout.read().decode()
+                stderr = process.stderr.read().decode()
+                self._check_missing_headers(stdout)
+                raise CalledProcessError(process.returncode, process.args, stdout, stderr)
+            # happy flow
+            self.process = process
+        else:
+            # process terminated, must be an error:
+            self._check_output(process, self.output_path)
+            raise RuntimeError("_check_output did not raise!")
+
+    def _dump(self) -> Path:
+        assert self.process is not None, "profiling not started!"
+        self.process.send_signal(self.dump_signal)
+        # important to not grab the transient data file
+        while True:
+            output_files = glob.glob(f"{str(self.output_path)}.*")
+            if output_files:
+                break
+
+            if self._stop_event.wait(0.1):
+                raise StopEventSetException()
+
+        # All the snapshot samples should be in one file
+        assert len(output_files) == 1
+        return Path(output_files[0])
+
+    def snapshot(self) -> Mapping[int, Mapping[str, int]]:
+        if self._stop_event.wait(self._duration):
+            raise StopEventSetException()
+        collapsed_path = self._dump()
+        collapsed_text = collapsed_path.read_text()
+        collapsed_path.unlink()
+        return parse_many_collapsed(collapsed_text)
+
+    def _terminate(self) -> Optional[int]:
+        code = None
+        if self.process is not None:
+            self.process.terminate()
+            code = self.process.wait()
+            self.process = None
+        return code
+
+    def stop(self):
+        code = self._terminate()
+        if code is not None:
+            logger.info("Finished profiling Python processes with PyPerf")
+        return code
+
+
+_profiler_class = None
+
+
+def determine_profiler_class(storage_dir: str, stop_event: Event):
+    try:
+        PythonEbpfProfiler.test(storage_dir, stop_event)
+        return PythonEbpfProfiler
+    except Exception as e:
+        # Fallback to py-spy
+        logger.debug(f"eBPF profiler error: {str(e)}")
+        logger.info("Python eBPF profiler initialization failed. Falling back to py-spy...")
+        return PySpyProfiler
+
+
+def get_python_profiler(
+    frequency: int, duration: int, stop_event: Event, storage_dir: str
+) -> Union[PythonEbpfProfiler, PySpyProfiler]:
+    global _profiler_class
+    if _profiler_class is None:
+        _profiler_class = determine_profiler_class(storage_dir, stop_event)
+    return _profiler_class(frequency, duration, stop_event, storage_dir)

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -1,3 +1,19 @@
+# TODO: copied from the main Dockerfile... too bad we don't have includes.
+FROM ubuntu:20.04 as bcc-builder
+
+RUN apt-get update
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y git build-essential iperf llvm-9-dev libclang-9-dev \
+  cmake python3 flex bison libelf-dev libz-dev
+
+WORKDIR /bcc
+
+RUN git clone --depth 1 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 119d71bf9681182759eb76d40660c0ec19f3fc42
+RUN mkdir bcc/build && cd bcc/build && \
+  cmake -DPYTHON_CMD=python3 -DINSTALL_CPP_EXAMPLES=y -DCMAKE_INSTALL_PREFIX=/bcc/root .. && \
+  make -C examples/cpp/pyperf -j -l VERBOSE=1 install
+
+
 # Centos 7 image is used to grab an old version of `glibc` during `pyinstaller` bundling.
 # This will allow the executable to run on older versions of the kernel, eventually leading to the executable running on a wider range of machines.
 FROM centos:7 as build-stage
@@ -5,12 +21,21 @@ WORKDIR /app
 
 RUN yum update -y && yum install -y epel-release
 RUN yum install -y gcc python3 curl python3-pip patchelf python3-devel
+
 COPY requirements.txt requirements.txt
-COPY dev-requirements.txt dev-requirements.txt
-COPY build.sh build.sh
-RUN python3 -m pip install -r dev-requirements.txt
 RUN python3 -m pip install -r requirements.txt
-RUN ./build.sh
+
+COPY dev-requirements.txt dev-requirements.txt
+RUN python3 -m pip install -r dev-requirements.txt
+
+COPY scripts/build.sh scripts/build.sh
+RUN ./scripts/build.sh
+
+COPY --from=bcc-builder /bcc/root/share/bcc/examples/cpp/PyPerf gprofiler/resources/python/pyperf/
+# copy licenses and notice file.
+COPY --from=bcc-builder /bcc/bcc/LICENSE.txt gprofiler/resources/python/pyperf/
+COPY --from=bcc-builder /bcc/bcc/licenses gprofiler/resources/python/pyperf/licenses
+COPY --from=bcc-builder /bcc/bcc/NOTICE gprofiler/resources/python/pyperf/
 
 COPY . .
 RUN pyinstaller pyinstaller.spec

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -18,6 +18,9 @@ mkdir -p gprofiler/resources/python
 curl -fL https://github.com/Granulate/py-spy/releases/download/v0.3.5g1/py-spy -o gprofiler/resources/python/py-spy
 chmod +x gprofiler/resources/python/py-spy
 
+# pyperf - just create the directory for it, it will be built/downloaded later
+mkdir -p gprofiler/resources/python/pyperf
+
 # perf
 curl -fL https://github.com/Granulate/linux/releases/download/v5.6-perf/perf -z gprofiler/resources/perf -o gprofiler/resources/perf
 chmod +x gprofiler/resources/perf

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -12,7 +12,7 @@ import pytest  # type: ignore
 from docker import DockerClient
 from docker.models.images import Image
 
-from gprofiler.merge import parse_collapsed
+from gprofiler.merge import parse_one_collapsed
 from tests.util import run_privileged_container
 
 
@@ -46,5 +46,5 @@ def test_from_executable(
     output = glob(str(output_directory / "*.col"))
     assert len(output) == 1
     collapsed_path = output[0]
-    collapsed = parse_collapsed(Path(collapsed_path).read_text())
+    collapsed = parse_one_collapsed(Path(collapsed_path).read_text())
     assert_collapsed(collapsed)

--- a/tests/test_libpython.py
+++ b/tests/test_libpython.py
@@ -7,9 +7,9 @@ from docker import DockerClient
 from docker.models.images import Image
 from threading import Event
 
-from gprofiler.python import PythonProfiler
+from gprofiler.python import get_python_profiler
 
-from tests import CONTAINERS_DIRECTORY  # type: ignore
+from tests import CONTAINERS_DIRECTORY
 
 
 @pytest.fixture
@@ -29,13 +29,12 @@ def application_docker_image(docker_client: DockerClient) -> Image:
 def test_python_select_by_libpython(
     tmp_path,
     application_docker_container,
-    output_directory,
     assert_collapsed,
 ) -> None:
     """
     Tests that profiling of processes running Python, whose basename(readlink("/proc/pid/exe")) isn't "python".
     (for example, uwsgi). We expect to select these because they have "libpython" in their "/proc/pid/maps".
     """
-    profiler = PythonProfiler(1000, 1, Event(), str(tmp_path))
-    process_collapsed = profiler.profile_processes()
+    profiler = get_python_profiler(1000, 1, Event(), str(tmp_path))
+    process_collapsed = profiler.snapshot()
     assert_collapsed(process_collapsed.get(application_docker_container.attrs["State"]["Pid"]))

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -3,40 +3,62 @@
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
 import pytest  # type: ignore
+import os
 from glob import glob
 from pathlib import Path
 from threading import Event
-from typing import Callable, Mapping
+from typing import Optional, Callable, Mapping
 
 from docker import DockerClient
 from docker.models.images import Image
 
+from gprofiler.merge import parse_one_collapsed
 from gprofiler.java import JavaProfiler
-from gprofiler.python import PythonProfiler
-from gprofiler.merge import parse_collapsed
-from tests.util import run_privileged_container
+from gprofiler.python import PySpyProfiler, PythonEbpfProfiler
+from gprofiler.utils import resource_path
+from tests.util import run_privileged_container, copy_file_from_image
 
 
 @pytest.mark.parametrize("runtime", ["java"])
 def test_java_from_host(
     tmp_path: Path,
     application_pid: int,
-    assert_collapsed: Callable[[Mapping[str, int]], None],
+    assert_collapsed: Callable[[Optional[Mapping[str, int]]], None],
 ) -> None:
     profiler = JavaProfiler(1000, 1, True, Event(), str(tmp_path))
-    process_collapsed = profiler.profile_processes()
+    process_collapsed = profiler.snapshot()
     assert_collapsed(process_collapsed.get(application_pid))
 
 
 @pytest.mark.parametrize("runtime", ["python"])
-def test_python_from_host(
+def test_pyspy(
     tmp_path: Path,
     application_pid: int,
-    assert_collapsed: Callable[[Mapping[str, int]], None],
+    assert_collapsed: Callable[[Optional[Mapping[str, int]]], None],
 ) -> None:
-    profiler = PythonProfiler(1000, 1, Event(), str(tmp_path))
-    process_collapsed = profiler.profile_processes()
+    profiler = PySpyProfiler(1000, 1, Event(), str(tmp_path))
+    process_collapsed = profiler.snapshot()
     assert_collapsed(process_collapsed.get(application_pid))
+
+
+@pytest.mark.parametrize("runtime", ["python"])
+def test_python_ebpf(
+    tmp_path,
+    application_pid,
+    assert_collapsed,
+    gprofiler_docker_image,
+):
+    # get PyPerf from the built container
+    pyperf_path = resource_path(PythonEbpfProfiler.PYPERF_RESOURCE)
+    copy_file_from_image(
+        gprofiler_docker_image,
+        os.path.join("/app", "gprofiler", "resources", PythonEbpfProfiler.PYPERF_RESOURCE),
+        pyperf_path,
+    )
+
+    with PythonEbpfProfiler(1000, 1, Event(), str(tmp_path)) as profiler:
+        process_collapsed = profiler.snapshot()
+        assert_collapsed(process_collapsed.get(application_pid))
 
 
 @pytest.mark.parametrize("runtime", ["java", "python"])
@@ -49,12 +71,16 @@ def test_from_container(
 ) -> None:
     _ = application_pid  # Fixture only used for running the application.
     inner_output_directory = "/tmp/gpofiler"
-    volumes = {str(output_directory): {"bind": inner_output_directory, "mode": "rw"}}
+    volumes = {
+        "/usr/src": {"bind": "/usr/src", "mode": "ro"},
+        "/lib/modules": {"bind": "/lib/modules", "mode": "ro"},
+        str(output_directory): {"bind": inner_output_directory, "mode": "rw"},
+    }
     run_privileged_container(
         docker_client, gprofiler_docker_image, ["-d", "1", "-o", inner_output_directory], volumes=volumes
     )
     output = glob(str(output_directory / "*.col"))
     assert len(output) == 1
     collapsed_path = output[0]
-    collapsed = parse_collapsed(Path(collapsed_path).read_text())
+    collapsed = parse_one_collapsed(Path(collapsed_path).read_text())
     assert_collapsed(collapsed)

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,3 +1,4 @@
+import subprocess
 from typing import List, Dict
 
 from docker import DockerClient
@@ -26,3 +27,13 @@ def run_privileged_container(
         **extra_kwargs,
     )
     print(f"Container logs {container}")
+
+
+def copy_file_from_image(image: Image, container_path: str, host_path: str) -> None:
+    # I tried writing it with the docker-py API, but retrieving large files with container.get_archive() just hangs...
+    subprocess.run(
+        f"c=$(docker container create {image.id}) && "
+        f"{{ docker cp $c:{container_path} {host_path}; ret=$?; docker rm $c > /dev/null; exit $ret; }}",
+        shell=True,
+        check=True,
+    )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
--verbose flag is removed from docker file;
the output was messy with all the debug stuff, if there is a need this flag can be passed explicitly.
Added some info logs indicating different stages of gProfiler initialization .
<!--- Describe your changes in detail -->
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
## Motivation and Context
As an existing gProfiler user, I would like to understand the progress of the G-profiler initialization/installation.
<!--- Why is this change required? What problem does it solve? -->
## How Has This Been Tested?
Docker image was builded and ran configured to send data to the `performance-studio`.
Logs monitored with `docker logs -f gprofiler`.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
## Screenshots:
stdout after the change:
```bash
[11:22:47] Running gprofiler (version 0.0.7)...
[11:22:47] Kernel uname release: 4.15.0-58-generic
[11:22:47] Kernel uname version: #64-Ubuntu SMP Tue Aug 6 11:12:41 UTC 2019
[11:22:47] Total CPUs: 1
[11:22:47] Total RAM: 0.96 GB
[11:22:47] Linux distribution: ('Ubuntu', '18.04', 'bionic')
[11:22:47] libc version: ('glibc', b'2.27-3ubuntu1')
[11:22:48] Connection to server successfully established
[11:22:48] gProfiler initialized and ready to start profiling
[11:22:48] Initializing Java profiler (frequency: 10hz, duration: 60s)
[11:22:48] Initializing Python profiler (frequency: 10hz, duration: 60s)
[11:22:48] Initializing system profiler (frequency: 10hz, duration: 60s)
[11:22:48] Running global perf...
[11:22:48] Profiling process 604 (['/usr/bin/python3', '/usr/bin/networkd-dispatcher', '--run-startup-triggers'])
[11:23:48] Finished profiling process 604
[11:23:54] Finished running global perf
[11:23:56] Successfully upload profile to server
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the relevant documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
