### PR TITLE
python: PyPerf: Faster initialization + timeouts in snapshot()

### DIFF
--- a/gprofiler/exceptions.py
+++ b/gprofiler/exceptions.py
@@ -18,14 +18,12 @@ class CalledProcessError(subprocess.CalledProcessError):
     def __str__(self):
         if self.returncode and self.returncode < 0:
             try:
-                return f"Command '{self.cmd}' died with {signal.Signals(-self.returncode)!r}."
+                base = f"Command '{self.cmd}' died with {signal.Signals(-self.returncode)!r}."
             except ValueError:
-                return f"Command '{self.cmd}' died with unknown signal {-self.returncode}."
+                base = f"Command '{self.cmd}' died with unknown signal {-self.returncode}."
         else:
-            return (
-                f"Command '{self.cmd}' returned non-zero exit status {self.returncode}. "
-                f"stderr: {self.stderr}, stdout: {self.stdout}"
-            )
+            base = f"Command '{self.cmd}' returned non-zero exit status {self.returncode}. "
+        return base + f"stderr: {self.stderr}, stdout: {self.stdout}"
 
 
 class ProgramMissingException(Exception):

--- a/gprofiler/exceptions.py
+++ b/gprofiler/exceptions.py
@@ -23,7 +23,7 @@ class CalledProcessError(subprocess.CalledProcessError):
                 base = f"Command '{self.cmd}' died with unknown signal {-self.returncode}."
         else:
             base = f"Command '{self.cmd}' returned non-zero exit status {self.returncode}. "
-        return base + f"stderr: {self.stderr}, stdout: {self.stdout}"
+        return f"{base}\nstdout: {self.stdout}\nstderr: {self.stderr}"
 
 
 class ProgramMissingException(Exception):

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -49,15 +49,13 @@ class GProfiler:
         self._stop_event = Event()
         self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=10)
         self._temp_storage_dir = TemporaryDirectory(dir=TEMPORARY_STORAGE_PATH)
-        self.python_profiler = get_python_profiler(
-            self._frequency, self._duration, self._stop_event, self._temp_storage_dir.name
-        )
         self.java_profiler = JavaProfiler(
             self._frequency, self._duration, True, self._stop_event, self._temp_storage_dir.name
         )
         self.system_profiler = SystemProfiler(
             self._frequency, self._duration, self._stop_event, self._temp_storage_dir.name
         )
+        self.initialize_python_profiler()
 
     def __enter__(self):
         self.start()
@@ -65,6 +63,15 @@ class GProfiler:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.stop()
+
+    def initialize_python_profiler(self) -> None:
+        self.python_profiler = get_python_profiler(
+            self._frequency,
+            self._duration,
+            self._stop_event,
+            self._temp_storage_dir.name,
+            self.initialize_python_profiler,
+        )
 
     def _generate_output_files(
         self, collapsed_data: str, local_start_time: datetime.datetime, local_end_time: datetime.datetime

--- a/gprofiler/python.py
+++ b/gprofiler/python.py
@@ -9,7 +9,7 @@ import signal
 import glob
 from pathlib import Path
 from threading import Event
-from typing import List, Mapping, Optional, Union
+from typing import Callable, List, Mapping, Optional, Union
 from subprocess import Popen
 
 from psutil import Process
@@ -24,11 +24,19 @@ logger = logging.getLogger(__name__)
 class PythonProfilerBase:
     MAX_FREQUENCY = 100
 
-    def __init__(self, frequency: int, duration: int, stop_event: Optional[Event], storage_dir: str):
+    def __init__(
+        self,
+        frequency: int,
+        duration: int,
+        stop_event: Optional[Event],
+        storage_dir: str,
+        reinitialize_profiler: Callable[[], None],
+    ):
         self._frequency = min(frequency, self.MAX_FREQUENCY)
         self._duration = duration
         self._stop_event = stop_event or Event()
         self._storage_dir = storage_dir
+        self._reinitialize_profiler = reinitialize_profiler
         logger.info(f"Initializing Python profiler (frequency: {self._frequency}hz, duration: {duration}s)")
 
     def start(self):
@@ -132,8 +140,15 @@ class PythonEbpfProfiler(PythonProfilerBase):
     dump_poll_retries = 50  # 50 retries * dump_poll_interval = 5 seconds
     poll_timeout = 10  # seconds
 
-    def __init__(self, frequency: int, duration: int, stop_event: Optional[Event], storage_dir: str):
-        super().__init__(frequency, duration, stop_event, storage_dir)
+    def __init__(
+        self,
+        frequency: int,
+        duration: int,
+        stop_event: Optional[Event],
+        storage_dir: str,
+        reinitialize_profiler: Callable[[], None],
+    ):
+        super().__init__(frequency, duration, stop_event, storage_dir, reinitialize_profiler)
         self.process = None
         self.output_path = Path(self._storage_dir) / "py.col.dat"
 
@@ -218,6 +233,7 @@ class PythonEbpfProfiler(PythonProfilerBase):
             global _profiler_class
             _profiler_class = PySpyProfiler
             logger.warn("PyPerf dead/not responding, killing it and reverting to py-spy")
+            self._reinitialize_profiler()
 
             process = self.process  # save it
             self._terminate()
@@ -265,9 +281,9 @@ def determine_profiler_class(storage_dir: str, stop_event: Event):
 
 
 def get_python_profiler(
-    frequency: int, duration: int, stop_event: Event, storage_dir: str
+    frequency: int, duration: int, stop_event: Event, storage_dir: str, reinitialize_profiler: Callable[[], None]
 ) -> Union[PythonEbpfProfiler, PySpyProfiler]:
     global _profiler_class
     if _profiler_class is None:
         _profiler_class = determine_profiler_class(storage_dir, stop_event)
-    return _profiler_class(frequency, duration, stop_event, storage_dir)
+    return _profiler_class(frequency, duration, stop_event, storage_dir, reinitialize_profiler)

--- a/gprofiler/python.py
+++ b/gprofiler/python.py
@@ -213,8 +213,10 @@ class PythonEbpfProfiler(PythonProfilerBase):
             # Duration is irrelevant here, we want to run continuously.
         ]
         self.process = start_process(cmd)
-        # no need to check for success here - we're already past calling test(), PyPerf has been already proved
-        # working.
+        # wait until the transient data file appears - because once returning from here, PyPerf may
+        # be polled via snapshot() and we need it to finish installing its signal handler.
+        if not wait_event(self.poll_timeout, self._stop_event, lambda: os.path.exists(self.output_path)):
+            raise TimeoutError("PyPerf didn't boot")
 
     def _glob_output(self) -> List[str]:
         # important to not grab the transient data file

--- a/gprofiler/python.py
+++ b/gprofiler/python.py
@@ -237,12 +237,12 @@ class PythonEbpfProfiler(PythonProfilerBase):
 
         # error flow :(
         if _reinitialize_profiler is not None:
-            logger.warn("Reverting to py-spy")
+            logger.warning("Reverting to py-spy")
             global _profiler_class
             _profiler_class = PySpyProfiler
             _reinitialize_profiler()
 
-        logger.warn("PyPerf dead/not responding, killing it")
+        logger.warning("PyPerf dead/not responding, killing it")
         process = self.process  # save it
         self._terminate()
         self._pyperf_error(process)

--- a/gprofiler/python.py
+++ b/gprofiler/python.py
@@ -185,7 +185,7 @@ class PythonEbpfProfiler(PythonProfilerBase):
             cls._pyperf_error(process)
 
     @classmethod
-    def test(cls, storage_dir: str, stop_event: Optional[Event]):
+    def test(cls, storage_dir: str, stop_event: Event):
         test_path = Path(storage_dir) / ".test"
         for f in glob.glob(f"{str(test_path)}.*"):
             os.unlink(f)

--- a/gprofiler/python.py
+++ b/gprofiler/python.py
@@ -188,23 +188,9 @@ class PythonEbpfProfiler(PythonProfilerBase):
             str(self._frequency),
             # Duration is irrelevant here, we want to run continuously.
         ]
-        process = start_process(cmd)
-        try:
-            poll_process(process, self.poll_timeout, self._stop_event)
-        except TimeoutError:
-            # Process is alive. So far, so good...
-            if not self.output_path.exists():
-                process.kill()
-                stdout = process.stdout.read().decode()
-                stderr = process.stderr.read().decode()
-                self._check_missing_headers(stdout)
-                raise CalledProcessError(process.returncode, process.args, stdout, stderr)
-            # happy flow
-            self.process = process
-        else:
-            # process terminated, must be an error:
-            self._check_output(process, self.output_path)
-            raise RuntimeError("_check_output did not raise!")
+        self.process = start_process(cmd)
+        # no need to check for success here - we're already past calling test(), PyPerf has been already proved
+        # working.
 
     def _dump(self) -> Path:
         assert self.process is not None, "profiling not started!"

--- a/gprofiler/python.py
+++ b/gprofiler/python.py
@@ -309,7 +309,11 @@ def determine_profiler_class(storage_dir: str, stop_event: Event):
 
 
 def get_python_profiler(
-    frequency: int, duration: int, stop_event: Event, storage_dir: str, reinitialize_profiler: Callable[[], None]
+    frequency: int,
+    duration: int,
+    stop_event: Event,
+    storage_dir: str,
+    reinitialize_profiler: Optional[Callable[[], None]] = None,
 ) -> Union[PythonEbpfProfiler, PySpyProfiler]:
     global _reinitialize_profiler
     _reinitialize_profiler = reinitialize_profiler

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -14,7 +14,7 @@ import ctypes
 from functools import lru_cache
 from subprocess import CompletedProcess, Popen, TimeoutExpired
 from threading import Event, Thread
-from typing import Iterator, Union, List, Optional, Tuple
+from typing import Callable, Iterator, Union, List, Optional, Tuple
 from pathlib import Path
 
 import importlib_resources
@@ -83,6 +83,19 @@ def start_process(cmd: Union[str, List[str]], **kwargs) -> Popen:
         **kwargs,
     )
     return popen
+
+
+def wait_event(timeout: float, stop_event: Event, condition: Callable[[], bool]) -> bool:
+    end_time = time.monotonic() + timeout
+    while True:
+        if condition():
+            return True
+
+        if stop_event.wait(0.1):
+            raise StopEventSetException()
+
+        if time.monotonic() > end_time:
+            return False
 
 
 def poll_process(process, timeout, stop_event):

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -89,23 +89,22 @@ def start_process(cmd: Union[str, List[str]], **kwargs) -> Popen:
     return popen
 
 
-def wait_event(timeout: float, stop_event: Event, condition: Callable[[], bool]) -> bool:
+def wait_event(timeout: float, stop_event: Event, condition: Callable[[], bool]) -> None:
     end_time = time.monotonic() + timeout
     while True:
         if condition():
-            return True
+            break
 
         if stop_event.wait(0.1):
             raise StopEventSetException()
 
         if time.monotonic() > end_time:
-            return False
+            raise TimeoutError()
 
 
 def poll_process(process, timeout: float, stop_event: Event):
     try:
-        if not wait_event(timeout, stop_event, lambda: process.poll() is not None):
-            raise TimeoutError()
+        wait_event(timeout, stop_event, lambda: process.poll() is not None)
     except StopEventSetException:
         process.kill()
         raise

--- a/tests/test_libpython.py
+++ b/tests/test_libpython.py
@@ -35,7 +35,6 @@ def test_python_select_by_libpython(
     Tests that profiling of processes running Python, whose basename(readlink("/proc/pid/exe")) isn't "python".
     (for example, uwsgi). We expect to select these because they have "libpython" in their "/proc/pid/maps".
     """
-    profiler = get_python_profiler(1000, 1, Event(), str(tmp_path), lambda: None)
-    with profiler:
+    with get_python_profiler(1000, 1, Event(), str(tmp_path), lambda: None) as profiler:
         process_collapsed = profiler.snapshot()
     assert_collapsed(process_collapsed.get(application_docker_container.attrs["State"]["Pid"]))

--- a/tests/test_libpython.py
+++ b/tests/test_libpython.py
@@ -35,6 +35,6 @@ def test_python_select_by_libpython(
     Tests that profiling of processes running Python, whose basename(readlink("/proc/pid/exe")) isn't "python".
     (for example, uwsgi). We expect to select these because they have "libpython" in their "/proc/pid/maps".
     """
-    profiler = get_python_profiler(1000, 1, Event(), str(tmp_path))
+    profiler = get_python_profiler(1000, 1, Event(), str(tmp_path), lambda: None)
     process_collapsed = profiler.snapshot()
     assert_collapsed(process_collapsed.get(application_docker_container.attrs["State"]["Pid"]))

--- a/tests/test_libpython.py
+++ b/tests/test_libpython.py
@@ -35,6 +35,6 @@ def test_python_select_by_libpython(
     Tests that profiling of processes running Python, whose basename(readlink("/proc/pid/exe")) isn't "python".
     (for example, uwsgi). We expect to select these because they have "libpython" in their "/proc/pid/maps".
     """
-    with get_python_profiler(1000, 1, Event(), str(tmp_path), lambda: None) as profiler:
+    with get_python_profiler(1000, 1, Event(), str(tmp_path)) as profiler:
         process_collapsed = profiler.snapshot()
     assert_collapsed(process_collapsed.get(application_docker_container.attrs["State"]["Pid"]))

--- a/tests/test_libpython.py
+++ b/tests/test_libpython.py
@@ -36,5 +36,6 @@ def test_python_select_by_libpython(
     (for example, uwsgi). We expect to select these because they have "libpython" in their "/proc/pid/maps".
     """
     profiler = get_python_profiler(1000, 1, Event(), str(tmp_path), lambda: None)
-    process_collapsed = profiler.snapshot()
+    with profiler:
+        process_collapsed = profiler.snapshot()
     assert_collapsed(process_collapsed.get(application_docker_container.attrs["State"]["Pid"]))

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -36,7 +36,7 @@ def test_pyspy(
     application_pid: int,
     assert_collapsed: Callable[[Optional[Mapping[str, int]]], None],
 ) -> None:
-    profiler = PySpyProfiler(1000, 1, Event(), str(tmp_path))
+    profiler = PySpyProfiler(1000, 1, Event(), str(tmp_path), lambda: None)
     process_collapsed = profiler.snapshot()
     assert_collapsed(process_collapsed.get(application_pid))
 

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -36,7 +36,7 @@ def test_pyspy(
     application_pid: int,
     assert_collapsed: Callable[[Optional[Mapping[str, int]]], None],
 ) -> None:
-    profiler = PySpyProfiler(1000, 1, Event(), str(tmp_path), lambda: None)
+    profiler = PySpyProfiler(1000, 1, Event(), str(tmp_path))
     process_collapsed = profiler.snapshot()
     assert_collapsed(process_collapsed.get(application_pid))
 


### PR DESCRIPTION
## Description
I see no reason to run the PyPerf bootstrap checks again right after running `PythonEbpfProfiler.test`. It only slows down the boostrap of gProfiler.

I added timeouts in `_dump()` (called every `snapshot()`) so we can catch dead/hanging PyPerfs.

## Motivation and Context
Faster bootstrap of gProfiler.

## How Has This Been Tested?
Manually.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
