### PR TITLE
Use perfs output switching capability

### DIFF
--- a/gprofiler/perf.py
+++ b/gprofiler/perf.py
@@ -4,15 +4,23 @@
 #
 import logging
 import os
+import signal
 from pathlib import Path
-from tempfile import NamedTemporaryFile
 from threading import Event
-from typing import Iterable, Mapping
+from typing import Iterable, Mapping, Optional
 
 import psutil
 
+from gprofiler.exceptions import CalledProcessError
 from gprofiler.merge import parse_perf_script
-from gprofiler.utils import TEMPORARY_STORAGE_PATH, resource_path, run_process
+from gprofiler.utils import (
+    TEMPORARY_STORAGE_PATH,
+    poll_process,
+    resource_path,
+    run_process,
+    start_process,
+    wait_for_file,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -21,18 +29,18 @@ PERF_BUILDID_DIR = os.path.join(TEMPORARY_STORAGE_PATH, "perf-buildids")
 
 # TODO: base on ProfilerBase, currently can't because the snapshot() API differs here.
 class SystemProfiler:
+    dump_timeout = 5  # seconds
+    poll_timeout = 5  # seconds
+
     def __init__(self, frequency: int, duration: int, stop_event: Event, storage_dir: str):
         logger.info(f"Initializing system profiler (frequency: {frequency}hz, duration: {duration}s)")
+        self._perf_cmd = [resource_path("perf"), "--buildid-dir", PERF_BUILDID_DIR]
         self._frequency = frequency
         self._duration = duration
         self._stop_event = stop_event
         self._storage_dir = storage_dir
-
-    def start(self):
-        pass
-
-    def stop(self):
-        pass
+        self.output_path = storage_dir + '/perf.data'
+        self.process = None
 
     def __enter__(self):
         self.start()
@@ -41,35 +49,7 @@ class SystemProfiler:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.stop()
 
-    def _run_perf(self, filename_base: str, dwarf=False):
-        parsed_path = os.path.join(self._storage_dir, f"{filename_base}.parsed")
-
-        buildid_args = ["--buildid-dir", PERF_BUILDID_DIR]
-
-        with NamedTemporaryFile(dir=self._storage_dir) as record_file:
-            args = ["-F", str(self._frequency), "-a", "-g", "-o", record_file.name]
-            if dwarf:
-                args += ["--call-graph", "dwarf"]
-            run_process(
-                [resource_path("perf")] + buildid_args + ["record"] + args + ["--", "sleep", str(self._duration)],
-                stop_event=self._stop_event,
-            )
-            with open(parsed_path, "w") as f:
-                run_process(
-                    [resource_path("perf")] + buildid_args + ["script", "-F", "+pid", "-i", record_file.name], stdout=f
-                )
-            return parsed_path
-
-    def snapshot(self) -> Iterable[Mapping[str, str]]:
-        free_disk = psutil.disk_usage(self._storage_dir).free
-        if free_disk < 4 * 1024 * 1024:
-            raise Exception(f"Free disk space: {free_disk}kb. Skipping perf!")
-
-        logger.info("Running global perf...")
-        record_path = self._run_perf("global")
-        logger.info("Finished running global perf")
-        return parse_perf_script(Path(record_path).read_text())
-
+    def start(self, dwarf=False):
         # TODO: run dwarf in parallel, after supporting it in merge.py
         # Alternatively: fix golang dwarf problems and the run just dwarf
 
@@ -80,3 +60,76 @@ class SystemProfiler:
 
         # logger.info("Running global perf with dwarf...")
         # run_perf("global_debug", dwarf_frequency, dwarf=True)
+
+        logger.info("Running global perf...")
+        args = ["-F", str(self._frequency), "-a", "-g", "-o", self.output_path, '--switch-output=signal']
+        if dwarf:
+            args += ["--call-graph", "dwarf"]
+        process = start_process(self._perf_cmd + ["record"] + args)
+        # Wait until the transient data file appears. That will indicate that the perf session has started.
+        try:
+            wait_for_file(self.output_path, self.poll_timeout, self._stop_event)
+        except TimeoutError:
+            process.kill()
+            logger.error(f"perf failed to start. stdout {process.stdout.read()!r} stderr {process.stderr.read()!r}")
+            raise
+        else:
+            self.process = process
+
+    def _dump(self) -> Path:
+        assert self.process is not None, "profiling not started!"
+        self.process.send_signal(signal.SIGUSR2)
+        try:
+            # important to not grab the transient perf.data file
+            return wait_for_file(f'{self.output_path}.*', self.dump_timeout, self._stop_event)
+        except TimeoutError:
+            logger.warning("perf dump is taking longer than expected...")
+            return None
+        finally:
+            logger.debug(f"perf output: {self.process.stderr.read1(4096)}")
+
+    def _process_error(self):
+        stdout = self.process.stdout.read().decode()
+        stderr = self.process.stderr.read().decode()
+        raise CalledProcessError(self.process.returncode, self.process.args, stdout, stderr)
+
+    def _check_free_space(self):
+        free_disk = psutil.disk_usage(self._storage_dir).free
+        if free_disk < 4 * 1024 * 1024:
+            raise Exception(f"Free disk space: {free_disk}kb. Skipping perf!")
+
+    def _perf_script(self, record_file: Path) -> str:
+        parsed_path = os.path.join(self._storage_dir, "global.parsed")
+        with open(parsed_path, "w+") as f:
+            run_process(self._perf_cmd + ["script", "-F", "+pid", "-i", str(record_file)], stdout=f)
+            f.seek(0)
+            script = f.read()
+        os.unlink(parsed_path)
+        os.unlink(record_file)
+        return script
+
+    def snapshot(self) -> Iterable[Mapping[str, str]]:
+        try:
+            poll_process(self.process, self._duration, self._stop_event)
+        except TimeoutError:
+            # perf is still alive. We can proceed with dump.
+            record_file = self._dump()
+        else:
+            self._process_error()
+
+        self._check_free_space()
+        script = self._perf_script(record_file)
+        return parse_perf_script(script)
+
+    def _terminate(self) -> Optional[int]:
+        code = None
+        if self.process is not None:
+            self.process.terminate()  # okay to call even if process is already dead
+            code = self.process.wait()
+            self.process = None
+        return code
+
+    def stop(self):
+        code = self._terminate()
+        if code is not None:
+            logger.info("Finished running global perf")

--- a/gprofiler/php.py
+++ b/gprofiler/php.py
@@ -13,7 +13,7 @@ from typing import List, Mapping, MutableMapping, Optional, Pattern
 
 from gprofiler.exceptions import StopEventSetException
 from gprofiler.profiler_base import ProfilerBase
-from gprofiler.utils import limit_frequency, resource_path, start_process, wait_event
+from gprofiler.utils import limit_frequency, resource_path, start_process, wait_for_file
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +87,7 @@ class PHPSpyProfiler(ProfilerBase):
         # parsing.
         # If an error occurs after this stage it's probably a spied _process specific and not phpspy general error.
         try:
-            wait_event(self.poll_timeout, self._stop_event, lambda: os.path.exists(self._output_path))
+            wait_for_file(self._output_path, self.poll_timeout, self._stop_event)
         except TimeoutError:
             process.kill()
             raise


### PR DESCRIPTION
## Description
Currently for each snapshot we execute perf on `sleep {duration}`. This PR replaces this with running perf without stopping and using the output switching capability to dump the recorded events on each snapshot.

## Motivation and Context
This should avoid enabling/disabling of perf events every `duration` step for each core.

## How Has This Been Tested?
Ran locally on Ubuntu 18 VM. Output files look ok.

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests for new logic.
