### PR TITLE
Don't install unneeded packages when building perf

### DIFF
--- a/scripts/perf_env.sh
+++ b/scripts/perf_env.sh
@@ -5,12 +5,18 @@
 #
 set -euo pipefail
 
-apt-get update && apt-get install -y \
-    build-essential \
+apt-get update
+apt-get install -y --no-install-recommends \
+    gcc \
+    g++ \
+    make \
     git \
     curl \
+    ca-certificates \
+    lbzip2 \
+    unzip \
+    python3 \
     autoconf \
-    asciidoc \
     libssl-dev \
     zlib1g-dev \
     libaudit-dev \


### PR DESCRIPTION
## Description
The build installs `texlive-*-doc` packages which amount to 500MB+ download. For example, `texlive-latex-extra-doc`:
```
Get:359 http://archive.ubuntu.com/ubuntu xenial/main amd64 texlive-latex-extra-doc all 2015.20160320-1 [338 MB]
```
On a slow/metered connection this is a considerable barrier to building the image. We don't need these packages.

## How Has This Been Tested?
Build succeeds, perf still works. I don't think perf requires any of the recommended packages besides what's already specified.