### PR TITLE
PyInstaller: Improvements & robustness

### DIFF
--- a/gprofiler/python.py
+++ b/gprofiler/python.py
@@ -160,6 +160,20 @@ class PythonEbpfProfiler(PythonProfilerBase):
             raise CalledProcessError(process.returncode, process.args, stdout, stderr)
 
     @classmethod
+    def get_pyperf_cmd(cls) -> List[str]:
+        pyperf = resource_path(cls.PYPERF_RESOURCE)
+        staticx_dir = os.getenv("STATICX_BUNDLE_DIR")
+        # are we running under staticx?
+        if staticx_dir is not None:
+            # STATICX_BUNDLE_DIR is where staticx has extracted all of the libraries it had collected
+            # earlier.
+            # see https://github.com/JonathonReinhart/staticx#run-time-information
+            # we run PyPerf with the same ld.so whose libc it was compiled against.
+            return [f"{staticx_dir}/ld-2.17.so", "--library-path", staticx_dir, pyperf]
+        else:
+            return [pyperf]
+
+    @classmethod
     def test(cls, storage_dir: str, stop_event: Optional[Event]):
         test_path = Path(storage_dir) / ".test"
         for f in glob.glob(f"{str(test_path)}.*"):
@@ -168,7 +182,7 @@ class PythonEbpfProfiler(PythonProfilerBase):
         # Run the process and check if the output file is properly created.
         # Wait up to 10sec for the process to terminate.
         # Allow cancellation via the stop_event.
-        cmd = [resource_path(cls.PYPERF_RESOURCE), "--output", str(test_path), "-F", "1", "--duration", "1"]
+        cmd = cls.get_pyperf_cmd() + ["--output", str(test_path), "-F", "1", "--duration", "1"]
         process = start_process(cmd)
         try:
             poll_process(process, cls.poll_timeout, stop_event)
@@ -180,8 +194,7 @@ class PythonEbpfProfiler(PythonProfilerBase):
 
     def start(self):
         logger.info("Starting profiling of Python processes with PyPerf")
-        cmd = [
-            resource_path(self.PYPERF_RESOURCE),
+        cmd = self.get_pyperf_cmd() + [
             "--output",
             str(self.output_path),
             "-F",

--- a/gprofiler/python.py
+++ b/gprofiler/python.py
@@ -169,7 +169,7 @@ class PythonEbpfProfiler(PythonProfilerBase):
             # earlier.
             # see https://github.com/JonathonReinhart/staticx#run-time-information
             # we run PyPerf with the same ld.so whose libc it was compiled against.
-            return [f"{staticx_dir}/ld-2.17.so", "--library-path", staticx_dir, pyperf]
+            return [f"{staticx_dir}/.staticx.interp", "--library-path", staticx_dir, pyperf]
         else:
             return [pyperf]
 

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -38,7 +38,16 @@ COPY --from=bcc-builder /bcc/bcc/licenses gprofiler/resources/python/pyperf/lice
 COPY --from=bcc-builder /bcc/bcc/NOTICE gprofiler/resources/python/pyperf/
 
 COPY . .
-RUN pyinstaller pyinstaller.spec
+
+# run PyInstaller and make sure no 'gprofiler.*' modules are missing.
+# see https://pyinstaller.readthedocs.io/en/stable/when-things-go-wrong.html
+# from a quick look I didn't see how to tell PyInstaller to exit with an error on this, hence
+# this check in the shell.
+RUN pyinstaller pyinstaller.spec \
+    && echo \
+    && test -f build/pyinstaller/warn-pyinstaller.txt \
+    && if grep 'gprofiler\.' build/pyinstaller/warn-pyinstaller.txt ; then echo 'PyInstaller failed to pack gProfiler code! See lines above. Make sure to check for SyntaxError as this is often the reason.'; exit 1; fi;
+
 # staticx packs dynamically linked app with all of their dependencies, it tries to figure out which dynamic libraries are need for its execution
 # in some cases, when the application is lazily loading some DSOs, staticx doesn't handle it.
 # libcgcc_s is such a library, so we pass it manually to staticx.

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -71,11 +71,10 @@ RUN pyinstaller pyinstaller.spec \
 COPY ./scripts/list_needed_libs.sh ./scripts/list_needed_libs.sh
 # staticx packs dynamically linked app with all of their dependencies, it tries to figure out which dynamic libraries are need for its execution
 # in some cases, when the application is lazily loading some DSOs, staticx doesn't handle it.
-# libcgcc_s is such a library, so we pass it manually to staticx.
-# additionally, we use list_needed_libs.sh to list the dynamic dependencies of *all* of our resources,
+# we use list_needed_libs.sh to list the dynamic dependencies of *all* of our resources,
 # and make staticx pack them as well.
 # using scl here to get the proper LD_LIBRARY_PATH set
-RUN source scl_source enable devtoolset-8 llvm-toolset-7 && libs=$(./scripts/list_needed_libs.sh) && staticx $libs -l /usr/lib/gcc/x86_64-redhat-linux/4.8.2/libgcc_s.so dist/gprofiler dist/gprofiler
+RUN source scl_source enable devtoolset-8 llvm-toolset-7 && libs=$(./scripts/list_needed_libs.sh) && staticx $libs dist/gprofiler dist/gprofiler
 
 FROM scratch AS export-stage
 

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -37,12 +37,13 @@ COPY --from=bcc-builder /bcc/bcc/LICENSE.txt gprofiler/resources/python/pyperf/
 COPY --from=bcc-builder /bcc/bcc/licenses gprofiler/resources/python/pyperf/licenses
 COPY --from=bcc-builder /bcc/bcc/NOTICE gprofiler/resources/python/pyperf/
 
-COPY . .
+COPY gprofiler gprofiler
 
 # run PyInstaller and make sure no 'gprofiler.*' modules are missing.
 # see https://pyinstaller.readthedocs.io/en/stable/when-things-go-wrong.html
 # from a quick look I didn't see how to tell PyInstaller to exit with an error on this, hence
 # this check in the shell.
+COPY pyi_build.py pyinstaller.spec .
 RUN pyinstaller pyinstaller.spec \
     && echo \
     && test -f build/pyinstaller/warn-pyinstaller.txt \

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -49,10 +49,11 @@ RUN pyinstaller pyinstaller.spec \
     && test -f build/pyinstaller/warn-pyinstaller.txt \
     && if grep 'gprofiler\.' build/pyinstaller/warn-pyinstaller.txt ; then echo 'PyInstaller failed to pack gProfiler code! See lines above. Make sure to check for SyntaxError as this is often the reason.'; exit 1; fi;
 
+COPY ./scripts/list_needed_libs.sh ./scripts/list_needed_libs.sh
 # staticx packs dynamically linked app with all of their dependencies, it tries to figure out which dynamic libraries are need for its execution
 # in some cases, when the application is lazily loading some DSOs, staticx doesn't handle it.
 # libcgcc_s is such a library, so we pass it manually to staticx.
-RUN staticx -l /usr/lib/gcc/x86_64-redhat-linux/4.8.2/libgcc_s.so dist/gprofiler dist/gprofiler
+RUN libs=$(./scripts/list_needed_libs.sh) && staticx $libs -l /usr/lib/gcc/x86_64-redhat-linux/4.8.2/libgcc_s.so dist/gprofiler dist/gprofiler
 
 FROM scratch AS export-stage
 

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -20,7 +20,7 @@ FROM centos:7 as build-stage
 WORKDIR /app
 
 RUN yum update -y && yum install -y epel-release
-RUN yum install -y gcc python3 curl python3-pip patchelf python3-devel
+RUN yum install -y gcc python3 curl python3-pip patchelf python3-devel upx
 
 COPY requirements.txt requirements.txt
 RUN python3 -m pip install -r requirements.txt

--- a/scripts/list_needed_libs.sh
+++ b/scripts/list_needed_libs.sh
@@ -16,7 +16,7 @@ libs=
 
 for f in $BINS ; do
     set +e
-    ldd_output=$(ldd $f 2>&1)
+    ldd_output="$(ldd $f 2>&1)"
     ret=$?
     set -e
 

--- a/scripts/list_needed_libs.sh
+++ b/scripts/list_needed_libs.sh
@@ -23,7 +23,7 @@ for f in $BINS ; do
     if [ $ret -eq 0 ]; then
         if [[ "$ldd_output" == *" not found"* ]]; then
             >&2 echo "missing libs/symbols for binary $f"
-            >&2 cat <<< "$ldd_output"
+            >&2 echo "$ldd_output"
             exit 1
         fi
 

--- a/scripts/list_needed_libs.sh
+++ b/scripts/list_needed_libs.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) Granulate. All rights reserved.
+# Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
+#
+set -e
+
+# this file lists all dynamic dependenices of executables in gprofiler/resources.
+# we use it to let staticx know which libraries it should pack inside.
+# (staticx knows to pack the libraries used by the executable we're packing. it doesn't know
+# which executables are to be used by it)
+
+BINS=$(find gprofiler/resources -executable -type f)
+
+libs=
+
+for f in $BINS ; do
+    set +e
+    ldd_output=$(ldd $f 2>&1)
+    ret=$?
+    set -e
+
+    if [ $ret -eq 0 ]; then
+        if [[ "$ldd_output" == *" not found"* ]]; then
+            >&2 echo "missing libs/symbols for binary $f"
+            >&2 cat <<< "$ldd_output"
+            exit 1
+        fi
+
+        libs="$libs $(grep -v vdso <<< "$ldd_output" | awk '$2 == "=>" { print $3 }')"
+    elif [[ "$ldd_output" != *"not a dynamic executable"* ]]; then
+        >&2 echo "ldd failed: $ldd_output"
+        exit 1
+    fi
+done
+
+for l in $libs ; do
+    >&2 echo "found needed lib: $l"
+    echo -n " -l $l"
+done


### PR DESCRIPTION
## Description
A bunch of commits that'll make it more robust.

1. Install UPX so PyInstaller uses it and the size goes down a bit.
2. Fail PyInstaller build if any of our `gprofiler.*` 
3. Avoid `COPY . .` so build is cached for non-code changes.
4. Include DSOs needed by our resources when calling staticx. This step also ensures all DSO dependencies are resolved, and fails the build if they are not. Currently all executables are static, only PyPerf is dynamic ~~and misses some DSOs in `centos:7`, so build fails.~~

~~I plan to add a few more commits of improvements here (stuff for staticx as well)~~

## Motivation and Context
Easier development & less chances to inject errors.

## How Has This Been Tested?
Locally.

I tried to build with `SyntaxError`s and now the build fails (instead of passing, and producing a broken binary which results in `ImportError`) - this tests the PyInstaller Analysis checks.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
