### PR TITLE
Run gProfiler from /tmp dir bug

### DIFF
--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -5,9 +5,7 @@
 import datetime
 import logging
 import os
-import random
 import re
-import string
 import sys
 import time
 import shutil

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -5,7 +5,9 @@
 import datetime
 import logging
 import os
+import random
 import re
+import string
 import sys
 import time
 import shutil
@@ -32,7 +34,7 @@ from gprofiler.exceptions import (
 
 logger = logging.getLogger(__name__)
 
-TEMPORARY_STORAGE_PATH = "/tmp/gprofiler"
+TEMPORARY_STORAGE_PATH = f"/tmp/gprofiler_tmp"
 
 
 def resource_path(relative_path: str = "") -> str:

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -32,7 +32,7 @@ from gprofiler.exceptions import (
 
 logger = logging.getLogger(__name__)
 
-TEMPORARY_STORAGE_PATH = f"/tmp/gprofiler_tmp"
+TEMPORARY_STORAGE_PATH = "/tmp/gprofiler_tmp"
 
 
 def resource_path(relative_path: str = "") -> str:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
If executable gProfiler is run from `/tmp`, there is a collision with TEMPORARY_STORAGE_PATH.
By default the executable name is `gprofiler` as well the temp directory is `gprofiler`
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
## Motivation and Context
Make possible to run gProfiler from `/tmp` with default names.
<!--- Why is this change required? What problem does it solve? -->
## How Has This Been Tested?
Compiled locally and ran on Ubuntu 18.04 VM under `/tmp` dir.
Previous version printed `NotADirectoryError: [Errno 20] Not a directory: '/tmp/gprofiler/tmpssruylt3'`
Version with the change worked as expected.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
## Screenshots (if appropriate):
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the relevant documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
