### PR TITLE
Change --profiling-interval units to seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,11 @@ the results.
 ## Profiling options
 * `--profiling-frequency`: The sampling frequency of the profiling, in *hertz*.
 * `--profiling-duration`: The duration of the each profiling session, in *seconds*.
-* `--profiling-interval`: The interval between each profiling session, in *minutes*.
+* `--profiling-interval`: The interval between each profiling session, in *seconds*.
 
 The default profiling frequency is *10 hertz*. Using higher frequency will lead to more accurate results, but will create greater overhead on the profiled system & programs.
 
-The default duration is *60 seconds* and the default interval is *1 minute*. So gProfiler runs the profiling
-sessions back-to-back.
+The default duration is *60 seconds*, and the default interval matches it. So gProfiler runs the profiling sessions back-to-back - the next session starts as soon as the previous session is done.
 
 ### Continuous mode
 gProfiler can be run in a continuous mode, profiling periodically, using the `--continuous`/`-c` flag.


### PR DESCRIPTION
## Description
It's confusing that the interval is in minutes and duration in seconds.

Also, it makes sense to allow finer control over the interval - that is, seconds and not minutes.

## Motivation and Context
Removes confusion + allows for finer control on interval.

## How Has This Been Tested?
Locally.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change) - changes the commandline parameters.
## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
