### PR TITLE
Fix incorrect scaling in merge_profiles()

### DIFF
--- a/gprofiler/merge.py
+++ b/gprofiler/merge.py
@@ -251,6 +251,10 @@ def merge_profiles(
 ) -> Tuple[str, int]:
     # merge process profiles into the global perf results.
     for pid, stacks in process_profiles.items():
+        if len(stacks) == 0:
+            # no samples collected by the runtime profiler for this process (empty stackcollapse file)
+            continue
+
         process_perf = perf_pid_to_stacks_counter.get(pid)
         if process_perf is None:
             # no samples collected by perf for this process.

--- a/gprofiler/merge.py
+++ b/gprofiler/merge.py
@@ -257,10 +257,10 @@ def merge_profiles(
             continue
 
         perf_samples_count = sum(process_perf.values())
-        assert perf_samples_count > 0
-
         profile_samples_count = sum(stacks.values())
-        ratio = profile_samples_count / perf_samples_count
+        assert profile_samples_count > 0
+
+        ratio = perf_samples_count / profile_samples_count
 
         # do the scaling by the ratio of samples: samples we received from the runtime profiler
         # of this process, by the samples we received from perf for this process.

--- a/gprofiler/merge.py
+++ b/gprofiler/merge.py
@@ -260,10 +260,9 @@ def merge_profiles(
         profile_samples_count = sum(stacks.values())
         assert profile_samples_count > 0
 
+        # do the scaling by the ratio of samples: samples we received from perf for this process,
+        # divided by samples we received from the runtime profiler of this process.
         ratio = perf_samples_count / profile_samples_count
-
-        # do the scaling by the ratio of samples: samples we received from the runtime profiler
-        # of this process, by the samples we received from perf for this process.
         for stack in stacks:
             stacks[stack] = round(stacks[stack] * ratio)
 


### PR DESCRIPTION
## Description
I've accidentally swapped the condition in #89.
Usually the ratio is close to 1, and anyway the process stacks won't amount to more
than the perf stacks in a normal situation, so it doesn't mess with the results
too much.

## Motivation and Context
Fix a bug

## How Has This Been Tested?
```
diff --git a/gprofiler/python.py b/gprofiler/python.py
index b53a2db..095eab3 100644
--- a/gprofiler/python.py
+++ b/gprofiler/python.py
@@ -40,7 +40,7 @@ class PySpyProfiler(ProfilerBase):
             resource_path("python/py-spy"),
             "record",
             "-r",
-            str(self._frequency),
+            str(1),
             "-d",
             str(self._duration),
             "--nonblocking",
(END)
```

With this patch on master, gProfiler runs with `-d 5` and default frequency, I run Python with `while 1: pass` and I get 0 stacks (because the division is incorrect so it's scaled to 0 samples).
With this patch on this branch, I get 50~ stacks as expected (scaling multiplies the 5 samples collected by py-spy to 50~)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
