### PR TITLE
Raise error instead of infinitely looping when app container exits prematurely

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,6 +155,8 @@ def application_docker_container(
     else:
         container: Container = docker_client.containers.run(application_docker_image, detach=True, user="5555:6666")
         while container.status != "running":
+            if container.status == "exited":
+                raise Exception(container.logs().decode())
             sleep(1)
             container.reload()
         yield container


### PR DESCRIPTION
When the app container exits during tests we get a hang. This raises an exception with the logs instead.