### PR TITLE
python: py-spy: Ignore PyPy

### DIFF
--- a/gprofiler/python.py
+++ b/gprofiler/python.py
@@ -95,6 +95,8 @@ class PySpyProfiler(PythonProfilerBase):
                 # PyPy is called pypy3 or pypy (for 2)
                 # py-spy is, of course, only for CPython, and will report a possibly not-so-nice error
                 # when invoked on pypy.
+                # I'm checking for "pypy" in the basename here. I'm not aware of libpypy being directly loaded
+                # into non-pypy processes, if we ever encounter that - we can check the maps instead
                 if os.path.basename(process.exe()).startswith("pypy"):
                     continue
 

--- a/gprofiler/python.py
+++ b/gprofiler/python.py
@@ -92,6 +92,12 @@ class PySpyProfiler(PythonProfilerBase):
                 if any(item in cmdline for item in self.BLACKLISTED_PYTHON_PROCS):
                     continue
 
+                # PyPy is called pypy3 or pypy (for 2)
+                # py-spy is, of course, only for CPython, and will report a possibly not-so-nice error
+                # when invoked on pypy.
+                if os.path.basename(process.exe()).startswith("pypy"):
+                    continue
+
                 filtered_procs.append(process)
             except Exception:
                 logger.exception(f"Couldn't add pid {process.pid} to list")


### PR DESCRIPTION
## Description
Since a3b5b73949bc6f064c15e3966cfbb25ce208e497 we're matching on processes with {site,dist}-packages
in their maps (aiming at CPython native extensions).
This matches on native extensions loaded into other Python implementations, such as PyPy.
However, py-spy can't profile them. So we'll avoid trying to profile them (to avoid the possibly-obscure
error message from py-spy). We can add more ignored implementations later, if we encounter any.

Example error:
```
[2021-05-13 18:45:13,061] INFO: gprofiler.python: Profiling process 671516 (['pypy'])
....
[2021-05-13 18:45:13,149] DEBUG: gprofiler.utils: (['/app/gprofiler/resources/python/py-spy', 'record', '-r', '10', '-d', '60', '--nonblocking', '--format', 'raw', '-F', '--gil', '--output', '/tmp/gprofiler_tmp/tmpvi62nyce/671516.py.col.dat', '-p', '671516', '--full-filenames']) stderr: b'Error: Failed to parse python binary\nReason: Malformed entity: Section 106 size (4195440) + addr (24) is out of bounds. Overflowed: false\n\n'
[2021-05-13 18:45:13,150] ERROR: gprofiler.python: Failed to profile Python process 671516
Traceback (most recent call last):
  File "/app/gprofiler/python.py", line 119, in snapshot
    results[futures[future]] = future.result()
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 432, in result
    return self.__get_result()
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 388, in __get_result
    raise self._exception
  File "/usr/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/app/gprofiler/python.py", line 75, in _profile_process
    run_process(self._make_command(process.pid, local_output_path), stop_event=self._stop_event)
  File "/app/gprofiler/utils.py", line 172, in run_process
    raise CalledProcessError(retcode, process.args, output=stdout, stderr=stderr)
gprofiler.exceptions.CalledProcessError: Command '['/app/gprofiler/resources/python/py-spy', 'record', '-r', '10', '-d', '60', '--nonblocking', '--format', 'raw', '-F', '--gil', '--output', '/tmp/gprofiler_tmp/tmpvi62nyce/671516.py.col.dat', '-p', '671516', '--full-filenames']' returned non-zero exit status 1. 
stdout: b''
stderr: b'Error: Failed to parse python binary\nReason: Malformed entity: Section 106 size (4195440) + addr (24) is out of bounds. Overflowed: false\n\n'
```

## Motivation and Context
Avoid ugly errors.

It's doesn't modify gProfiler's behavior - we haven't profiled PyPy before, and we don't do so now. The native stacks from `perf` are taken, anyway. I'm just avoiding the error prints.

## How Has This Been Tested?
Tested gProfiler on a system with pypy & pypy3 which have loaded native extensions and verified it doesn't select them for profiling anymore.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
