### PR TITLE
java: Robustness improvements, round 2

### DIFF
--- a/gprofiler/docker_client.py
+++ b/gprofiler/docker_client.py
@@ -21,9 +21,9 @@ class DockerClient:
             logger.warning(
                 'Could not initiate the Docker client, so the profiling data will not include the container'
                 ' names. If you are running the gProfiler in a container, please mount the Docker sock file'
-                'by running the Docker run command with the following argument: '
-                '"-v /var/run/docker.sock:/var/run/docker.sock". Otherwise, please open a new issue here: '
-                'https://github.com/Granulate/gprofiler/issues/new'
+                ' by running the Docker run command with the following argument:'
+                ' "-v /var/run/docker.sock:/var/run/docker.sock". Otherwise, please open a new issue here:'
+                ' https://github.com/Granulate/gprofiler/issues/new'
             )
             self._client = None
 

--- a/gprofiler/java.py
+++ b/gprofiler/java.py
@@ -74,16 +74,15 @@ class JavaProfiler(ProfilerBase):
         ]
 
     def _get_async_profiler_stop_cmd(
-        self, pid: int, output_path: str, jattach_path: str, async_profiler_lib_path: str, log_path: str
+        self, pid: int, output_path: Optional[str], jattach_path: str, async_profiler_lib_path: str, log_path: str
     ) -> List[str]:
-        return [
-            jattach_path,
-            str(pid),
-            "load",
-            async_profiler_lib_path,
-            "true",
-            f"stop,file={output_path},{self.OUTPUT_FORMAT},{self.FORMAT_PARAMS},log={log_path}",
-        ]
+        ap_params = ["stop"]
+        if output_path is not None:
+            ap_params.append(f"file={output_path}")
+            ap_params.append(self.OUTPUT_FORMAT)
+            ap_params.append(self.FORMAT_PARAMS)
+        ap_params.append(f"log={log_path}")
+        return [jattach_path, str(pid), "load", async_profiler_lib_path, "true", ",".join(ap_params)]
 
     def _run_async_profiler(self, cmd: List[str], log_path_host: str, pid: int) -> None:
         try:

--- a/gprofiler/java.py
+++ b/gprofiler/java.py
@@ -85,12 +85,12 @@ class JavaProfiler(ProfilerBase):
             f"stop,file={output_path},{self.OUTPUT_FORMAT},{self.FORMAT_PARAMS},log={log_path}",
         ]
 
-    def _run_async_profiler(self, cmd: List[str], log_path_host: str) -> None:
+    def _run_async_profiler(self, cmd: List[str], log_path_host: str, pid: int) -> None:
         try:
             run_process(cmd)
         except CalledProcessError:
             if os.path.exists(log_path_host):
-                logger.warning(f"async-profiler log: {Path(log_path_host).read_text()}")
+                logger.warning(f"async-profiler (on {pid}) log: {Path(log_path_host).read_text()}")
             raise
 
     def _start_async_profiler(
@@ -115,6 +115,7 @@ class JavaProfiler(ProfilerBase):
                     log_path_process,
                 ),
                 log_path_host,
+                process.pid,
             )
         except CalledProcessError:
             is_loaded = f" {libasyncprofiler_path_process}" in Path(f"/proc/{process.pid}/maps").read_text()
@@ -230,6 +231,7 @@ class JavaProfiler(ProfilerBase):
                     log_path_process,
                 ),
                 log_path_host,
+                process.pid,
             )
         else:
             # no output in this case :/

--- a/gprofiler/java.py
+++ b/gprofiler/java.py
@@ -216,7 +216,7 @@ class JavaProfiler(ProfilerBase):
         try:
             # make it readable & exectuable by all.
             # see comment on TemporaryDirectoryWithMode in GProfiler.__init__.
-            os.makedirs(storage_dir_host, 0o755)
+            os.makedirs(storage_dir_host, 0o755, exist_ok=True)
             return self._profile_process_with_dir(process, storage_dir_host, process_root)
         finally:
             # ignore_errors because we are deleting paths via /proc/pid/root - and those processes

--- a/gprofiler/java.py
+++ b/gprofiler/java.py
@@ -90,6 +90,7 @@ class JavaProfiler(ProfilerBase):
         except CalledProcessError:
             if os.path.exists(log_path_host):
                 logger.warning(f"async-profiler (on {pid}) log: {Path(log_path_host).read_text()}")
+                os.unlink(log_path_host)
             raise
 
     def _start_async_profiler(

--- a/gprofiler/java.py
+++ b/gprofiler/java.py
@@ -54,6 +54,7 @@ class AsyncProfiledProcess:
     JATTACH = resource_path("java/jattach")
     FORMAT_PARAMS = "ann,sig"
     OUTPUT_FORMAT = "collapsed"
+    OUTPUTS_MODE = 0o622  # readable by root, writable by all
 
     def __init__(self, process: Process, storage_dir: str):
         self.process = process
@@ -86,7 +87,7 @@ class AsyncProfiledProcess:
 
         # make out & log paths writable for all, so target process can write to them.
         # see comment on TemporaryDirectoryWithMode in GProfiler.__init__.
-        touch_path(self._output_path_host, 0o666)
+        touch_path(self._output_path_host, self.OUTPUTS_MODE)
         self._recreate_log()
         # copy libasyncProfiler.so if needed
         if not os.path.exists(self._libap_path_host):
@@ -123,7 +124,7 @@ class AsyncProfiledProcess:
             os.chmod(self._libap_path_host, 0o755)
 
     def _recreate_log(self) -> None:
-        touch_path(self._log_path_host, 0o666)
+        touch_path(self._log_path_host, self.OUTPUTS_MODE)
 
     def _check_disk_requirements(self) -> None:
         free_disk = psutil.disk_usage(self._ap_dir_host).free

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -106,9 +106,7 @@ class GProfiler:
         self._temp_storage_dir = TemporaryDirectoryWithMode(dir=TEMPORARY_STORAGE_PATH, mode=0o755)
         self.java_profiler = (
             create_profiler_or_noop(
-                lambda: JavaProfiler(
-                    self._frequency, self._duration, True, self._stop_event, self._temp_storage_dir.name
-                ),
+                lambda: JavaProfiler(self._frequency, self._duration, self._stop_event, self._temp_storage_dir.name),
                 "java",
             )
             if self._runtimes["java"]

--- a/gprofiler/python.py
+++ b/gprofiler/python.py
@@ -52,7 +52,7 @@ class PythonProfilerBase(ProfilerBase):
 
 
 class PySpyProfiler(PythonProfilerBase):
-    MAX_FREQUENCY = 10
+    MAX_FREQUENCY = 50
     BLACKLISTED_PYTHON_PROCS = ["unattended-upgrades", "networkd-dispatcher", "supervisord", "tuned"]
 
     def _make_command(self, pid: int, output_path: str):

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -238,6 +238,15 @@ def touch_path(path: str, mode: int) -> None:
     os.chmod(path, mode)
 
 
+def remove_path(path: str, missing_ok: bool = False) -> None:
+    # backporting missing_ok, available only from 3.8
+    try:
+        Path(path).unlink()
+    except FileNotFoundError:
+        if not missing_ok:
+            raise
+
+
 def is_same_ns(pid: int, nstype: str) -> bool:
     return os.stat(f"/proc/self/ns/{nstype}").st_ino == os.stat(f"/proc/{pid}/ns/{nstype}").st_ino
 

--- a/scripts/async_profiler_build.sh
+++ b/scripts/async_profiler_build.sh
@@ -5,5 +5,5 @@
 #
 set -euo pipefail
 
-git clone --depth 1 -b v2.0g2 https://github.com/Granulate/async-profiler.git && cd async-profiler && git reset --hard 9692c57ab9b3f77cd489a6ee26cad18d081c3e45
+git clone --depth 1 -b v2.0g3 https://github.com/Granulate/async-profiler.git && cd async-profiler && git reset --hard 51447a849d686e899c1cd393e83f0f7c41685d95
 make release

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -25,7 +25,7 @@ def test_java_from_host(
     assert_collapsed: Callable[[Optional[Mapping[str, int]]], None],
     gprofiler_docker_image_resources,
 ) -> None:
-    with JavaProfiler(1000, 1, True, Event(), str(tmp_path)) as profiler:
+    with JavaProfiler(1000, 1, Event(), str(tmp_path)) as profiler:
         process_collapsed = profiler.snapshot()
         assert_collapsed(process_collapsed.get(application_pid))
 


### PR DESCRIPTION
## Description
This PR improves the robustness of the Java profiler in several aspects:
1. We now handle processes where AP was already loaded & started - for example, of gProfiler is brutally stopped while profiling a Java process, AP remains running and the next time gProfiler runs, we can't start AP again. We now identify that case, stop AP and re-start it.
2. We no longer load AP from multiple paths - there is a single path `/tmp/gprofiler_tmp/async-profiler/libasyncProfiler.so` (per namespace, ofc) where AP resides.
3. We no longer store multiple copies of AP on-disk - previously we'd store 1 copy per process, now we store 1 copy per namespace.
4. ... to be added

It also improves the code by adding the `AsyncProfiledProcess` helper class, so we avoid long methods with large amount of parameters.

## Motivation and Context
Improve robustness of the Java profiler.

## How Has This Been Tested?
* Ran gProfiler, killed it (`kill -9`), ran it again and verified that it restarts AP.
* Stressed it on >100 Java processes to ensure that the AP copying logic works (injected random sleeps in it)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
  - [ ] AP already started in a container
  - [ ] AP already started on host
  - [ ] stress test with >100 java processes?
