### PR TITLE
Check for root privileges before attempting to open /var/log/gprofiler/gprofiler.log

### DIFF
--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -268,15 +268,15 @@ def parse_cmd_args():
     return args
 
 
-def verify_preconditions():
+def verify_preconditions(args):
     if not is_root():
-        logger.error("Must run gprofiler as root, please re-run.")
-        return False
-    return True
+        print("Must run gprofiler as root, please re-run.", file=sys.stderr)
+        sys.exit(1)
 
 
 def main():
     args = parse_cmd_args()
+    verify_preconditions(args)
     setup_logger(logging.DEBUG if args.verbose else logging.INFO, args.log_file)
     global logger  # silences flake8, who now knows that the "logger" global we refer to was initialized.
 
@@ -286,9 +286,6 @@ def main():
             log_system_info()
         except Exception:
             logger.exception("Encountered an exception while getting basic system info")
-
-        if not verify_preconditions():
-            sys.exit(1)
 
         if args.output_dir:
             if not Path(args.output_dir).is_dir():

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -268,7 +268,7 @@ def parse_cmd_args():
     return args
 
 
-def verify_preconditions(args):
+def verify_preconditions():
     if not is_root():
         print("Must run gprofiler as root, please re-run.", file=sys.stderr)
         sys.exit(1)
@@ -276,7 +276,7 @@ def verify_preconditions(args):
 
 def main():
     args = parse_cmd_args()
-    verify_preconditions(args)
+    verify_preconditions()
     setup_logger(logging.DEBUG if args.verbose else logging.INFO, args.log_file)
     global logger  # silences flake8, who now knows that the "logger" global we refer to was initialized.
 


### PR DESCRIPTION
## Description
When executed as a regular user, opening the default log file will fail. Check for root privileges first.
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the relevant documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
