### PR TITLE
Log the Python version gProfiler runs with

### DIFF
--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -6,6 +6,7 @@ import datetime
 import logging
 import os
 import re
+import sys
 import time
 import shutil
 import subprocess
@@ -242,6 +243,7 @@ def get_libc_version() -> Tuple[str, bytes]:
 
 def log_system_info():
     uname = platform.uname()
+    logger.info(f"gProfiler Python version: {sys.version}")
     logger.info(f"Kernel uname release: {uname.release}")
     logger.info(f"Kernel uname version: {uname.version}")
     logger.info(f"Total CPUs: {os.cpu_count()}")


### PR DESCRIPTION
## Description
Will be useful when debugging.

## Motivation and Context
Helps debugging Python-related issues in gProfiler - since gProfiler may run on several versions, depending on the run type.

## How Has This Been Tested?
Manually:
```
[2021-04-27 09:30:38,514] INFO: gprofiler.utils: gProfiler Python version: 3.8.5 (default, Jan 27 2021, 15:41:15) 
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
