### PR TITLE
Rename tests util class name to avoid PyTest collection

### DIFF
--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -19,7 +19,7 @@ from tests.utils import run_gprofiler_in_container
 
 
 # adds the "status" command to AsyncProfiledProcess from gProfiler.
-class TestsAsyncProfiledProcess(AsyncProfiledProcess):
+class AsyncProfiledProcessForTests(AsyncProfiledProcess):
     def status_async_profiler(self):
         self._run_async_profiler(self._get_base_cmd() + [f"status,log={self._log_path_process}"])
 
@@ -65,7 +65,7 @@ def test_java_async_profiler_stopped(
 
     # run "status"
     proc = psutil.Process(application_pid)
-    with TestsAsyncProfiledProcess(proc, tmp_path) as ap_proc:
+    with AsyncProfiledProcessForTests(proc, tmp_path) as ap_proc:
         ap_proc.status_async_profiler()
     # printed the process' stdout, see ACTION_STATUS case in async-profiler/profiler.cpp
     expected_message = b"Profiling is running for "


### PR DESCRIPTION
## Description
Currently, tests are having an annoying PyTest warning because PyTest tries to collect `TestsAsyncProfiledProcess` but fails because the `__init__` of this class is implemented and PyTest thinks this a "class" test and tries to collect it during the PyTest collection phase.

Unfortunately, there is no built-in decorator in PyTest that avoids collecting selected test items, so simply just rename the class name to avoid collection.

## How Has This Been Tested?
Tested by the CI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
