### PR TITLE
utils: Allow executing processes with & without staticx settings

### DIFF
--- a/gprofiler/python.py
+++ b/gprofiler/python.py
@@ -169,20 +169,6 @@ class PythonEbpfProfiler(PythonProfilerBase):
             cls._pyperf_error(process)
 
     @classmethod
-    def _get_pyperf_cmd(cls) -> List[str]:
-        pyperf = resource_path(cls.PYPERF_RESOURCE)
-        staticx_dir = os.getenv("STATICX_BUNDLE_DIR")
-        # are we running under staticx?
-        if staticx_dir is not None:
-            # STATICX_BUNDLE_DIR is where staticx has extracted all of the libraries it had collected
-            # earlier.
-            # see https://github.com/JonathonReinhart/staticx#run-time-information
-            # we run PyPerf with the same ld.so whose libc it was compiled against.
-            return [f"{staticx_dir}/.staticx.interp", "--library-path", staticx_dir, pyperf]
-        else:
-            return [pyperf]
-
-    @classmethod
     def test(cls, storage_dir: str, stop_event: Event):
         test_path = Path(storage_dir) / ".test"
         for f in glob.glob(f"{str(test_path)}.*"):
@@ -191,8 +177,8 @@ class PythonEbpfProfiler(PythonProfilerBase):
         # Run the process and check if the output file is properly created.
         # Wait up to 10sec for the process to terminate.
         # Allow cancellation via the stop_event.
-        cmd = cls._get_pyperf_cmd() + ["--output", str(test_path), "-F", "1", "--duration", "1"]
-        process = start_process(cmd)
+        cmd = [resource_path(cls.PYPERF_RESOURCE), "--output", str(test_path), "-F", "1", "--duration", "1"]
+        process = start_process(cmd, static_bin=True)
         try:
             poll_process(process, cls.poll_timeout, stop_event)
         except TimeoutError:
@@ -203,14 +189,15 @@ class PythonEbpfProfiler(PythonProfilerBase):
 
     def start(self):
         logger.info("Starting profiling of Python processes with PyPerf")
-        cmd = self._get_pyperf_cmd() + [
+        cmd = [
+            resource_path(self.PYPERF_RESOURCE),
             "--output",
             str(self.output_path),
             "-F",
             str(self._frequency),
             # Duration is irrelevant here, we want to run continuously.
         ]
-        process = start_process(cmd)
+        process = start_process(cmd, static_bin=True)
         # wait until the transient data file appears - because once returning from here, PyPerf may
         # be polled via snapshot() and we need it to finish installing its signal handler.
         try:

--- a/gprofiler/python.py
+++ b/gprofiler/python.py
@@ -178,7 +178,7 @@ class PythonEbpfProfiler(PythonProfilerBase):
         # Wait up to 10sec for the process to terminate.
         # Allow cancellation via the stop_event.
         cmd = [resource_path(cls.PYPERF_RESOURCE), "--output", str(test_path), "-F", "1", "--duration", "1"]
-        process = start_process(cmd, static_bin=True)
+        process = start_process(cmd, via_staticx=True)
         try:
             poll_process(process, cls.poll_timeout, stop_event)
         except TimeoutError:
@@ -197,7 +197,7 @@ class PythonEbpfProfiler(PythonProfilerBase):
             str(self._frequency),
             # Duration is irrelevant here, we want to run continuously.
         ]
-        process = start_process(cmd, static_bin=True)
+        process = start_process(cmd, via_staticx=True)
         # wait until the transient data file appears - because once returning from here, PyPerf may
         # be polled via snapshot() and we need it to finish installing its signal handler.
         try:

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -158,10 +158,13 @@ def pgrep_exe(match: str) -> Iterator[Process]:
 def pgrep_maps(match: str) -> List[Process]:
     # this is much faster than iterating over processes' maps with psutil.
     result = subprocess.run(
-        f"grep -lP '{match}' /proc/*/maps", stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, shell=True
+        f"grep -lP '{match}' /proc/*/maps", stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
     )
     # might get 2 (which 'grep' exits with, if some files were unavailable, because processes have exited)
-    assert result.returncode in (0, 2), f"unexpected 'grep' exit code: {result.returncode}"
+    assert result.returncode in (
+        0,
+        2,
+    ), f"unexpected 'grep' exit code: {result.returncode}, stdout {result.stdout!r} stderr {result.stderr!r}"
 
     processes: List[Process] = []
     for line in result.stdout.splitlines():

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -85,11 +85,14 @@ def start_process(cmd: Union[str, List[str]], **kwargs) -> Popen:
     logger.debug(f"Running command: ({cmd_text})")
     if isinstance(cmd, str):
         cmd = [cmd]
+    env = kwargs.pop("env", {})
+    env.update({"LD_LIBRARY_PATH": ""})
     popen = Popen(
         cmd,
         stdout=kwargs.pop("stdout", subprocess.PIPE),
         stderr=kwargs.pop("stderr", subprocess.PIPE),
         preexec_fn=kwargs.pop("preexec_fn", os.setpgrp),
+        env=env,
         **kwargs,
     )
     return popen

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -184,8 +184,12 @@ def pgrep_exe(match: str) -> Iterator[Process]:
 
 def pgrep_maps(match: str) -> List[Process]:
     # this is much faster than iterating over processes' maps with psutil.
-    result = subprocess.run(
-        f"grep -lP '{match}' /proc/*/maps", stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
+    result = run_process(
+        f"grep -lP '{match}' /proc/*/maps",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        shell=True,
+        suppress_log=True,
     )
     # might get 2 (which 'grep' exits with, if some files were unavailable, because processes have exited)
     assert result.returncode in (
@@ -269,7 +273,7 @@ def get_libc_version() -> Tuple[str, bytes]:
     # so we'll run "ldd --version" and extract the version string from it.
     # not passing "encoding"/"text" - this runs in a different mount namespace, and Python fails to
     # load the files it needs for those encodings (getting LookupError: unknown encoding: ascii)
-    ldd_version = subprocess.run(["ldd", "--version"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT).stdout
+    ldd_version = run_process(["ldd", "--version"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT).stdout
     # catches GLIBC & EGLIBC
     m = re.search(br"GLIBC (.*?)\)", ldd_version)
     if m is not None:

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -92,8 +92,6 @@ def start_process(cmd: Union[str, List[str]], via_staticx: bool, **kwargs) -> Po
         # if so, if "via_staticx" was requested, then run the binary with the staticx ld.so
         # because it's supposed to be run with it.
         if via_staticx:
-            # we shouldn't try to run any program that's not our resource with "via_staticx".
-            assert cmd[0].startswith(resource_path("/"))
             # STATICX_BUNDLE_DIR is where staticx has extracted all of the libraries it had collected
             # earlier.
             # see https://github.com/JonathonReinhart/staticx#run-time-information


### PR DESCRIPTION
## Description
Allow starting new processes with the staticx settings / without them. This is relevant to 2 cases:
1. When running on old systems, our `LD_LIBRARY_PATH` affects execution of system programs we run, like `grep` and `ldd`. It shouldn't.
2. Other binary utilities (besides PyPerf) could use this 

## Motivation and Context
1. Run system programs like `grep` on old machines, without our libs interfering. For example, I get this error when we run `ldd --version`:
```
[2021-05-10 11:43:51,257] INFO: gprofiler.utils: libc version: ('unknown', b"/bin/bash: /lib64/libc.so.6: version `GLIBC_2.14' not found (required by /tmp/_MEIq0Ri7F/libtinfo.so.5)\n/bin/bash: /lib64/libc.so.6: version `GLIBC_2.15' not found (required by /tmp/_MEIq0Ri7F/libtinfo.so.5)\n")
```
2. Make it easier for future code to invoke resources with staticx settings.

## How Has This Been Tested?
On a CentOS 6 machine - verified that running `grep`, `ldd` now works.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
