### PR TITLE
deploy: k8s: Fix indentation errors in YAML

### DIFF
--- a/deploy/k8s/gprofiler.yaml
+++ b/deploy/k8s/gprofiler.yaml
@@ -27,8 +27,8 @@ spec:
           hostPath:
             path: /usr/src
         - name: docker-sock # Allow containers to fetch the names
-            hostPath:
-              path: /var/run/docker.sock
+          hostPath:
+            path: /var/run/docker.sock
       hostPID: true
       securityContext:
         runAsUser: 0
@@ -55,7 +55,7 @@ spec:
               mountPath: /usr/src
               readOnly: true
             - name: docker-sock
-                mountPath: /var/run/docker.sock
+              mountPath: /var/run/docker.sock
           args:
             - -cu
             - --token


### PR DESCRIPTION
## Description
Fixes an indentation error in the k8s YAML.

## Motivation and Context
Fix an error.

## How Has This Been Tested?
Tested the fixed YAML on my cluster.

## Screenshots

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
