### PR TITLE
Initial PHP support using phpspy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,12 @@ WORKDIR /bcc
 COPY ./scripts/pyperf_build.sh .
 RUN ./pyperf_build.sh
 
+# ubuntu:20.04
+FROM ubuntu@sha256:cf31af331f38d1d7158470e095b132acd126a7180a54f263d386da88eb681d93 as phpspy-builder
+RUN apt update && apt install -y git wget make gcc
+COPY scripts/phpspy_build.sh .
+RUN ./phpspy_build.sh
+
 
 # ubuntu 20.04
 FROM ubuntu@sha256:cf31af331f38d1d7158470e095b132acd126a7180a54f263d386da88eb681d93
@@ -46,6 +52,10 @@ COPY --from=bcc-builder /bcc/bcc/NOTICE gprofiler/resources/python/pyperf/
 
 COPY --from=pyspy-builder /py-spy/target/x86_64-unknown-linux-musl/release/py-spy gprofiler/resources/python/py-spy
 COPY --from=perf-builder /perf gprofiler/resources/perf
+
+RUN mkdir -p gprofiler/resources/python/phpspy
+COPY --from=phpspy-builder /phpspy/phpspy gprofiler/resources/php/phpspy
+COPY --from=phpspy-builder /binutils/binutils-2.25/bin/bin/objdump gprofiler/resources/php/objdump
 
 COPY scripts/build.sh scripts/build.sh
 RUN ./scripts/build.sh

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Alongside `perf`, gProfiler invokes runtime-specific profilers for processes bas
 * The CPython interpreter, versions 2.7 and 3.5-3.9.
   * eBPF profiling (based on PyPerf) requires Linux 4.14 or higher. Profiling using eBPF incurs lower overhead. This requires kernel headers to be installed.
   * If eBPF is not available for whatever reason, py-spy is used.
+* PHP (Zend Engine), versions 7.0-8.0.
+  * Uses [Granulate's fork](https://github.com/Granulate/phpspy/) of the phpspy project.
 
 The runtime-specific profilers produce stack traces that include runtime information (i.e, stacks of Java/Python functions), unlike `perf` which produces native stacks of the JVM / CPython interpreter.
 The runtime stacks are then merged into the data collected by `perf`, substituting the *native* stacks `perf` has collected for those processes.
@@ -133,6 +135,7 @@ We recommend going through our [contribution guide](https://github.com/granulate
 * [async-profiler](https://github.com/jvm-profiling-tools/async-profiler) by [Andrei Pangin](https://github.com/apangin). See [our fork](https://github.com/Granulate/async-profiler).
 * [py-spy](https://github.com/benfred/py-spy) by [Ben Frederickson](https://github.com/benfred). See [our fork](https://github.com/Granulate/py-spy).
 * [bcc](https://github.com/iovisor/bcc) (for PyPerf) by the IO Visor project. See [our fork](https://github.com/Granulate/bcc).
+* [phpspy](https://github.com/adsr/phpspy) by [Adam Saponara](https://github.com/adsr). See [our fork](https://github.com/Granulate/phpspy).
 
 # Footnotes
 

--- a/gprofiler/php.py
+++ b/gprofiler/php.py
@@ -1,0 +1,234 @@
+import fcntl
+import glob
+import logging
+import os
+import re
+import signal
+from collections import Counter, defaultdict
+from functools import lru_cache
+from pathlib import Path
+from subprocess import Popen
+from threading import Event
+from typing import List, Mapping, MutableMapping, Optional, Pattern
+
+from gprofiler.exceptions import StopEventSetException
+from gprofiler.profiler_base import ProfilerBase
+from gprofiler.utils import limit_frequency, resource_path, start_process, wait_event
+
+logger = logging.getLogger(__name__)
+
+
+class PHPSpyProfiler(ProfilerBase):
+    PHPSPY_RESOURCE = "php/phpspy"
+    # Currently tracing only php-fpm, TODO: support mod_php in apache.
+    DEFAULT_PROCESS_FILTER = "php-fpm"
+    dump_signal = signal.SIGUSR2
+    poll_timeout = 10  # seconds
+    MAX_FREQUENCY = 999
+    MIN_DURATION = 3  # seconds, phpspy is running commands at bootstrap and it takes some time.
+    BUFFER_SIZE = 16384
+    NUM_WORKERS = 16  # Num of workers following unique PHP processes (one worker per _process)
+
+    # regex required for parsing phpspy output
+    SINGLE_FRAME_RE = re.compile(r'^(?P<f_index>\d+) (?P<line>.*)$')  # "1 main.php:24"
+    PID_METADATA_RE = re.compile(r'^# pid = (.*)$')  # "# pid = 455"
+    PHP_FRAME_ANNOTATION = "[php]"
+
+    def __init__(
+        self,
+        frequency: int,
+        duration: int,
+        stop_event: Optional[Event],
+        storage_dir: str,
+        php_process_filter: str = DEFAULT_PROCESS_FILTER,
+    ):
+        self._frequency = limit_frequency(self.MAX_FREQUENCY, frequency, "phpspy", logger)
+
+        if duration < self.MIN_DURATION:
+            logger.warning(
+                f"Minimum duration for phpspy is {self.MIN_DURATION} (given {duration}), "
+                "raise duration in order to profile php processes"
+            )
+            self._enabled = False
+
+        self._duration = max(duration, self.MIN_DURATION)
+        self._stop_event = stop_event or Event()
+        self._storage_dir = storage_dir
+        logger.info(f"Initializing PHP profiler (frequency: {self._frequency}hz, duration: {self._duration}s)")
+        self._process: Optional[Popen] = None
+        self._output_path = Path(self._storage_dir) / "php.col"
+        self._process_filter = php_process_filter
+        self._enabled = True
+
+    def start(self):
+        if not self._enabled:
+            return
+
+        logger.info("Starting profiling of PHP processes with phpspy")
+        phpspy_path = resource_path(self.PHPSPY_RESOURCE)
+        cmd = [
+            phpspy_path,
+            "--verbose-fields=p",  # output pid
+            "-P",
+            self._process_filter,
+            "-H",
+            str(self._frequency),
+            "-b",
+            str(self.BUFFER_SIZE),
+            "-T",
+            str(self.NUM_WORKERS),
+            "--output",
+            str(self._output_path),
+            # Duration is irrelevant here, we want to run continuously.
+        ]
+
+        # importlib.resources doesn't provide a way to get a directory because it's not "a resource",
+        # we use the same dir for required binaries, if they are not available.
+        phpspy_dir = os.path.dirname(phpspy_path)
+        env = os.environ.copy()
+        env["PATH"] = f"{env.get('PATH')}:{phpspy_dir}"
+        process = start_process(cmd, env=env, via_staticx=False)
+        # Executing phpspy, expecting the output file to be created, phpspy creates it at bootstrap after argument
+        # parsing.
+        # If an error occurs after this stage it's probably a spied _process specific and not phpspy general error.
+        try:
+            wait_event(self.poll_timeout, self._stop_event, lambda: os.path.exists(self._output_path))
+        except TimeoutError:
+            process.kill()
+            raise
+        else:
+            self._process = process
+
+        # Set the stderr fd as non-blocking so the read operation on it won't block if no data is available.
+        fcntl.fcntl(
+            self._process.stderr.fileno(),
+            fcntl.F_SETFL,
+            fcntl.fcntl(self._process.stderr.fileno(), fcntl.F_GETFL) | os.O_NONBLOCK,
+        )
+
+        # Ignoring type since _process.stderr is typed as Optional[IO[Any]] which doesn't have the `read1` method.
+        stderr = self._process.stderr.read1(1024).decode()  # type: ignore
+        self._process_stderr(stderr)
+
+    def _dump(self) -> Path:
+        assert self._process is not None, "profiling not started!"
+        self._process.send_signal(self.dump_signal)
+        # important to not grab the transient data file
+        while True:
+            output_files = glob.glob(f"{str(self._output_path)}.*")
+            if output_files:
+                break
+
+            if self._stop_event.wait(0.1):
+                raise StopEventSetException()
+
+        # All the snapshot samples should be in a single file
+        assert len(output_files) == 1
+        return Path(output_files[0])
+
+    @classmethod
+    def _collapse_frames(cls, raw_frames: List[str]) -> str:
+        parsed_frames = []
+        for idx, raw_frame in enumerate(raw_frames):
+            match = cls.SINGLE_FRAME_RE.match(raw_frame)
+            if not match:
+                raise CorruptedPHPSpyOutputException(f"Line {idx} ({raw_frame}) didn't match known re pattern")
+
+            if int(match.group('f_index')) != idx:
+                raise CorruptedPHPSpyOutputException(
+                    f"phpspy reported index {match.group('f_index')} doesn't match line index ({idx})"
+                )
+
+            parsed_frames.append(f"{match.group('line')}_{cls.PHP_FRAME_ANNOTATION}")
+        return ';'.join(reversed(parsed_frames))
+
+    @classmethod
+    def _parse_phpspy_output(cls, phpspy_output: str) -> Mapping[int, Mapping[str, int]]:
+        def extract_metadata_section(re_expr: Pattern, metadata_line: str) -> str:
+            match = re_expr.match(metadata_line)
+            if not match:
+                raise CorruptedPHPSpyOutputException(
+                    f"Couldn't extract metadata via regex '{re_expr.pattern}', line '{metadata_line}'"
+                )
+            return match.group(1)
+
+        results: MutableMapping[int, MutableMapping[str, int]] = defaultdict(Counter)
+
+        stacks = phpspy_output.split('\n\n')  # Last part is always empty.
+        last_stack, stacks = stacks[-1], stacks[:-1]
+        if last_stack != "":
+            logger.warning(f"phpspy output: last stack is not empty - '{last_stack}'")
+
+        corrupted_stacks = 0
+        for stack in stacks:
+            try:
+                frames = stack.split('\n')
+                # Last line is the PID.
+                pid_raw = frames.pop(-1)
+                pid = int(extract_metadata_section(cls.PID_METADATA_RE, pid_raw))
+                collapsed_frames = cls._collapse_frames(frames)
+                results[pid][collapsed_frames] += 1
+
+            except CorruptedPHPSpyOutputException:
+                logger.exception(stack)
+                corrupted_stacks += 1
+
+            except Exception:
+                corrupted_stacks += 1
+                logger.exception('Unknown exception caught while parsing a phpspy stack, continuing to the next stack')
+
+        if corrupted_stacks > 0:
+            logger.warning(f"phpspy: {corrupted_stacks} corrupted stacks")
+
+        return dict(results)
+
+    def snapshot(self) -> Mapping[int, Mapping[str, int]]:
+        if not self._enabled:
+            return {}
+
+        if self._stop_event.wait(self._duration):
+            raise StopEventSetException()
+        stderr = self._process.stderr.read1(1024).decode()  # type: ignore
+        self._process_stderr(stderr)
+
+        phpspy_output_path = self._dump()
+        phpspy_output_text = phpspy_output_path.read_text()
+        phpspy_output_path.unlink()
+        return self._parse_phpspy_output(phpspy_output_text)
+
+    def _terminate(self) -> Optional[int]:
+        code = None
+        if self._process is not None:
+            self._process.terminate()
+            code = self._process.wait()
+            self._process = None
+        return code
+
+    def stop(self):
+        code = self._terminate()
+        if code is not None:
+            logger.info("Finished profiling PHP processes with phpspy")
+
+    def _process_stderr(self, stderr: str):
+        skip_re = self._get_stderr_skip_regex()
+        lines = stderr.splitlines()
+        for line in lines:
+            if not skip_re.search(line):
+                logger.debug(f"phpspy: error: {line}")
+
+    @staticmethod
+    @lru_cache(maxsize=1)
+    def _get_stderr_skip_regex() -> Pattern:
+        skip_patterns = [
+            "popen_read_line: No stdout;",  # Generic popen fail line, doesn't really mean anything
+            # Many "self pgrep" log errors that will happen only on race conditions.
+            "Couldn't read proc fs file",
+            "Can't open file for reading",
+            "Couldn't read data from file",
+        ]
+        groups = [f"({re.escape(pattern)})" for pattern in skip_patterns]
+        return re.compile("|".join(groups))
+
+
+class CorruptedPHPSpyOutputException(Exception):
+    pass

--- a/gprofiler/python.py
+++ b/gprofiler/python.py
@@ -17,7 +17,7 @@ from psutil import Process
 from .exceptions import CalledProcessError, ProcessStoppedException, StopEventSetException
 from .merge import parse_many_collapsed, parse_one_collapsed
 from .profiler_base import ProfilerBase
-from .utils import pgrep_maps, poll_process, resource_path, run_process, start_process, wait_event
+from .utils import limit_frequency, pgrep_maps, poll_process, resource_path, run_process, start_process, wait_event
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ class PythonProfilerBase(ProfilerBase):
     ):
         super().__init__()
         assert isinstance(self.MAX_FREQUENCY, int)
-        self._frequency = min(frequency, self.MAX_FREQUENCY)
+        self._frequency = limit_frequency(self.MAX_FREQUENCY, frequency, self.__class__.__name__, logger)
         self._duration = duration
         self._stop_event = stop_event or Event()
         self._storage_dir = storage_dir
@@ -287,7 +287,6 @@ class PythonEbpfProfiler(PythonProfilerBase):
         code = self._terminate()
         if code is not None:
             logger.info("Finished profiling Python processes with PyPerf")
-        return code
 
 
 _profiler_class = None

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -420,3 +420,14 @@ def reset_umask() -> None:
     Resets our umask back to a sane value.
     """
     os.umask(0o022)
+
+
+def limit_frequency(limit: int, requested: int, msg_header: str, runtime_logger: logging.Logger):
+    if requested > limit:
+        runtime_logger.warning(
+            f"{msg_header}: Requested frequency ({requested}) is higher than the limit {limit}, "
+            f"limiting frequency to the limit ({limit})"
+        )
+        return limit
+
+    return requested

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -17,6 +17,13 @@ RUN ./perf_env.sh
 COPY scripts/perf_build.sh .
 RUN ./perf_build.sh
 
+# ubuntu:20.04
+FROM ubuntu@sha256:cf31af331f38d1d7158470e095b132acd126a7180a54f263d386da88eb681d93 as phpspy-builder
+RUN apt update && apt install -y git wget make gcc
+COPY scripts/phpspy_build.sh .
+RUN ./phpspy_build.sh
+
+
 # Centos 7 image is used to grab an old version of `glibc` during `pyinstaller` bundling.
 # This will allow the executable to run on older versions of the kernel, eventually leading to the executable running on a wider range of machines.
 # centos:7
@@ -74,6 +81,14 @@ RUN cp /bcc/bcc/NOTICE gprofiler/resources/python/pyperf/
 
 COPY --from=pyspy-builder /py-spy/target/x86_64-unknown-linux-musl/release/py-spy gprofiler/resources/python/py-spy
 COPY --from=perf-builder /perf gprofiler/resources/perf
+
+RUN mkdir -p gprofiler/resources/python/phpspy
+COPY --from=phpspy-builder /phpspy/phpspy gprofiler/resources/php/phpspy
+COPY --from=phpspy-builder /binutils/binutils-2.25/bin/bin/objdump gprofiler/resources/php/objdump
+COPY --from=phpspy-builder /binutils/binutils-2.25/bin/bin/strings gprofiler/resources/php/strings
+COPY --from=centos:6 /usr/bin/awk gprofiler/resources/php/awk
+COPY --from=centos:6 /usr/bin/xargs gprofiler/resources/php/xargs
+
 
 COPY gprofiler gprofiler
 

--- a/scripts/phpspy_build.sh
+++ b/scripts/phpspy_build.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) Granulate. All rights reserved.
+# Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
+#
+set -euo pipefail
+
+# First build phpspy
+pushd /
+git clone --depth=1 -b v0.6.0-g3 --recursive https://github.com/Granulate/phpspy.git && git -C phpspy reset --hard fe361c557c648616c644c4968e4efe485753f3e7
+cd /phpspy
+make
+popd
+
+# Then, build binutils - required for static objdump
+
+BINUTILS_VERSION=2.25
+
+mkdir -p /binutils
+pushd /binutils
+wget http://ftp.gnu.org/gnu/binutils/binutils-$BINUTILS_VERSION.tar.gz
+tar xzf binutils-$BINUTILS_VERSION.tar.gz
+cd binutils-$BINUTILS_VERSION
+./configure --disable-nls --prefix=$(pwd)/bin
+make configure-host
+make LDFLAGS="-all-static"
+make install
+popd

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,3 +7,6 @@ from pathlib import Path
 HERE = Path(__file__).parent
 PARENT = HERE.parent
 CONTAINERS_DIRECTORY = HERE / "containers"
+RESOURCES_DIRECTORY = PARENT / "gprofiler" / "resources"
+
+PHPSPY_DURATION = 3  # seconds

--- a/tests/containers/php/Dockerfile
+++ b/tests/containers/php/Dockerfile
@@ -1,0 +1,6 @@
+FROM php:7.4
+
+WORKDIR /app
+ADD fibonacci.php /app
+
+CMD ["php", "fibonacci.php"]

--- a/tests/containers/php/fibonacci.php
+++ b/tests/containers/php/fibonacci.php
@@ -1,0 +1,18 @@
+<?php
+function Fibonacci($number){
+
+    if ($number == 0)
+        return 0;
+    else if ($number == 1)
+        return 1;
+
+    else
+        return (Fibonacci($number-1) +
+                Fibonacci($number-2));
+}
+
+$number = 200;
+for ($counter = 0; $counter < $number; $counter++){
+    echo Fibonacci($counter) . PHP_EOL;
+}
+?>

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -7,7 +7,7 @@ set -e
 
 if [ -z ${NO_APT_INSTALL+x} ]; then
  sudo DEBIAN_FRONTEND=noninteractive apt-get -qq update
- sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends openjdk-8-jdk python3 python3-pip docker.io
+ sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends openjdk-8-jdk python3 python3-pip docker.io php
 fi
 
 python3 -m pip install -q --upgrade setuptools pip

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -5,7 +5,7 @@
 import os
 from pathlib import Path
 from threading import Event
-from typing import Callable, Mapping, Optional
+from typing import Callable, List, Mapping, Optional
 
 import pytest  # type: ignore
 from docker import DockerClient
@@ -13,8 +13,10 @@ from docker.models.images import Image
 
 from gprofiler.java import JavaProfiler
 from gprofiler.merge import parse_one_collapsed
+from gprofiler.php import PHPSpyProfiler
 from gprofiler.python import PySpyProfiler, PythonEbpfProfiler
 from gprofiler.utils import resource_path
+from tests import PHPSPY_DURATION, RESOURCES_DIRECTORY
 from tests.utils import (
     assert_function_in_collapsed,
     copy_file_from_image,
@@ -47,6 +49,25 @@ def test_pyspy(
         assert_collapsed(process_collapsed.get(application_pid))
 
 
+@pytest.mark.parametrize("runtime", ["php"])
+def test_phpspy(
+    tmp_path: Path,
+    application_pid: int,
+    assert_collapsed: Callable[[Optional[Mapping[str, int]]], None],
+    gprofiler_docker_image: Image,
+) -> None:
+    os.makedirs(str(RESOURCES_DIRECTORY / "php"), exist_ok=True)
+    copy_file_from_image(
+        gprofiler_docker_image,
+        os.path.join("/app", "gprofiler", "resources", "php", "phpspy"),
+        resource_path("php/phpspy"),
+    )
+
+    with PHPSpyProfiler(1000, PHPSPY_DURATION, Event(), str(tmp_path), php_process_filter="php") as profiler:
+        process_collapsed = profiler.snapshot()
+        assert_collapsed(process_collapsed.get(application_pid))
+
+
 @pytest.mark.parametrize("runtime", ["python"])
 def test_python_ebpf(
     tmp_path,
@@ -69,24 +90,24 @@ def test_python_ebpf(
         assert_function_in_collapsed("sys_getdents64", collapsed)  # ensure kernels stacks exist
 
 
-@pytest.mark.parametrize("runtime", ["java", "python"])
+@pytest.mark.parametrize("runtime", ["java", "python", "php"])
 def test_from_container(
     docker_client: DockerClient,
     application_pid: int,
+    runtime_specific_args: List[str],
     gprofiler_docker_image: Image,
     output_directory: Path,
     assert_collapsed: Callable[[Mapping[str, int]], None],
 ) -> None:
     _ = application_pid  # Fixture only used for running the application.
-    inner_output_directory = "/tmp/gpofiler"
+    inner_output_directory = "/tmp/gprofiler"
     volumes = {
         "/usr/src": {"bind": "/usr/src", "mode": "ro"},
         "/lib/modules": {"bind": "/lib/modules", "mode": "ro"},
         str(output_directory): {"bind": inner_output_directory, "mode": "rw"},
     }
-    run_privileged_container(
-        docker_client, gprofiler_docker_image, ["-d", "1", "-o", inner_output_directory], volumes=volumes
-    )
+    args = ["-d", "1", "-o", inner_output_directory] + runtime_specific_args
+    run_privileged_container(docker_client, gprofiler_docker_image, args, volumes=volumes)
 
     collapsed = parse_one_collapsed(Path(output_directory / "last_profile.col").read_text())
     assert_collapsed(collapsed)


### PR DESCRIPTION
## Description
Add initial support for PHP processes profiling using phpspy project (Granulate's fork) in continuous mode (pgrep mode in phpspy)

## Motivation and Context
Like Java and Python, we would like to support PHP runtime profiling.
At this point only PHP workloads running on top of [php-fpm](https://www.php.net/manual/en/install.fpm.php), in the future adding support to PHP running inside apache workers [`mod_php`](https://cwiki.apache.org/confluence/display/HTTPD/PHP) and other options.

### Notes:
* Based on Granulate's fork release  [Granulate phpspy v0.6.0-g3](https://github.com/Granulate/phpspy/releases/tag/v0.6.0-g3)

## How Has This Been Tested?
* Automatic tests have been written for both container and executable packaging methods. 
* Granulate phpspy fork was tested manually.

## Screenshots (if appropriate):
Drupal (running inside a container on the same host as the gProfiler): 
![image](https://user-images.githubusercontent.com/33522503/117956376-a5b00100-b321-11eb-947d-a411fed82903.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Credits:
* [phpspy](https://github.com/adsr/phpspy) by [Adam Saponara](https://github.com/adsr). See [our fork](https://github.com/Granulate/phpspy).