### PR TITLE
java: Use run_in_ns() instead of nsenter for JDK version check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,9 +60,17 @@ jobs:
       fail-fast: false
       matrix:
         # add ubuntu 14.04 and alpine, when they will be ready
-        containers: [ 'ubuntu:16.04', 'ubuntu:18.04',
-                      'ubuntu:20.04', 'ubuntu:20.10', 'centos:7', 'centos:8', 'debian:8',
-                      'debian:9', 'debian:10' ]
+        containers: [
+                      'ubuntu:16.04',
+                      'ubuntu:18.04',
+                      'ubuntu:20.04',
+                      'ubuntu:20.10',
+                      'centos:7',
+                      'centos:8',
+                      'debian:8',
+                      'debian:9',
+                      'debian:10',
+                    ]
     runs-on: ubuntu-20.04
     steps:
       - name: Set up Python 3.8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,8 +59,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # add alpine, when it's ready
         containers: [
+                      'alpine',
                       'ubuntu:14.04',
                       'ubuntu:16.04',
                       'ubuntu:18.04',

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,8 +59,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # add ubuntu 14.04 and alpine, when they will be ready
+        # add alpine, when it's ready
         containers: [
+                      'ubuntu:14.04',
                       'ubuntu:16.04',
                       'ubuntu:18.04',
                       'ubuntu:20.04',

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,19 +59,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        containers: [
-                      'alpine',
-                      'ubuntu:14.04',
-                      'ubuntu:16.04',
-                      'ubuntu:18.04',
-                      'ubuntu:20.04',
-                      'ubuntu:20.10',
-                      'centos:7',
-                      'centos:8',
-                      'debian:8',
-                      'debian:9',
-                      'debian:10',
-                    ]
+        containers:
+          - alpine
+          - ubuntu:14.04
+          - ubuntu:16.04
+          - ubuntu:18.04
+          - ubuntu:20.04
+          - ubuntu:20.10
+          - centos:7
+          - centos:8
+          - debian:8
+          - debian:9
+          - debian:10
     runs-on: ubuntu-20.04
     steps:
       - name: Set up Python 3.8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,9 @@ jobs:
       fail-fast: false
       matrix:
         containers:
-          - alpine
+          # TODO alpine doesn't work, I get FileNotFoundError: [Errno 2] No such file or directory: '/tmp/_MEIMV2FRL/gprofiler/resources/java/jattach'
+          # and the Python process seems like it's not being identified.
+          # - alpine
           - ubuntu:14.04
           - ubuntu:16.04
           - ubuntu:18.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,8 +60,11 @@ jobs:
       fail-fast: false
       matrix:
         containers:
-          # TODO alpine doesn't work, I get FileNotFoundError: [Errno 2] No such file or directory: '/tmp/_MEIMV2FRL/gprofiler/resources/java/jattach'
-          # and the Python process seems like it's not being identified.
+          # TODO alpine doesn't work, I get FileNotFoundError: [Errno 2] No such file or directory: '/tmp/_MEIMV2FRL/gprofiler/resources/java/jattach',
+          # which is probably due to the musl ld.so being used instead of the glibc one jattach was built for.
+          # we can force the use the glibc ld.so (like used for PyPerf, see get_pyperf_cmd) but in general we need a distribution of
+          # async-profiler compiled for musl (because libasyncProfiler.so itself is to be loaded to musl-based processes).
+          # The Python process seems like it's not being identified.
           # - alpine
           - ubuntu:14.04
           - ubuntu:16.04

--- a/README.md
+++ b/README.md
@@ -83,16 +83,12 @@ The following platforms are currently not supported with the gProfiler executabl
 
 **Remark:** container-based execution works and can be used in those cases.
 
-The `nsenter` program needs to be installed for Java profiling. For Debian/Ubuntu, install the `util-linux` package.
-
 ## Running as a Kubernetes DaemonSet
 See [gprofiler.yaml](deploy/k8s/gprofiler.yaml) for a basic template of a DaemonSet running gProfiler.
 Make sure to insert the `GPROFILER_TOKEN` and `GPROFILER_SERVICE` variables in the appropriate location!
 
 ## Running from source
 gProfiler requires Python 3.6+ to run.
-
-As mentioned in the [running-as-an-executable](#executable-known-issues) section, `nsenter` needs to be installed.
 
 ```bash
 pip3 install -r requirements.txt

--- a/gprofiler/java.py
+++ b/gprofiler/java.py
@@ -24,7 +24,7 @@ from .utils import (
     remove_prefix,
     touch_path,
     is_same_ns,
-    assert_program_installed,
+    run_in_ns,
     TEMPORARY_STORAGE_PATH,
 )
 
@@ -103,30 +103,34 @@ class JavaProfiler:
                 logger.warning(f"async-profiler log: {Path(log_path_host).read_text()}")
             raise
 
+    @staticmethod
+    def _get_java_version(process: Process) -> str:
+        java_version_cmd_output = None
+
+        def _run_java_version() -> None:
+            nonlocal java_version_cmd_output
+
+            java_version_cmd_output = run_process(
+                [
+                    f"/proc/{process.pid}/exe",
+                    "-version",
+                ]
+            )
+
+        run_in_ns("mnt", _run_java_version, process.pid)
+
+        if java_version_cmd_output is None:
+            raise Exception("Failed to get java version")
+
+        # Version is printed to stderr
+        return java_version_cmd_output.stderr.decode()
+
     def profile_process(self, process: Process) -> Optional[Mapping[str, int]]:
         logger.info(f"Profiling java process {process.pid}...")
 
-        assert_program_installed("nsenter")
-
         # Get Java version
         if os.path.basename(process.exe()) not in self.SKIP_VERSION_CHECK_BINARIES:
-            try:
-                java_version_cmd_output = run_process(
-                    [
-                        "nsenter",
-                        "-t",
-                        str(process.pid),
-                        "--mount",
-                        "--",
-                        f"/proc/{process.pid}/exe",
-                        "-version",
-                    ]
-                )
-            except CalledProcessError as e:
-                raise Exception("Failed to get java version: {}".format(e))
-
-            # Version is printed to stderr
-            if not self.is_jdk_version_supported(java_version_cmd_output.stderr.decode()):
+            if not self.is_jdk_version_supported(self._get_java_version(process)):
                 logger.warning(f"Process {process.pid} running unsupported Java version, skipping...")
                 return None
 

--- a/gprofiler/java.py
+++ b/gprofiler/java.py
@@ -105,6 +105,11 @@ class JavaProfiler:
 
     @staticmethod
     def _get_java_version(process: Process) -> str:
+        # TODO avoid the readlink here - this will let us operate with "(deleted)" files,
+        # but it requires to get the innermost PID (because the /proc in the target mount NS
+        # is probably mounted with the innermost PID NS...)
+        java_path = os.readlink(f"/proc/{process.pid}/exe")
+
         java_version_cmd_output = None
 
         def _run_java_version() -> None:
@@ -112,7 +117,7 @@ class JavaProfiler:
 
             java_version_cmd_output = run_process(
                 [
-                    f"/proc/{process.pid}/exe",
+                    java_path,
                     "-version",
                 ]
             )

--- a/gprofiler/java.py
+++ b/gprofiler/java.py
@@ -122,7 +122,8 @@ class JavaProfiler:
                 ]
             )
 
-        run_in_ns("mnt", _run_java_version, process.pid)
+        # doesn't work without changing PID NS as well (I'm getting ENOENT for libjli.so)
+        run_in_ns(["pid", "mnt"], _run_java_version, process.pid)
 
         if java_version_cmd_output is None:
             raise Exception("Failed to get java version")

--- a/gprofiler/java.py
+++ b/gprofiler/java.py
@@ -117,9 +117,8 @@ class JavaProfiler:
                         "-t",
                         str(process.pid),
                         "--mount",
-                        "--pid",
                         "--",
-                        os.readlink(f"/proc/{process.pid}/exe"),
+                        f"/proc/{process.pid}/exe",
                         "-version",
                     ]
                 )

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -266,26 +266,37 @@ def get_run_mode() -> str:
         return "local_python"
 
 
-# we can't setns(CLONE_NEWNS) in a multithreaded program (unless we unshare(CLONE_NEWNS) before)
-# so, we start a new thread, unshare() & setns() it, get our needed information and then stop this thread
-# (so we don't keep unshared threads running around)
-# for other namespace types, we use this function to execute callbacks without changing the namespaces for the
-# core threads.
-# by default, run in init NS. you can pass 'target_pid' to run in the namespace of that process.
-def run_in_ns(nstype: str, callback: Callable[[], None], target_pid: int = 1) -> None:
-    def _switch_and_run():
-        if not is_same_ns(target_pid, nstype):
-            libc = ctypes.CDLL("libc.so.6")
+def run_in_ns(nstypes: List[str], callback: Callable[[], None], target_pid: int = 1) -> None:
+    """
+    Runs a callback in a new thread, switching to a set of the namespaces of a target process before
+    doing so.
 
-            flag = {
-                "mnt": 0x00020000,  # CLONE_NEWNS
-                "net": 0x40000000,  # CLONE_NEWNET
-            }[nstype]
-            if (
-                libc.unshare(flag) != 0
-                or libc.setns(os.open(f"/proc/{target_pid}/ns/{nstype}", os.O_RDONLY), flag) != 0
-            ):
-                raise ValueError(f"Failed to unshare({nstype}) and setns({nstype})")
+    Needed initially for swithcing mount namespaces, because we can't setns(CLONE_NEWNS) in a multithreaded
+    program (unless we unshare(CLONE_NEWNS) before). so, we start a new thread, unshare() & setns() it,
+    run our callback and then stop the thread (so we don't keep unshared threads running around).
+    For other namespace types, we use this function to execute callbacks without changing the namespaces
+    for the core threads.
+
+    By default, run stuff in init NS. You can pass 'target_pid' to run in the namespace of that process.
+    """
+
+    # make sure "mnt" is last, once we change it our /proc is gone
+    nstypes = sorted(nstypes, key=lambda ns: 1 if ns == "mnt" else 0)
+
+    def _switch_and_run():
+        libc = ctypes.CDLL("libc.so.6")
+        for nstype in nstypes:
+            if not is_same_ns(target_pid, nstype):
+                flag = {
+                    "mnt": 0x00020000,  # CLONE_NEWNS
+                    "net": 0x40000000,  # CLONE_NEWNET
+                    "pid": 0x20000000,  # CLONE_NEWPID
+                }[nstype]
+                if (
+                    libc.unshare(flag) != 0
+                    or libc.setns(os.open(f"/proc/{target_pid}/ns/{nstype}", os.O_RDONLY), flag) != 0
+                ):
+                    raise ValueError(f"Failed to unshare({nstype}) and setns({nstype})")
 
         callback()
 
@@ -311,7 +322,7 @@ def log_system_info():
         results.append(distro.linux_distribution())
         results.append(get_libc_version())
 
-    run_in_ns("mnt", get_distro_and_libc)
+    run_in_ns(["mnt"], get_distro_and_libc)
     assert len(results) == 2, f"only {len(results)} results, expected 2"
 
     logger.info(f"Linux distribution: {results[0]}")
@@ -345,6 +356,6 @@ def grab_gprofiler_mutex() -> bool:
             # hold the reference so lock remains taken
             gprofiler_mutex = s
 
-    run_in_ns("net", _take_lock)
+    run_in_ns(["net"], _take_lock)
 
     return gprofiler_mutex is not None


### PR DESCRIPTION
## Description
Use new `run_in_ns()` helper instead of using `nsenter` to implement the JDK version checking.

Based on https://github.com/Granulate/gprofiler/pull/52 for some of the changes. Will merge after it.

## Motivation and Context
Drop dependency on `nsenter`.

## How Has This Been Tested?
Checked that we correctly get the JDK version for the `java` image (Debian 8 based) and `java:alpine` (Alpine based.. duh :)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
