### PR TITLE
python: Add --python-mode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,32 @@ The default profiling frequency is *11 hertz*. Using higher frequency will lead 
 
 The default duration is *60 seconds*, and the default interval matches it. So gProfiler runs the profiling sessions back-to-back - the next session starts as soon as the previous session is done.
 
-* `--no-java`, `--no-python`, `--no-php`, `--no-ruby`: Disable the runtime-specific profilers.
+### Java profiling options
+
+* `--no-java`: Disable profilers for Java.
+
+### Python profiling options
+* `--no-python`: Alias of `--python-mode none`.
+* `--python-mode`: Controls which profiler is used for Python.
+    * `auto` - (default) try with PyPerf, fall back to py-spy.
+    * `pyperf` - Use PyPerf with no py-spy fallback.
+    * `pyspy` - Use py-spy.
+    * `none` - Disable profilers for Python.
+
+### PHP profiling options
+* `--no-php`: Disable profilers for PHP.
+* `--php-proc-filter`: Process filter (`pgrep`) to select PHP processes for profiling (this is phpspy's `-P` option)
+
+### Ruby profiling options
+* `--no-ruby`: Disable profilers for Ruby.
+
+### System profiling options
 
 * `--perf-mode`: Controls the global perf strategy. Must be one of the following options:
-  * `fp` - Use Frame Pointers for the call graph
-  * `dwarf` - Use DWARF for the call graph (adds the `--call-graph dwarf` argument to the `perf` command)
-  * `smart` - Run both `fp` and `dwarf`, then choose the result with the highest average of stack frames count, per process.
-  * `none` - Avoids running `perf` at all. See [perf-less mode](#perf-less-mode).
+    * `fp` - Use Frame Pointers for the call graph
+    * `dwarf` - Use DWARF for the call graph (adds the `--call-graph dwarf` argument to the `perf` command)
+    * `smart` - Run both `fp` and `dwarf`, then choose the result with the highest average of stack frames count, per process.
+    * `none` - Avoids running `perf` at all. See [perf-less mode](#perf-less-mode).
 
 ### Continuous mode
 gProfiler can be run in a continuous mode, profiling periodically, using the `--continuous`/`-c` flag.

--- a/README.md
+++ b/README.md
@@ -54,10 +54,12 @@ The default duration is *60 seconds*, and the default interval matches it. So gP
 ### Python profiling options
 * `--no-python`: Alias of `--python-mode none`.
 * `--python-mode`: Controls which profiler is used for Python.
-    * `auto` - (default) try with PyPerf, fall back to py-spy.
+    * `auto` - (default) try with PyPerf (eBPF), fall back to py-spy.
     * `pyperf` - Use PyPerf with no py-spy fallback.
     * `pyspy` - Use py-spy.
     * `none` - Disable profilers for Python.
+
+Profiling using eBPF incurs lower overhead & provides kernel stacks. This (currently) requires kernel headers to be installed.
 
 ### PHP profiling options
 * `--no-php`: Disable profilers for PHP.
@@ -137,7 +139,7 @@ Alongside `perf`, gProfiler invokes runtime-specific profilers for processes bas
 * Java runtimes (version 7+) based on the HotSpot JVM, including the Oracle JDK and other builds of OpenJDK like AdoptOpenJDK and Azul Zulu.
   * Uses async-profiler.
 * The CPython interpreter, versions 2.7 and 3.5-3.9.
-  * eBPF profiling (based on PyPerf) requires Linux 4.14 or higher. Profiling using eBPF incurs lower overhead. This requires kernel headers to be installed.
+  * eBPF profiling (based on PyPerf) requires Linux 4.14 or higher; see [Python profiling options](#python-profiling-options) for more info.
   * If eBPF is not available for whatever reason, py-spy is used.
 * PHP (Zend Engine), versions 7.0-8.0.
   * Uses [Granulate's fork](https://github.com/Granulate/phpspy/) of the phpspy project.

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -479,7 +479,6 @@ def parse_cmd_args():
 
     parser.add_argument('--version', action='version', version=__version__)
     parser.add_argument("-v", "--verbose", action="store_true", default=False, dest="verbose")
-    
 
     logging_options = parser.add_argument_group("logging")
     logging_options.add_argument("--log-file", action="store", type=str, dest="log_file", default=DEFAULT_LOG_FILE)
@@ -514,7 +513,7 @@ def parse_cmd_args():
         help="Time between each profiling sessions in seconds (default: %(default)s). Note: this is the time between"
         " session starts, not between the end of one session to the beginning of the next one.",
     )
-    
+
     parser.add_argument(
         "--disable-pidns-check",
         action="store_false",

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -417,20 +417,23 @@ def parse_cmd_args():
         help="Do not invoke runtime-specific profilers for Python processes (legacy option for '--python-mode none')",
     )
 
-    parser.add_argument(
+    php_options = parser.add_argument_group("PHP")
+    php_options.add_argument(
         "--no-php",
         dest="php",
         action="store_false",
         default=True,
         help="Do not invoke runtime-specific profilers for PHP processes",
     )
-    parser.add_argument(
+    php_options.add_argument(
         "--php-proc-filter",
         dest="php_process_filter",
         default=PHPSpyProfiler.DEFAULT_PROCESS_FILTER,
         help="Process filter for php processes (default: %(default)s)",
     )
-    parser.add_argument(
+
+    ruby_options = parser.add_argument_group("Ruby")
+    ruby_options.add_argument(
         "--no-ruby",
         dest="ruby",
         action="store_false",
@@ -438,7 +441,8 @@ def parse_cmd_args():
         help="Do not invoke runtime-specific profilers for Ruby processes",
     )
 
-    parser.add_argument(
+    perf_options = parser.add_argument_group("perf")
+    perf_options.add_argument(
         "--perf-mode",
         dest="perf_mode",
         default="fp",
@@ -447,7 +451,7 @@ def parse_cmd_args():
         "by choosing the best result per process. If 'none' is chosen, do not invoke 'perf' at all. The "
         "output, in that case, is the concatenation of the results from all of the runtime profilers.",
     )
-    parser.add_argument(
+    perf_options.add_argument(
         "--perf-dwarf-stack-size",
         dest="dwarf_stack_size",
         default=8192,

--- a/gprofiler/python.py
+++ b/gprofiler/python.py
@@ -117,7 +117,7 @@ class PySpyProfiler(ProfilerBase):
 
 
 class PythonEbpfError(CalledProcessError):
-    """ "
+    """
     An error encountered while running PyPerf.
     """
 

--- a/gprofiler/python.py
+++ b/gprofiler/python.py
@@ -323,8 +323,9 @@ class PythonProfiler(ProfilerInterface):
         if self._ebpf_profiler is not None:
             try:
                 return self._ebpf_profiler.snapshot()
-            except PythonEbpfError:
-                logger.warning("Python eBPF profiler failed")
+            except PythonEbpfError as e:
+                pypspy_msg = ", falling back to py-spy" if self._pyspy_profiler is not None else ""
+                logger.warning(f"Python eBPF profiler failed (exit code: {e.returncode}){pypspy_msg}")
                 self._ebpf_profiler = None
                 return {}  # empty this round
         elif self._pyspy_profiler is not None:

--- a/gprofiler/python.py
+++ b/gprofiler/python.py
@@ -290,7 +290,6 @@ class PythonProfiler(ProfilerInterface):
         storage_dir: str,
         python_mode: str,
     ):
-        # not calling my c'tor - we're just a proxy class
         assert python_mode in ("auto", "pyperf", "pyspy"), f"unexpected mode: {python_mode}"
         if python_mode in ("auto", "pyperf"):
             self._ebpf_profiler = self._create_ebpf_profiler(frequency, duration, stop_event, storage_dir)

--- a/gprofiler/python.py
+++ b/gprofiler/python.py
@@ -10,13 +10,13 @@ import signal
 from pathlib import Path
 from subprocess import Popen
 from threading import Event
-from typing import Callable, List, Optional, Union
+from typing import List, Optional
 
 from psutil import Process
 
 from gprofiler.exceptions import CalledProcessError, ProcessStoppedException, StopEventSetException
 from gprofiler.merge import parse_many_collapsed, parse_one_collapsed
-from gprofiler.profiler_base import ProfilerBase
+from gprofiler.profiler_base import ProfilerBase, ProfilerInterface
 from gprofiler.types import ProcessToStackSampleCounters
 from gprofiler.utils import (
     pgrep_maps,
@@ -29,8 +29,6 @@ from gprofiler.utils import (
 )
 
 logger = logging.getLogger(__name__)
-
-_reinitialize_profiler: Optional[Callable[[], None]] = None
 
 
 class PySpyProfiler(ProfilerBase):
@@ -118,6 +116,12 @@ class PySpyProfiler(ProfilerBase):
         return results
 
 
+class PythonEbpfError(CalledProcessError):
+    """ "
+    An error encountered while running PyPerf.
+    """
+
+
 class PythonEbpfProfiler(ProfilerBase):
     MAX_FREQUENCY = 1000
     PYPERF_RESOURCE = "python/pyperf/PyPerf"
@@ -165,7 +169,7 @@ class PythonEbpfProfiler(ProfilerBase):
         stdout = process.stdout.read().decode()
         stderr = process.stderr.read().decode()
         cls._check_missing_headers(stdout)
-        raise CalledProcessError(process.returncode, process.args, stdout, stderr)
+        raise PythonEbpfError(process.returncode, process.args, stdout, stderr)
 
     @classmethod
     def _check_output(cls, process: Popen, output_path: Path):
@@ -245,18 +249,10 @@ class PythonEbpfProfiler(ProfilerBase):
             return output
         except TimeoutError:
             # error flow :(
-            try:
-                if _reinitialize_profiler is not None:
-                    logger.warning("Reverting to py-spy")
-                    global _profiler_class
-                    _profiler_class = PySpyProfiler
-                    _reinitialize_profiler()
-            finally:
-                # in any case, we should stop PyPerf.
-                logger.warning("PyPerf dead/not responding, killing it")
-                process = self.process  # save it
-                self._terminate()
-                self._pyperf_error(process)
+            logger.warning("PyPerf dead/not responding, killing it")
+            process = self.process  # save it
+            self._terminate()
+            self._pyperf_error(process)
 
     def snapshot(self) -> ProcessToStackSampleCounters:
         if self._stop_event.wait(self._duration):
@@ -280,31 +276,66 @@ class PythonEbpfProfiler(ProfilerBase):
             logger.info("Finished profiling Python processes with PyPerf")
 
 
-_profiler_class = None
+class PythonProfiler(ProfilerInterface):
+    """
+    Controls PySpyProfiler & PythonEbpfProfiler as needed, providing a clean interface
+    to GProfiler.
+    """
 
+    def __init__(
+        self,
+        frequency: int,
+        duration: int,
+        stop_event: Event,
+        storage_dir: str,
+        python_mode: str,
+    ):
+        # not calling my c'tor - we're just a proxy class
+        assert python_mode in ("auto", "pyperf", "pyspy"), f"unexpected mode: {python_mode}"
+        if python_mode in ("auto", "pyperf"):
+            self._ebpf_profiler = self._create_ebpf_profiler(frequency, duration, stop_event, storage_dir)
+        else:
+            self._ebpf_profiler = None
 
-def determine_profiler_class(storage_dir: str, stop_event: Event):
-    try:
-        PythonEbpfProfiler.test(storage_dir, stop_event)
-        return PythonEbpfProfiler
-    except Exception as e:
-        # Fallback to py-spy
-        logger.debug(f"eBPF profiler error: {str(e)}")
-        logger.info("Python eBPF profiler initialization failed. Falling back to py-spy...")
-        return PySpyProfiler
+        if python_mode in ("auto", "pyspy"):
+            self._pyspy_profiler: Optional[PySpyProfiler] = PySpyProfiler(frequency, duration, stop_event, storage_dir)
+        else:
+            self._pyspy_profiler = None
 
+    def _create_ebpf_profiler(
+        self, frequency: int, duration: int, stop_event: Event, storage_dir: str
+    ) -> Optional[PythonEbpfProfiler]:
+        try:
+            PythonEbpfProfiler.test(storage_dir, stop_event)
+            return PythonEbpfProfiler(frequency, duration, stop_event, storage_dir)
+        except Exception as e:
+            logger.debug(f"eBPF profiler error: {str(e)}")
+            logger.info("Python eBPF profiler initialization failed")
+            return None
 
-def get_python_profiler(
-    frequency: int,
-    duration: int,
-    stop_event: Event,
-    storage_dir: str,
-    reinitialize_profiler: Optional[Callable[[], None]] = None,
-) -> Union[PythonEbpfProfiler, PySpyProfiler]:
-    global _reinitialize_profiler
-    _reinitialize_profiler = reinitialize_profiler
+    def start(self) -> None:
+        if self._ebpf_profiler is not None:
+            self._ebpf_profiler.start()
+        elif self._pyspy_profiler is not None:
+            self._pyspy_profiler.start()
 
-    global _profiler_class
-    if _profiler_class is None:
-        _profiler_class = determine_profiler_class(storage_dir, stop_event)
-    return _profiler_class(frequency, duration, stop_event, storage_dir)
+    def snapshot(self) -> ProcessToStackSampleCounters:
+        if self._ebpf_profiler is not None:
+            try:
+                return self._ebpf_profiler.snapshot()
+            except PythonEbpfError:
+                logger.warning("Python eBPF profiler failed")
+                self._ebpf_profiler = None
+                return {}  # empty this round
+        elif self._pyspy_profiler is not None:
+            return self._pyspy_profiler.snapshot()
+        else:
+            # this can happen python_mode was 'pyperf' and PyPerf has failed.
+            # we won't resort to py-spy in this case.
+            return {}
+
+    def stop(self) -> None:
+        if self._ebpf_profiler is not None:
+            self._ebpf_profiler.stop()
+        elif self._pyspy_profiler is not None:
+            self._pyspy_profiler.stop()

--- a/tests/test_libpython.py
+++ b/tests/test_libpython.py
@@ -8,7 +8,7 @@ import pytest  # type: ignore
 from docker import DockerClient
 from docker.models.images import Image
 
-from gprofiler.python import get_python_profiler
+from gprofiler.python import PythonProfiler
 from tests import CONTAINERS_DIRECTORY
 
 
@@ -36,7 +36,7 @@ def test_python_select_by_libpython(
     (for example, uwsgi). We expect to select these because they have "libpython" in their "/proc/pid/maps".
     This test runs a Python named "shmython".
     """
-    with get_python_profiler(1000, 1, Event(), str(tmp_path)) as profiler:
+    with PythonProfiler(1000, 1, Event(), str(tmp_path), "pyspy") as profiler:
         process_collapsed = profiler.snapshot()
     collapsed = process_collapsed.get(application_docker_container.attrs["State"]["Pid"])
     assert_collapsed(collapsed)


### PR DESCRIPTION
~~Based on https://github.com/Granulate/gprofiler/pull/108 and https://github.com/Granulate/gprofiler/pull/89, review only after.~~

## Description
Adds the `--python-mode` option:
* `auto` - try PyPerf, fallback to py-spy
* `pyperf` - PyPerf, and no fallback
* `pyspy` - py-spy w/o trying PyPerf
* `none` - like `--no-python`.

## Motivation and Context
Give tighter control over which profilers are run, exactly. It's possible to want to use PyPerf with no fallback, or to avoid trying PyPerf to begin with.

## How Has This Been Tested?
* Running with `auto` - PyPerf is selected, if I "hide" kernel headers then py-spy is selected
* Running with `auto` and killing PyPerf - `Python eBPF profiler failed (exit code: -15), falling back to py-spy`
* Running with `pyperf` and no kernel headers - no Python profiler is used
* Running with `pyperf` and PyPerf is killed - `Python eBPF profiler failed (exit code: -15)` and no pyspy next round.
* Running with `pyspy` just runs py-spy w/o PyPerf initialization
* Running with `none` runs no Python profiler at all.

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
