### PR TITLE
java: Execute "java" in the JDK version check via /proc/pid/exe

### DIFF
--- a/gprofiler/java.py
+++ b/gprofiler/java.py
@@ -100,7 +100,14 @@ class JavaProfiler(ProfilerBase):
             # this has the benefit of working even if the Java binary was replaced, e.g due to an upgrade.
             # in that case, the libraries would have been replaced as well, and therefore we're actually checking
             # the version of the now installed Java, and not the running one.
-            # but since this is used for the JDK check, it's good enough - we don't expect that to change.
+            # but since this is used for the "JDK type" check, it's good enough - we don't expect that to change.
+            # this whole check, however, is growing to be too complex, and we should consider other approaches
+            # for it:
+            # 1. purely in async-profiler - before calling any APIs that might harm blacklisted JDKs, we can
+            #    check the JDK type in async-profiler itself.
+            # 2. assume JDK type by the path, e.g the "java" Docker image has
+            #    "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java" which means "OpenJDK". needs to be checked for
+            #    other JDK types.
             java_path = f"/proc/{nspid}/exe"
         else:
             # TODO fix get_process_nspid() for all cases.

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -70,14 +70,18 @@ def get_self_container_id() -> Optional[str]:
     return get_process_container_id(os.getpid())
 
 
-def get_process_nspid(pid: int) -> int:
+def get_process_nspid(pid: int) -> Optional[int]:
     with open(f"/proc/{pid}/status") as f:
         for line in f:
             fields = line.split()
             if fields[0] == "NSpid:":
                 return int(fields[-1])
 
-    raise Exception(f"Couldn't find NSpid for pid {pid}")
+    # old kernel (pre 4.1) with no NSpid.
+    # TODO if needed, this can be implemented for pre 4.1, by reading all /proc/pid/sched files as
+    # seen by the PID NS; they expose the init NS PID (due to a bug fixed in 4.14~), and we can get the NS PID
+    # from the listing of those files itself.
+    return None
 
 
 def start_process(cmd: Union[str, List[str]], via_staticx: bool, **kwargs) -> Popen:


### PR DESCRIPTION
## Description
This has the benefit of working even after the binary was deleted. This is aiming for the "replaced" case - the Java package being auto-upgraded, for example. If the Java package was removed, then we can still run `java` this way, but all libraries will be missing.

Without this change, we `readlink` the file which was replaced, thus the `readlink` returns `.... (deleted)` and that file can't be executed, ofc.
We could also just strip the `(deleted)` part but I like this solution more. It is more accurate.

As noted in the comment in `_get_java_version()`, this grew too complex IMO and I want to simplify this check. In a future PR....

## Motivation and Context
Allow profiling Java processes which run a `java` been that's been replaced on disk.

## How Has This Been Tested?
First terminal:
```
root@b4cf39dc87a0:/# java Target
```
runs forever...

Profiling it with latest `master` works fine.

Then I ran:
```
root@b4cf39dc87a0:/# cp /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java x
root@b4cf39dc87a0:/# rm /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
root@b4cf39dc87a0:/# mv x /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
root@b4cf39dc87a0:/# ls -l /proc/$(pidof java)/exe
lrwxrwxrwx 1 root root 0 May 31 23:52 /proc/132/exe -> /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java (deleted)
```

and now latest `master` doesn't work:
```
FileNotFoundError: [Errno 2] No such file or directory: '/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java (deleted)'
```

but this branch succeeds.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the relevant documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
