### PR TITLE
Include parameters in POST query string for requests logging

### DIFF
--- a/gprofiler/client.py
+++ b/gprofiler/client.py
@@ -56,7 +56,12 @@ class APIClient:
         return "{}/{}/{}".format(self._host.rstrip("/"), self.BASE_PATH, version)
 
     def _get_query_params(self) -> List[Tuple[str, str]]:
-        return [("key", self._key), ("service", self._service), ("hostname", self._hostname)]
+        return [
+            ("key", self._key),
+            ("service", self._service),
+            ("hostname", self._hostname),
+            ("timestamp", get_iso8601_format_time(datetime.datetime.utcnow())),
+        ]
 
     def _send_request(
         self,

--- a/gprofiler/client.py
+++ b/gprofiler/client.py
@@ -37,15 +37,16 @@ class APIClient:
         self._host: str = host
         self._upload_timeout = upload_timeout
         self._version: str = version
+        self._key = key
         self._service = service
         self._hostname = hostname
 
-        self._init_session(key, service)
+        self._init_session()
         logger.info(f"The connection to the server was successfully established (service {service!r})")
 
-    def _init_session(self, key: str, service: str):
+    def _init_session(self):
         self._session: Session = requests.Session()
-        self._session.headers.update({"GPROFILER-API-KEY": key, "GPROFILER-SERVICE-NAME": service})
+        self._session.headers.update({"GPROFILER-API-KEY": self._key, "GPROFILER-SERVICE-NAME": self._service})
 
         # Raises on failure
         self.get_health()
@@ -55,7 +56,7 @@ class APIClient:
         return "{}/{}/{}".format(self._host.rstrip("/"), self.BASE_PATH, version)
 
     def _get_query_params(self) -> List[Tuple[str, str]]:
-        return [("service", self._service), ("hostname", self._hostname)]
+        return [("key", self._key), ("service", self._service), ("hostname", self._hostname)]
 
     def _send_request(
         self,

--- a/gprofiler/client.py
+++ b/gprofiler/client.py
@@ -12,7 +12,7 @@ from typing import Dict, List, Optional, Tuple
 import requests
 from requests import Session
 
-from gprofiler.utils import get_iso8061_format_time
+from gprofiler.utils import get_iso8601_format_time
 
 logger = logging.getLogger(__name__)
 
@@ -120,8 +120,8 @@ class APIClient:
         return self.post(
             "profiles",
             {
-                "start_time": get_iso8061_format_time(start_time),
-                "end_time": get_iso8061_format_time(end_time),
+                "start_time": get_iso8601_format_time(start_time),
+                "end_time": get_iso8601_format_time(end_time),
                 "hostname": self._hostname,
                 "profile": profile,
             },

--- a/gprofiler/client.py
+++ b/gprofiler/client.py
@@ -66,15 +66,15 @@ class APIClient:
         files: Dict = None,
         timeout: float = DEFAULT_REQUEST_TIMEOUT,
         api_version: str = None,
-        query_params: Dict[str, str] = None,
+        params: Dict[str, str] = None,
     ) -> Dict:
         opts: dict = {"headers": {}, "files": files, "timeout": timeout}
-        if query_params is None:
-            query_params = {}
+        if params is None:
+            params = {}
 
         if method.upper() == "GET":
             if data is not None:
-                query_params.update(data)
+                params.update(data)
         else:
             opts["headers"]["Content-Encoding"] = "gzip"
             opts["headers"]["Content-type"] = "application/json"
@@ -83,7 +83,7 @@ class APIClient:
                 json.dump(data, gzip_file, ensure_ascii=False)  # type: ignore
             opts["data"] = buffer.getvalue()
 
-        opts["params"] = self._get_query_params() + [(k, v) for k, v in query_params.items()]
+        opts["params"] = self._get_query_params() + [(k, v) for k, v in params.items()]
 
         resp = self._session.request(method, "{}/{}".format(self.get_base_url(api_version), path), **opts)
         if 400 <= resp.status_code < 500:

--- a/gprofiler/client.py
+++ b/gprofiler/client.py
@@ -88,8 +88,8 @@ class APIClient:
         resp = self._session.request(method, "{}/{}".format(self.get_base_url(api_version), path), **opts)
         if 400 <= resp.status_code < 500:
             try:
-                resp_data = resp.json()
-                raise APIError(resp_data["message"], resp_data)
+                response_data = resp.json()
+                raise APIError(response_data.get("message", "(no message in response)"), response_data)
             except ValueError:
                 raise APIError(resp.text)
         else:

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -268,7 +268,7 @@ class GProfiler:
 
         if self._client:
             try:
-                self._client.submit_profile(local_start_time, local_end_time, merged_result)
+                self._client.submit_profile(local_start_time, local_end_time, merged_result, total_samples)
             except Timeout:
                 logger.error("Upload of profile to server timed out.")
             except APIError as e:

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -268,7 +268,7 @@ class GProfiler:
 
         if self._client:
             try:
-                self._client.submit_profile(local_start_time, local_end_time, get_hostname(), merged_result)
+                self._client.submit_profile(local_start_time, local_end_time, merged_result)
             except Timeout:
                 logger.error("Upload of profile to server timed out.")
             except APIError as e:
@@ -528,7 +528,7 @@ def main():
             if "server_upload_timeout" in args:
                 client_kwargs["upload_timeout"] = args.server_upload_timeout
             client = (
-                APIClient(args.server_host, args.server_token, args.service_name, **client_kwargs)
+                APIClient(args.server_host, args.server_token, args.service_name, get_hostname(), **client_kwargs)
                 if args.upload_results
                 else None
             )

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -32,7 +32,7 @@ from gprofiler.utils import (
     TemporaryDirectoryWithMode,
     atomically_symlink,
     get_hostname,
-    get_iso8061_format_time,
+    get_iso8601_format_time,
     grab_gprofiler_mutex,
     is_root,
     is_running_in_init_pid,
@@ -172,8 +172,8 @@ class GProfiler:
         local_start_time: datetime.datetime,
         local_end_time: datetime.datetime,
     ) -> None:
-        start_ts = get_iso8061_format_time(local_start_time)
-        end_ts = get_iso8061_format_time(local_end_time)
+        start_ts = get_iso8601_format_time(local_start_time)
+        end_ts = get_iso8601_format_time(local_end_time)
         base_filename = os.path.join(self._output_dir, "profile_{}".format(end_ts))
 
         collapsed_path = base_filename + ".col"

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -259,7 +259,7 @@ class GProfiler:
                 logger.exception(f"{future.name} profiling failed")
 
         local_end_time = local_start_time + datetime.timedelta(seconds=(time.monotonic() - monotonic_start_time))
-        merged_result = merge.merge_perfs(
+        merged_result, total_samples = merge.merge_perfs(
             system_future.result(), process_perfs, self._docker_client, self._include_container_names
         )
 

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -194,7 +194,7 @@ def pgrep_maps(match: str) -> List[Process]:
     return processes
 
 
-def get_iso8061_format_time(time: datetime.datetime) -> str:
+def get_iso8601_format_time(time: datetime.datetime) -> str:
     return time.replace(microsecond=0).isoformat()
 
 


### PR DESCRIPTION
## Description
Based on https://github.com/Granulate/gprofiler/pull/98.

This PR lets gProfiler send a bunch of useful parameters in the query string of its requests. This is done merely for logging purposes - we don't extract these values in our backend; our ALB is able to extract parameters from the query string, and we can use these for proper logging & monitoring of sent requests.

## Motivation and Context
Help us debug & track requests to the backend, by logging useful pieces of data by our ALB.

## How Has This Been Tested?
I ran this version and was able to view all data correctly in the ALB logs.

## Screenshots
Athena query sample:
![Screenshot from 2021-06-04 01-03-03](https://user-images.githubusercontent.com/8831572/120717699-ad059d00-c4d0-11eb-9ca4-845cd4b50db3.png)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
