### PR TITLE
utils: Add "check" parameter to run_process()

### DIFF
--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -139,6 +139,7 @@ def run_process(
     stop_event: Event = None,
     suppress_log: bool = False,
     via_staticx: bool = False,
+    check: bool = True,
     **kwargs,
 ) -> CompletedProcess:
     with start_process(cmd, via_staticx, **kwargs) as process:
@@ -167,7 +168,7 @@ def run_process(
             logger.debug(f"({process.args!r}) stdout: {result.stdout}")
         if result.stderr:
             logger.debug(f"({process.args!r}) stderr: {result.stderr}")
-    if retcode:
+    if check and retcode != 0:
         raise CalledProcessError(retcode, process.args, output=stdout, stderr=stderr)
     return result
 
@@ -185,6 +186,7 @@ def pgrep_maps(match: str) -> List[Process]:
         stderr=subprocess.PIPE,
         shell=True,
         suppress_log=True,
+        check=False,
     )
     # might get 2 (which 'grep' exits with, if some files were unavailable, because processes have exited)
     assert result.returncode in (

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -271,7 +271,7 @@ def get_libc_version() -> Tuple[str, bytes]:
     # not passing "encoding"/"text" - this runs in a different mount namespace, and Python fails to
     # load the files it needs for those encodings (getting LookupError: unknown encoding: ascii)
     ldd_version = run_process(
-        ["ldd", "--version"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, suppress_log=True
+        ["ldd", "--version"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, suppress_log=True, check=False
     ).stdout
     # catches GLIBC & EGLIBC
     m = re.search(br"GLIBC (.*?)\)", ldd_version)


### PR DESCRIPTION
## Description
In 4201d640f15136314d42dbcb926dbde0c67e12ef I changed pgrep_maps() to use run_process().
It was using subprocess.run() without check=True, thus it wasn't expecting an exception to
be raised if the command exits with non-0.

## Motivation and Context
Fix the bug.

## How Has This Been Tested?
I ran it and now I see lines like: `[2021-05-13 18:33:49,775] DEBUG: gprofiler.utils: (["grep -lP '(?:^.+/(?:lib)?python[^/]*$)|(?:^.+/site-packages/.+?$)|(?:^.+/dist-packages/.+?$)' /proc/*/maps"]) exit code: 2`, and gProfiler continues running (and profiles existing Python processes as expected)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
