### PR TITLE
python: Upgrade PyPerf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y git build-essential iperf 
 
 WORKDIR /bcc
 
-RUN git clone --depth 1 -b v1.0.0 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 119d71bf9681182759eb76d40660c0ec19f3fc42
+RUN git clone --depth 1 -b v1.0.1 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 92b61ade89f554859950695b067288f60cb1f3e5
 RUN mkdir bcc/build && cd bcc/build && \
   cmake -DPYTHON_CMD=python3 -DINSTALL_CPP_EXAMPLES=y -DCMAKE_INSTALL_PREFIX=/bcc/root .. && \
   make -C examples/cpp/pyperf -j -l VERBOSE=1 install

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y git build-essential iperf 
 
 WORKDIR /bcc
 
-RUN git clone --depth 1 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 119d71bf9681182759eb76d40660c0ec19f3fc42
+RUN git clone --depth 1 -b v1.0.0 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 119d71bf9681182759eb76d40660c0ec19f3fc42
 RUN mkdir bcc/build && cd bcc/build && \
   cmake -DPYTHON_CMD=python3 -DINSTALL_CPP_EXAMPLES=y -DCMAKE_INSTALL_PREFIX=/bcc/root .. && \
   make -C examples/cpp/pyperf -j -l VERBOSE=1 install

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -17,7 +17,7 @@ RUN yum install -y \
 
 WORKDIR /bcc
 
-RUN git clone --depth 1 -b v1.0.0 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 119d71bf9681182759eb76d40660c0ec19f3fc42
+RUN git clone --depth 1 -b v1.0.1 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 92b61ade89f554859950695b067288f60cb1f3e5
 
 RUN yum install -y centos-release-scl-rh
 # mostly taken from https://github.com/iovisor/bcc/blob/master/INSTALL.md#install-and-compile-llvm

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -17,7 +17,7 @@ RUN yum install -y \
 
 WORKDIR /bcc
 
-RUN git clone --depth 1 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 119d71bf9681182759eb76d40660c0ec19f3fc42
+RUN git clone --depth 1 -b v1.0.0 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 119d71bf9681182759eb76d40660c0ec19f3fc42
 
 RUN yum install -y centos-release-scl-rh
 # mostly taken from https://github.com/iovisor/bcc/blob/master/INSTALL.md#install-and-compile-llvm


### PR DESCRIPTION
## Description
Upgrade PyPerf to include https://github.com/Granulate/bcc/pull/2 and fix `git clone` for the reason described in https://github.com/Granulate/gprofiler/pull/54#issuecomment-830710450.

As mentioned in the last commit - I like the "git reset --hard <sha>" because it's the best way to hardcode revisions,
so I prefer to keep it (although it's the source for this problem... on the other hand, it helped us to avoid "implicitly" upgrading PyPerf, which is not desired).

## Motivation and Context
Upgrade PyPerf with recent fix.

## How Has This Been Tested?
Tested the new gProfiler w/ the new PyPerf locally.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
