### PR TITLE
Ratelimit KeyboardInterrupts to avoid double/triple signalling

### DIFF
--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -315,7 +315,10 @@ def verify_preconditions():
 
 
 def setup_signals() -> None:
-    # see my commit message for the reason we handle sigint manually.
+    # When we run under staticx & PyInstaller, both of them forward (some of the) signals to gProfiler.
+    # We catch SIGINTs and ratelimit them, to avoid being interrupted again during the handling of the
+    # first INT.
+    # See my commit message for more information.
     signal.signal(signal.SIGINT, sigint_handler)
 
 


### PR DESCRIPTION
## Description
After https://github.com/Granulate/gprofiler/pull/42 and https://github.com/Granulate/gprofiler/pull/45. Based on https://github.com/Granulate/gprofiler/pull/45, will rebase after it's merged.

When run under staticx & PyInstaller, both of them forward (some of the) signals
to the gProfiler. Effectively, for a single ^C on my terminal, gProfiler gets 3
signals, as can be seen by "perf record -e signals:signal_deliver":

       gprofiler 908113 [007] 241166.780316: signal:signal_deliver: sig=2 errno=0 code=128 sa_handler=7f6804a00120 sa_flags=4000000
       gprofiler 908112 [004] 241166.780356: signal:signal_deliver: sig=2 errno=0 code=128 sa_handler=404470 sa_flags=14000000
       gprofiler 908101 [010] 241166.780356: signal:signal_deliver: sig=2 errno=0 code=128 sa_handler=400bfd sa_flags=4000000
       gprofiler 908112 [004] 241166.780394: signal:signal_deliver: sig=2 errno=0 code=0 sa_handler=404470 sa_flags=14000000
       gprofiler 908113 [007] 241166.780395: signal:signal_deliver: sig=2 errno=0 code=0 sa_handler=7f6804a00120 sa_flags=4000000
       gprofiler 908113 [007] 241166.780419: signal:signal_deliver: sig=2 errno=0 code=0 sa_handler=7f6804a00120 sa_flags=4000000

* 908101 is the staticx bootloader.
* 908112 is the PyInstaller bootloader.
* 908113 is gProfiler.

1. We can see that each of them got the SIGINT initially
2. Then PyInstaller got it again - forwarded by staticx
3. Then gProfiler got 2 more SIGINTs - one by PyInstaller, and another one for the signal
   forwarded from staticx.

This led to exceptions like:

    ^C[2021-04-29 12:47:45,670] ERROR: gprofiler: Profiling run failed!
    Traceback (most recent call last):
      File "threading.py", line 295, in wait
    KeyboardInterrupt

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "threading.py", line 551, in wait
      File "threading.py", line 295, in wait
    KeyboardInterrupt

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "gprofiler/main.py", line 178, in run_continuous
        self._snapshot()
      File "gprofiler/main.py", line 144, in _snapshot
        for future in concurrent.futures.as_completed([java_future, python_future]):
      File "concurrent/futures/_base.py", line 240, in as_completed
      File "threading.py", line 552, in wait
      File "threading.py", line 243, in __exit__
    RuntimeError: release unlocked lock

Because we got the KeyboardInterrupt more than once, and Python didn't like it.

This commit solves the problem by ratelimiting the SIGINTs we get to one per 0.5s
(although now, we should exit on the first one anyway...)
    
PyInstaller has --bootloader-ignore-signals which can disable that behavior, but staticx
doesn't have it. Also, it's nice if we can get signals from any of them...
So I took this approach.

## Motivation and Context
Before this fix, stopping gProfiler with ^C in the terminal would sometimes raise more than one `KeyboardInterrupt`, disrupting the handling of the first one (leading to gProfiler ignoring the ^C, or exiting without performing any cleanup).

## How Has This Been Tested?
I tested the standalone executable with this fix - after more than 10 runs I can't trigger the issue again (and without this fix it triggers about half the times). 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.