### PR TITLE
Add assert failure messages where missing

### DIFF
--- a/gprofiler/python.py
+++ b/gprofiler/python.py
@@ -230,7 +230,7 @@ class PythonEbpfProfiler(ProfilerBase):
 
         output_files = self._glob_output()
         # All the snapshot samples should be in one file
-        assert len(output_files) == 1
+        assert len(output_files) == 1, "expected single file but got: " + str(output_files)
         return Path(output_files[0])
 
     def _dump(self) -> Path:

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -250,7 +250,7 @@ def resolve_proc_root_links(proc_root: str, ns_path: str) -> str:
 
 def remove_prefix(s: str, prefix: str) -> str:
     # like str.removeprefix of Python 3.9, but this also ensures the prefix exists.
-    assert s.startswith(prefix)
+    assert s.startswith(prefix), f"{s} doesn't start with {prefix}"
     return s[len(prefix) :]
 
 


### PR DESCRIPTION
## Description
Makes it possible to get more information about what happened by reading the exception
message.
I didn't add it for obvious cases (e.g: assert x is not None).
Also didn't add it for tests code, because pytest adds its introspection.

## Motivation and Context
See description ^^

## How Has This Been Tested?
CI

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
