### PR TITLE
utils: Don't leak NS fds in run_in_ns()

### DIFF
--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -348,11 +348,16 @@ def run_in_ns(nstypes: List[str], callback: Callable[[], None], target_pid: int 
                     "pid": 0x20000000,  # CLONE_NEWPID
                     "uts": 0x04000000,  # CLONE_NEWUTS
                 }[nstype]
-                if (
-                    libc.unshare(flag) != 0
-                    or libc.setns(os.open(f"/proc/{target_pid}/ns/{nstype}", os.O_RDONLY), flag) != 0
-                ):
-                    raise ValueError(f"Failed to unshare({nstype}) and setns({nstype})")
+                if libc.unshare(flag) != 0:
+                    raise ValueError(f"Failed to unshare({nstype})")
+
+                nsfd = -1
+                try:
+                    nsfd = os.open(f"/proc/{target_pid}/ns/{nstype}", os.O_RDONLY)
+                    if libc.setns(nsfd, flag) != 0:
+                        raise ValueError(f"Failed to setns({nstype}) (to pid {target_pid})")
+                finally:
+                    os.close(nsfd)
 
         callback()
 

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -351,13 +351,9 @@ def run_in_ns(nstypes: List[str], callback: Callable[[], None], target_pid: int 
                 if libc.unshare(flag) != 0:
                     raise ValueError(f"Failed to unshare({nstype})")
 
-                nsfd = -1
-                try:
-                    nsfd = os.open(f"/proc/{target_pid}/ns/{nstype}", os.O_RDONLY)
-                    if libc.setns(nsfd, flag) != 0:
+                with open(f"/proc/{target_pid}/ns/{nstype}", "r") as nsf:
+                    if libc.setns(nsf.fileno(), flag) != 0:
                         raise ValueError(f"Failed to setns({nstype}) (to pid {target_pid})")
-                finally:
-                    os.close(nsfd)
 
         callback()
 


### PR DESCRIPTION
## Description
Avoid leaking fds :(

## Motivation and Context
Avoid leaking fds.

## How Has This Been Tested?
CI.

Verified fds are not leaked anymore, e.g `lr-x------ 1 root root 64 Jun 24 19:40 6 -> 'mnt:[4026531840]'` and `lr-x------ 1 root root 64 Jun 24 19:40 3 -> 'net:[4026532008]'`.

Also verified the output looks good (i.e, move to namespaces still happens correctly)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
