### PR TITLE
Get hostname from host UTS NS and log it

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Run the following to have gProfiler running continuously, uploading to Granulate
 ```bash
 docker pull granulate/gprofiler:latest
 docker run --name gprofiler -d --restart=always \
-    --network=host --pid=host --userns=host --privileged \
+    --pid=host --userns=host --privileged \
     -v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro \
     -v /var/run/docker.sock:/var/run/docker.sock \
 	granulate/gprofiler:latest -cu --token <token> --service-name <service> [options]

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -13,7 +13,6 @@ import sys
 import time
 from logging import Logger
 from pathlib import Path
-from socket import gethostname
 from threading import Event
 from typing import Callable, Dict, Optional
 
@@ -32,6 +31,7 @@ from gprofiler.utils import (
     TEMPORARY_STORAGE_PATH,
     TemporaryDirectoryWithMode,
     atomically_symlink,
+    get_hostname,
     get_iso8061_format_time,
     grab_gprofiler_mutex,
     is_root,
@@ -268,7 +268,7 @@ class GProfiler:
 
         if self._client:
             try:
-                self._client.submit_profile(local_start_time, local_end_time, gethostname(), merged_result)
+                self._client.submit_profile(local_start_time, local_end_time, get_hostname(), merged_result)
             except Timeout:
                 logger.error("Upload of profile to server timed out.")
             except APIError as e:

--- a/gprofiler/merge.py
+++ b/gprofiler/merge.py
@@ -5,11 +5,11 @@
 import json
 import logging
 import re
-import socket
 from collections import Counter, defaultdict
 from typing import Iterable, Mapping, MutableMapping
 
 from gprofiler.docker_client import DockerClient
+from gprofiler.utils import get_hostname
 
 logger = logging.getLogger(__name__)
 
@@ -137,7 +137,7 @@ def merge_perfs(
     docker_client.reset_cache()
     profile_metadata = {
         'containers': container_names,
-        'hostname': socket.gethostname(),
+        'hostname': get_hostname(),
         'container_names_enabled': should_determine_container_names,
     }
     output = [f"#{json.dumps(profile_metadata)}"]

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -466,7 +466,5 @@ def limit_frequency(limit: int, requested: int, msg_header: str, runtime_logger:
 
 
 def get_hostname() -> str:
-    if hostname is None:
-        raise Exception("hostname not initialized!")
-
+    assert hostname is not None, "hostname not initialized!"
     return hostname

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -461,3 +461,10 @@ def limit_frequency(limit: int, requested: int, msg_header: str, runtime_logger:
         return limit
 
     return requested
+
+
+def get_hostname() -> str:
+    if hostname is None:
+        raise Exception("hostname not initialized!")
+
+    return hostname

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -332,6 +332,10 @@ def run_in_ns(nstypes: List[str], callback: Callable[[], None], target_pid: int 
 
 
 def log_system_info():
+    # initialized first
+    global hostname
+    hostname = "unknown"
+
     uname = platform.uname()
     logger.info(f"gProfiler Python version: {sys.version}")
     logger.info(f"gProfiler run mode: {get_run_mode()}")
@@ -342,8 +346,6 @@ def log_system_info():
 
     distribution = "unknown"
     libc_version = "unknown"
-    global hostname
-    hostname = "unknown"
 
     # move to host mount NS for distro & ldd.
     # now, distro will read the files on host.

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -296,7 +296,7 @@ def run_in_ns(nstypes: List[str], callback: Callable[[], None], target_pid: int 
     Runs a callback in a new thread, switching to a set of the namespaces of a target process before
     doing so.
 
-    Needed initially for swithcing mount namespaces, because we can't setns(CLONE_NEWNS) in a multithreaded
+    Needed initially for switching mount namespaces, because we can't setns(CLONE_NEWNS) in a multithreaded
     program (unless we unshare(CLONE_NEWNS) before). so, we start a new thread, unshare() & setns() it,
     run our callback and then stop the thread (so we don't keep unshared threads running around).
     For other namespace types, we use this function to execute callbacks without changing the namespaces

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -39,6 +39,7 @@ logger = logging.getLogger(__name__)
 TEMPORARY_STORAGE_PATH = "/tmp/gprofiler_tmp"
 
 gprofiler_mutex: Optional[socket.socket]
+hostname: Optional[str] = None
 
 
 def resource_path(relative_path: str = "") -> str:
@@ -341,13 +342,15 @@ def log_system_info():
 
     distribution = "unknown"
     libc_version = "unknown"
+    global hostname
     hostname = "unknown"
 
     # move to host mount NS for distro & ldd.
     # now, distro will read the files on host.
     # also move to host UTS NS for the hostname.
     def get_infos():
-        nonlocal distribution, libc_version, hostname
+        nonlocal distribution, libc_version
+        global hostname
 
         try:
             distribution = distro.linux_distribution()

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -334,7 +334,7 @@ def run_in_ns(nstypes: List[str], callback: Callable[[], None], target_pid: int 
 def _initialize_system_info():
     # initialized first
     global hostname
-    hostname = "unknown"
+    hostname = "<unknown>"
     distribution = "unknown"
     libc_version = "unknown"
 

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -331,19 +331,10 @@ def run_in_ns(nstypes: List[str], callback: Callable[[], None], target_pid: int 
     t.join()
 
 
-def log_system_info():
+def _initialize_system_info():
     # initialized first
     global hostname
     hostname = "unknown"
-
-    uname = platform.uname()
-    logger.info(f"gProfiler Python version: {sys.version}")
-    logger.info(f"gProfiler run mode: {get_run_mode()}")
-    logger.info(f"Kernel uname release: {uname.release}")
-    logger.info(f"Kernel uname version: {uname.version}")
-    logger.info(f"Total CPUs: {os.cpu_count()}")
-    logger.info(f"Total RAM: {psutil.virtual_memory().total / (1 << 30):.2f} GB")
-
     distribution = "unknown"
     libc_version = "unknown"
 
@@ -371,6 +362,18 @@ def log_system_info():
 
     run_in_ns(["mnt", "uts"], get_infos)
 
+    return hostname, distribution, libc_version
+
+
+def log_system_info() -> None:
+    uname = platform.uname()
+    logger.info(f"gProfiler Python version: {sys.version}")
+    logger.info(f"gProfiler run mode: {get_run_mode()}")
+    logger.info(f"Kernel uname release: {uname.release}")
+    logger.info(f"Kernel uname version: {uname.version}")
+    logger.info(f"Total CPUs: {os.cpu_count()}")
+    logger.info(f"Total RAM: {psutil.virtual_memory().total / (1 << 30):.2f} GB")
+    hostname, distribution, libc_version = _initialize_system_info()
     logger.info(f"Linux distribution: {distribution}")
     logger.info(f"libc version: {libc_version}")
     logger.info(f"Hostname: {hostname}")


### PR DESCRIPTION
## Description
Need to get the hostname in init UTS NS, otherwise we might be seeing the container / Pod name.

## Motivation and Context
Get the correct hostname in containerized applications. Currently we instruct people to run gProfiler with `--network=host` for no good reason. I will remove it. Also, our k8s YAML doesn't have `hostNetwork: true`.

## How Has This Been Tested?
I added a print for `socket.gethostname()` w/o escaping the UTS NS. It prints the container hostname. This code prints the real hostname.

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
- [x] Remove `--network=host` from README & in the backend
- [x] Update other callers of `socket.gethostname()` to use a cached value I get from the host UTS NS.
