### PR TITLE
build: Pin image versions, improve .dockerignore and more

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,5 @@
 /build/
 **/__pycache__
 **/*.pyc
+gprofiler/resources
+!gprofiler/resources/flamegraph/flamegraph_template.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM rust:latest AS pyspy-builder
+# rust:latest 1.52.1
+FROM rust@sha256:5f3bbf6200c057c4934deac814224e0038baa018c76aa54dfb84dd734315dad4 AS pyspy-builder
 
 COPY scripts/pyspy_env.sh .
 RUN ./pyspy_env.sh
@@ -7,7 +8,8 @@ COPY scripts/pyspy_build.sh .
 RUN ./pyspy_build.sh
 
 
-FROM ubuntu:20.04 as bcc-builder
+# ubuntu 20.04
+FROM ubuntu@sha256:cf31af331f38d1d7158470e095b132acd126a7180a54f263d386da88eb681d93 AS bcc-builder
 
 RUN apt-get update
 
@@ -20,7 +22,8 @@ COPY ./scripts/pyperf_build.sh .
 RUN ./pyperf_build.sh
 
 
-FROM ubuntu:20.04
+# ubuntu 20.04
+FROM ubuntu@sha256:cf31af331f38d1d7158470e095b132acd126a7180a54f263d386da88eb681d93
 
 WORKDIR /app
 

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -1,5 +1,6 @@
 # copied from Dockerfile
-FROM rust:latest AS pyspy-builder
+# rust:latest 1.52.1
+FROM rust@sha256:5f3bbf6200c057c4934deac814224e0038baa018c76aa54dfb84dd734315dad4 AS pyspy-builder
 
 COPY scripts/pyspy_env.sh .
 RUN ./pyspy_env.sh
@@ -9,7 +10,8 @@ RUN ./pyspy_build.sh
 
 # Centos 7 image is used to grab an old version of `glibc` during `pyinstaller` bundling.
 # This will allow the executable to run on older versions of the kernel, eventually leading to the executable running on a wider range of machines.
-FROM centos:7 AS build-stage
+# centos:7
+FROM centos@sha256:0f4ec88e21daf75124b8a9e5ca03c37a5e937e0e108a255d890492430789b60e AS build-stage
 
 # bcc part
 # TODO: copied from the main Dockerfile... but modified a lot. we'd want to share it some day.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,21 +7,32 @@ set -e
 
 mkdir -p build
 
+function curl_with_timecond() {
+    url="$1"
+    output="$2"
+    if [ -f "$output" ]; then
+        time_cond="-z $output"
+    else
+        time_cond=""
+    fi
+    curl -fL "$url" $time_cond -o "$output"
+}
+
 # async-profiler
 mkdir -p gprofiler/resources/java
-curl -fL https://github.com/Granulate/async-profiler/releases/download/v2.0g1/async-profiler-2.0-linux-x64.tar.gz \
-   -z build/async-profiler-2.0-linux-x64.tar.gz -o build/async-profiler-2.0-linux-x64.tar.gz
+
+curl_with_timecond https://github.com/Granulate/async-profiler/releases/download/v2.0g1/async-profiler-2.0-linux-x64.tar.gz build/async-profiler-2.0-linux-x64.tar.gz
 tar -xzf build/async-profiler-2.0-linux-x64.tar.gz -C gprofiler/resources/java --strip-components=2 async-profiler-2.0-linux-x64/build
 
 # pyperf - just create the directory for it, it will be built later
 mkdir -p gprofiler/resources/python/pyperf
 
 # perf
-curl -fL https://github.com/Granulate/linux/releases/download/v5.12g1/perf -z gprofiler/resources/perf -o gprofiler/resources/perf
+curl_with_timecond https://github.com/Granulate/linux/releases/download/v5.12g1/perf gprofiler/resources/perf
 chmod +x gprofiler/resources/perf
 
 # burn
-curl -fL https://github.com/Granulate/burn/releases/download/v1.0.1g2/burn -z gprofiler/resources/burn -o gprofiler/resources/burn
+curl_with_timecond https://github.com/Granulate/burn/releases/download/v1.0.1g2/burn gprofiler/resources/burn
 chmod +x gprofiler/resources/burn
 
 rm -r build


### PR DESCRIPTION
## Description
1. Pin Docker image versions (see 1st commit message for details)
2. Improve `.dockerignore` (see 2nd commit message). Fixes local builds in case you had files in `gprofiler/resources`....
3. Avoid annoying `curl` warning

## Motivation and Context
Improve build.

## How Has This Been Tested?
Our tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
