### PR TITLE
Handle grep's "not found" error in pgrep_maps()

### DIFF
--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -191,6 +191,13 @@ def pgrep_maps(match: str) -> List[Process]:
         2,
     ), f"unexpected 'grep' exit code: {result.returncode}, stdout {result.stdout!r} stderr {result.stderr!r}"
 
+    error_lines = []
+    for line in result.stderr.splitlines():
+        if not (line.startswith("grep: /proc/") and line.endswith("/maps: No such file or directory")):
+            error_lines.append(line)
+    if error_lines:
+        logger.error(f"Unexpected 'grep' error output (first 10 lines): {error_lines[:10]}")
+
     processes: List[Process] = []
     for line in result.stdout.splitlines():
         assert line.startswith(b"/proc/") and line.endswith(b"/maps"), f"unexpected 'grep' line: {line!r}"

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -168,7 +168,12 @@ def run_process(
 
 def pgrep_exe(match: str) -> Iterator[Process]:
     pattern = re.compile(match)
-    return (process for process in psutil.process_iter() if pattern.match(process.exe()))
+    for process in psutil.process_iter():
+        try:
+            if pattern.match(process.exe()):
+                yield process
+        except psutil.NoSuchProcess:  # process might have died meanwhile
+            continue
 
 
 def pgrep_maps(match: str) -> List[Process]:

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -181,9 +181,13 @@ def pgrep_maps(match: str) -> List[Process]:
         suppress_log=True,
         check=False,
     )
-    # might get 2 (which 'grep' exits with, if some files were unavailable, because processes have exited)
+    # 0 - found
+    # 1 - not found
+    # 2 - error (which we might get for a missing /proc/pid/maps file of a process which just exited)
+    # so this ensures grep wasn't killed by a signal
     assert result.returncode in (
         0,
+        1,
         2,
     ), f"unexpected 'grep' exit code: {result.returncode}, stdout {result.stdout!r} stderr {result.stderr!r}"
 

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -193,7 +193,7 @@ def pgrep_maps(match: str) -> List[Process]:
 
     error_lines = []
     for line in result.stderr.splitlines():
-        if not (line.startswith("grep: /proc/") and line.endswith("/maps: No such file or directory")):
+        if not (line.startswith(b"grep: /proc/") and line.endswith(b"/maps: No such file or directory")):
             error_lines.append(line)
     if error_lines:
         logger.error(f"Unexpected 'grep' error output (first 10 lines): {error_lines[:10]}")

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -12,7 +12,7 @@ from docker import DockerClient
 from docker.models.images import Image
 
 from gprofiler.merge import parse_one_collapsed
-from tests.utils import run_privileged_container
+from tests.utils import run_gprofiler_in_container
 
 
 @pytest.mark.parametrize("runtime", ["java", "python", "php", "ruby"])
@@ -38,10 +38,11 @@ def test_from_executable(
 
         command = [
             str(gprofiler_inner_dir / gprofiler_exe),
+            "-v",
             "--output-dir",
             str(inner_output_dir),
         ] + runtime_specific_args
-        run_privileged_container(docker_client, exec_container_image, command=command, volumes=volumes)
+        run_gprofiler_in_container(docker_client, exec_container_image, command=command, volumes=volumes)
     else:
         os.mkdir(output_directory)
         command = ["sudo", str(gprofiler_exe), "--output-dir", str(output_directory), "-d", "5"] + runtime_specific_args

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -83,8 +83,8 @@ def test_java_async_profiler_stopped(
         assert expected_message in application_process.stdout.read1(4096)  # type: ignore
 
     # then start again, with 1 second
-    assert args[1] == "1000"
-    args[1] = "1"
+    assert args[2] == "1000"
+    args[2] = "1"
     _, logs = run_gprofiler_in_container(docker_client, gprofiler_docker_image, args, volumes=volumes)
 
     assert "Found async-profiler already started" in logs

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -15,7 +15,7 @@ from docker.models.images import Image
 
 from gprofiler.java import AsyncProfiledProcess
 from gprofiler.merge import parse_one_collapsed
-from tests.utils import run_privileged_container
+from tests.utils import run_gprofiler_in_container
 
 
 # adds the "status" command to AsyncProfiledProcess from gProfiler.
@@ -47,11 +47,11 @@ def test_java_async_profiler_stopped(
         str(output_directory): {"bind": inner_output_directory, "mode": "rw"},
     }
     # run Java only (just so initialization is faster w/o Python/PHP) for 1000 seconds
-    args = ["-d", "1000", "-o", inner_output_directory, "--no-php", "--no-python"] + runtime_specific_args
+    args = ["-v", "-d", "1000", "-o", inner_output_directory, "--no-php", "--no-python"] + runtime_specific_args
 
     container = None
     try:
-        container, logs = run_privileged_container(
+        container, logs = run_gprofiler_in_container(
             docker_client, gprofiler_docker_image, args, volumes=volumes, auto_remove=False, detach=True
         )
         assert container is not None, "got None container?"
@@ -85,7 +85,7 @@ def test_java_async_profiler_stopped(
     # then start again, with 1 second
     assert args[1] == "1000"
     args[1] = "1"
-    _, logs = run_privileged_container(docker_client, gprofiler_docker_image, args, volumes=volumes)
+    _, logs = run_gprofiler_in_container(docker_client, gprofiler_docker_image, args, volumes=volumes)
 
     assert "Found async-profiler already started" in logs
 

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -89,7 +89,7 @@ def test_from_container(
         "/lib/modules": {"bind": "/lib/modules", "mode": "ro"},
         str(output_directory): {"bind": inner_output_directory, "mode": "rw"},
     }
-    args = ["-v", "-d", "1", "-o", inner_output_directory] + runtime_specific_args
+    args = ["-v", "-d", "3", "-o", inner_output_directory] + runtime_specific_args
     run_gprofiler_in_container(docker_client, gprofiler_docker_image, args, volumes=volumes)
 
     collapsed = parse_one_collapsed(Path(output_directory / "last_profile.col").read_text())

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -16,7 +16,7 @@ from gprofiler.php import PHPSpyProfiler
 from gprofiler.python import PySpyProfiler, PythonEbpfProfiler
 from gprofiler.ruby import RbSpyProfiler
 from tests import PHPSPY_DURATION
-from tests.utils import assert_function_in_collapsed, run_privileged_container
+from tests.utils import assert_function_in_collapsed, run_gprofiler_in_container
 
 
 @pytest.mark.parametrize("runtime", ["java"])
@@ -89,8 +89,8 @@ def test_from_container(
         "/lib/modules": {"bind": "/lib/modules", "mode": "ro"},
         str(output_directory): {"bind": inner_output_directory, "mode": "rw"},
     }
-    args = ["-d", "1", "-o", inner_output_directory] + runtime_specific_args
-    run_privileged_container(docker_client, gprofiler_docker_image, args, volumes=volumes)
+    args = ["-v", "-d", "1", "-o", inner_output_directory] + runtime_specific_args
+    run_gprofiler_in_container(docker_client, gprofiler_docker_image, args, volumes=volumes)
 
     collapsed = parse_one_collapsed(Path(output_directory / "last_profile.col").read_text())
     assert_collapsed(collapsed)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -40,6 +40,26 @@ def run_privileged_container(
     return container, logs
 
 
+def _no_errors(logs: str):
+    # example line: [2021-06-12 10:13:57,528] ERROR: gprofiler: ruby profiling failed
+    assert "] ERROR: " not in logs, "found ERRORs in gProfiler logs!"
+
+
+def run_gprofiler_in_container(
+    docker_client: DockerClient, image: Image, command: List[str], **kwargs
+) -> Tuple[Optional[Container], str]:
+    """
+    Wrapper around run_privileged_container() that also verifies there are not ERRORs in gProfiler's output log.
+    """
+    assert "-v" in command, "plesae run with -v!"  # otherwise there are no loglevel prints
+    container, logs = run_privileged_container(docker_client, image, command, **kwargs)
+    if container is not None:
+        _no_errors(container.logs().decode())
+    else:
+        _no_errors(logs)
+    return container, logs
+
+
 def copy_file_from_image(image: Image, container_path: str, host_path: str) -> None:
     os.makedirs(os.path.dirname(host_path), exist_ok=True)
     # I tried writing it with the docker-py API, but retrieving large files with container.get_archive() just hangs...


### PR DESCRIPTION
## Description
Handle grep's "not found" error in `pgrep_maps()`. We haven't encountered it by now, because `pgrep_maps()` was run only on Pythons, and we always have Pythons running.

## Motivation and Context
Get rid of this error in the logs:
````
[2021-06-12 10:22:28,386] DEBUG: gprofiler.utils: (["grep -lP '(?:^.+/ruby[^/]*$)' /proc/*/maps"]) exit code: 1
[2021-06-12 10:22:28,386] ERROR: gprofiler: ruby profiling failed
Traceback (most recent call last):
  File "/app/gprofiler/main.py", line 271, in _snapshot
    process_perfs.update(future.result())
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 432, in result
    return self.__get_result()
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 388, in __get_result
    raise self._exception
  File "/usr/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/app/gprofiler/ruby.py", line 62, in snapshot
    processes_to_profile = _find_ruby_processes()
  File "/app/gprofiler/ruby.py", line 23, in _find_ruby_processes
    return pgrep_maps(r"(?:^.+/ruby[^/]*$)")
  File "/app/gprofiler/utils.py", line 185, in pgrep_maps
    assert result.returncode in (
AssertionError: unexpected 'grep' exit code: 1, stdout b'' stderr b''
```

## How Has This Been Tested?
1. Added a check in our tests for no `ERROR` logs.
2. Verified that the check actually catches the current error
3. Fixed the current error

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [x] I have added tests for new logic.
