### PR TITLE
Add version to query params

### DIFF
--- a/gprofiler/client.py
+++ b/gprofiler/client.py
@@ -12,6 +12,7 @@ from typing import Dict, List, Optional, Tuple
 import requests
 from requests import Session
 
+from gprofiler import __version__
 from gprofiler.utils import get_iso8601_format_time
 
 logger = logging.getLogger(__name__)
@@ -132,5 +133,5 @@ class APIClient:
             },
             timeout=self._upload_timeout,
             api_version="v2",
-            params={"samples": str(total_samples)},
+            params={"samples": str(total_samples), "version": __version__},
         )


### PR DESCRIPTION
## Description
Adds gProfiler version to the query params URL; see https://github.com/Granulate/gprofiler/pull/99.

## Motivation and Context
See https://github.com/Granulate/gprofiler/pull/99.

## How Has This Been Tested?
Built & ran gProfiler - verified the new `version` field shows correctly in Athena.

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
