### PR TITLE
python: Add py-spy build logic, and upgrade it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,12 @@
+FROM rust:latest AS pyspy-builder
+
+COPY scripts/pyspy_env.sh .
+RUN ./pyspy_env.sh
+
+COPY scripts/pyspy_build.sh .
+RUN ./pyspy_build.sh
+
+
 FROM ubuntu:20.04 as bcc-builder
 
 RUN apt-get update
@@ -25,6 +34,8 @@ COPY --from=bcc-builder /bcc/root/share/bcc/examples/cpp/PyPerf gprofiler/resour
 COPY --from=bcc-builder /bcc/bcc/LICENSE.txt gprofiler/resources/python/pyperf/
 COPY --from=bcc-builder /bcc/bcc/licenses gprofiler/resources/python/pyperf/licenses
 COPY --from=bcc-builder /bcc/bcc/NOTICE gprofiler/resources/python/pyperf/
+
+COPY --from=pyspy-builder /py-spy/target/x86_64-unknown-linux-musl/release/py-spy gprofiler/resources/python/py-spy
 
 COPY scripts/build.sh scripts/build.sh
 RUN ./scripts/build.sh

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,5 +4,3 @@ black
 mypy
 isort
 docker
-pyinstaller==4.0
-staticx

--- a/exe-requirements.txt
+++ b/exe-requirements.txt
@@ -1,3 +1,3 @@
 # requirements for the standalone executable
 pyinstaller==4.0
-staticx
+staticx==0.12.1

--- a/exe-requirements.txt
+++ b/exe-requirements.txt
@@ -1,0 +1,3 @@
+# requirements for the standalone executable
+pyinstaller==4.0
+staticx

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -1,3 +1,12 @@
+# copied from Dockerfile
+FROM rust:latest AS pyspy-builder
+
+COPY scripts/pyspy_env.sh .
+RUN ./pyspy_env.sh
+
+COPY scripts/pyspy_build.sh .
+RUN ./pyspy_build.sh
+
 # Centos 7 image is used to grab an old version of `glibc` during `pyinstaller` bundling.
 # This will allow the executable to run on older versions of the kernel, eventually leading to the executable running on a wider range of machines.
 FROM centos:7 AS build-stage
@@ -55,6 +64,8 @@ RUN cp /bcc/root/share/bcc/examples/cpp/PyPerf gprofiler/resources/python/pyperf
 RUN cp /bcc/bcc/LICENSE.txt gprofiler/resources/python/pyperf/
 RUN cp -r /bcc/bcc/licenses gprofiler/resources/python/pyperf/licenses
 RUN cp /bcc/bcc/NOTICE gprofiler/resources/python/pyperf/
+
+COPY --from=pyspy-builder /py-spy/target/x86_64-unknown-linux-musl/release/py-spy gprofiler/resources/python/py-spy
 
 COPY gprofiler gprofiler
 

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -52,8 +52,8 @@ RUN yum install -y gcc python3 curl python3-pip patchelf python3-devel upx
 COPY requirements.txt requirements.txt
 RUN python3 -m pip install -r requirements.txt
 
-COPY dev-requirements.txt dev-requirements.txt
-RUN python3 -m pip install -r dev-requirements.txt
+COPY exe-requirements.txt exe-requirements.txt
+RUN python3 -m pip install -r exe-requirements.txt
 
 COPY scripts/build.sh scripts/build.sh
 RUN ./scripts/build.sh

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,11 +13,6 @@ curl -fL https://github.com/Granulate/async-profiler/releases/download/v2.0g1/as
    -z build/async-profiler-2.0-linux-x64.tar.gz -o build/async-profiler-2.0-linux-x64.tar.gz
 tar -xzf build/async-profiler-2.0-linux-x64.tar.gz -C gprofiler/resources/java --strip-components=2 async-profiler-2.0-linux-x64/build
 
-# py-spy
-mkdir -p gprofiler/resources/python
-curl -fL https://github.com/Granulate/py-spy/releases/download/v0.3.5g1/py-spy -o gprofiler/resources/python/py-spy
-chmod +x gprofiler/resources/python/py-spy
-
 # pyperf - just create the directory for it, it will be built/downloaded later
 mkdir -p gprofiler/resources/python/pyperf
 

--- a/scripts/pyspy_build.sh
+++ b/scripts/pyspy_build.sh
@@ -5,6 +5,6 @@
 #
 set -euo pipefail
 
-git clone --depth 1 -b v0.3.5g1 https://github.com/Granulate/py-spy.git
+git clone --depth 1 -b v0.3.6g1 https://github.com/Granulate/py-spy.git && git -C py-spy reset --hard fcf4aa16587ae0b425d7533b828827901d14b24e
 cd py-spy
 cargo build --release --target=x86_64-unknown-linux-musl

--- a/scripts/pyspy_build.sh
+++ b/scripts/pyspy_build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) Granulate. All rights reserved.
+# Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
+#
+set -euo pipefail
+
+git clone --depth 1 -b v0.3.5g1 https://github.com/Granulate/py-spy.git
+cd py-spy
+cargo build --release --target=x86_64-unknown-linux-musl

--- a/scripts/pyspy_env.sh
+++ b/scripts/pyspy_env.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) Granulate. All rights reserved.
+# Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
+#
+set -euo pipefail
+
+# prepares the environment for building py-spy:
+# 1. installs the rust target x86_64-unknown-linux-musl - this can build static binaries
+# 2. downloads, builds & installs libunwind with musl
+# 2. downloads, builds & installs libz with musl
+# I use musl because it builds statically. otherwise, we need to build with old glibc; I tried to
+# build on centos:7 but it caused some errors out-of-the-box (libunwind was built w/o -fPIC and rust tried
+# to build it as shared (?))
+# in any way, building it static solves all issues. and I find it better to use more recent versions of libraries
+# like libunwind/zlib.
+
+rustup target add x86_64-unknown-linux-musl
+
+apt-get update && apt-get install -y musl-dev musl-tools
+
+mkdir builds && cd builds
+
+wget https://github.com/libunwind/libunwind/releases/download/v1.5/libunwind-1.5.0.tar.gz
+tar -xf libunwind-1.5.0.tar.gz
+cd libunwind-1.5.0
+CC=musl-gcc ./configure --disable-minidebuginfo --enable-ptrace --disable-tests --disable-documentation
+make
+make install
+
+wget https://zlib.net/zlib-1.2.11.tar.xz
+tar -xf zlib-1.2.11.tar.xz
+cd zlib-1.2.11
+# note the use of --prefix here. it matches the directory https://github.com/benfred/remoteprocess/blob/master/build.rs expects to find libs for musl.
+# the libunwind configure may install it in /usr/local/lib for all I care, but if we override /usr/local/lib/libz... with the musl ones,
+# it won't do any good...
+CC=musl-gcc ./configure --prefix=/usr/local/musl/x86_64-unknown-linux-musl
+make
+make install

--- a/tests/test_libpython.py
+++ b/tests/test_libpython.py
@@ -10,6 +10,7 @@ from docker.models.images import Image
 
 from gprofiler.python import get_python_profiler
 from tests import CONTAINERS_DIRECTORY
+from tests.utils import copy_pyspy_from_image
 
 
 @pytest.fixture
@@ -30,11 +31,13 @@ def test_python_select_by_libpython(
     tmp_path,
     application_docker_container,
     assert_collapsed,
+    gprofiler_docker_image: Image,
 ) -> None:
     """
     Tests that profiling of processes running Python, whose basename(readlink("/proc/pid/exe")) isn't "python".
     (for example, uwsgi). We expect to select these because they have "libpython" in their "/proc/pid/maps".
     """
+    copy_pyspy_from_image(gprofiler_docker_image)
     with get_python_profiler(1000, 1, Event(), str(tmp_path)) as profiler:
         process_collapsed = profiler.snapshot()
     assert_collapsed(process_collapsed.get(application_docker_container.attrs["State"]["Pid"]))

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -34,7 +34,15 @@ def test_pyspy(
     tmp_path: Path,
     application_pid: int,
     assert_collapsed: Callable[[Optional[Mapping[str, int]]], None],
+    gprofiler_docker_image,
 ) -> None:
+    # get py-spy from the built container
+    copy_file_from_image(
+        gprofiler_docker_image,
+        os.path.join("/app", "gprofiler", "resources", "python", "py-spy"),
+        resource_path("python/py-spy"),
+    )
+
     profiler = PySpyProfiler(1000, 1, Event(), str(tmp_path))
     process_collapsed = profiler.snapshot()
     assert_collapsed(process_collapsed.get(application_pid))

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -24,9 +24,9 @@ def test_java_from_host(
     application_pid: int,
     assert_collapsed: Callable[[Optional[Mapping[str, int]]], None],
 ) -> None:
-    profiler = JavaProfiler(1000, 1, True, Event(), str(tmp_path))
-    process_collapsed = profiler.snapshot()
-    assert_collapsed(process_collapsed.get(application_pid))
+    with JavaProfiler(1000, 1, True, Event(), str(tmp_path)) as profiler:
+        process_collapsed = profiler.snapshot()
+        assert_collapsed(process_collapsed.get(application_pid))
 
 
 @pytest.mark.parametrize("runtime", ["python"])
@@ -37,9 +37,9 @@ def test_pyspy(
     gprofiler_docker_image: Image,
 ) -> None:
     copy_pyspy_from_image(gprofiler_docker_image)
-    profiler = PySpyProfiler(1000, 1, Event(), str(tmp_path))
-    process_collapsed = profiler.snapshot()
-    assert_collapsed(process_collapsed.get(application_pid))
+    with PySpyProfiler(1000, 1, Event(), str(tmp_path)) as profiler:
+        process_collapsed = profiler.snapshot()
+        assert_collapsed(process_collapsed.get(application_pid))
 
 
 @pytest.mark.parametrize("runtime", ["python"])

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -15,7 +15,7 @@ from gprofiler.java import JavaProfiler
 from gprofiler.merge import parse_one_collapsed
 from gprofiler.python import PySpyProfiler, PythonEbpfProfiler
 from gprofiler.utils import resource_path
-from tests.utils import copy_file_from_image, run_privileged_container
+from tests.utils import copy_file_from_image, copy_pyspy_from_image, run_privileged_container
 
 
 @pytest.mark.parametrize("runtime", ["java"])
@@ -34,15 +34,9 @@ def test_pyspy(
     tmp_path: Path,
     application_pid: int,
     assert_collapsed: Callable[[Optional[Mapping[str, int]]], None],
-    gprofiler_docker_image,
+    gprofiler_docker_image: Image,
 ) -> None:
-    # get py-spy from the built container
-    copy_file_from_image(
-        gprofiler_docker_image,
-        os.path.join("/app", "gprofiler", "resources", "python", "py-spy"),
-        resource_path("python/py-spy"),
-    )
-
+    copy_pyspy_from_image(gprofiler_docker_image)
     profiler = PySpyProfiler(1000, 1, Event(), str(tmp_path))
     process_collapsed = profiler.snapshot()
     assert_collapsed(process_collapsed.get(application_pid))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,6 +6,8 @@ from typing import Dict, List
 from docker import DockerClient
 from docker.models.images import Image
 
+from gprofiler.utils import resource_path
+
 
 def run_privileged_container(
     docker_client: DockerClient,
@@ -48,3 +50,12 @@ def chmod_path_parts(path: Path, add_mode: int) -> None:
     for i in range(1, len(path.parts)):
         subpath = os.path.join(*path.parts[:i])
         os.chmod(subpath, os.stat(subpath).st_mode | add_mode)
+
+
+def copy_pyspy_from_image(gprofiler_docker_image: Image):
+    # get py-spy from the built container
+    copy_file_from_image(
+        gprofiler_docker_image,
+        os.path.join("/app", "gprofiler", "resources", "python", "py-spy"),
+        resource_path("python/py-spy"),
+    )


### PR DESCRIPTION
~~Based on https://github.com/Granulate/gprofiler/pull/67.~~

## Description
Upgrade py-spy to its latest release, and include the build logic here (instead of downloading from GH releases) so it's easier to make changes in py-spy and rebuild gProfiler with them.

## Motivation and Context
Regarding adding the build of py-spy here - it's easier for new developers to work on this project if the build is self contained and it's clear from where each resource comes, and how to reproduce that resource.

## How Has This Been Tested?
Our tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
