### PR TITLE
python, ruby: Remove collapsed files after reading

### DIFF
--- a/gprofiler/merge.py
+++ b/gprofiler/merge.py
@@ -7,6 +7,7 @@ import math
 import random
 import re
 from collections import Counter, defaultdict
+from pathlib import Path
 from typing import Iterable, Optional, Tuple
 
 from gprofiler.docker_client import DockerClient
@@ -51,6 +52,15 @@ def parse_one_collapsed(collapsed: str, add_comm: Optional[str] = None) -> Stack
             logger.exception(f'bad stack - line="{line}"')
 
     return stacks
+
+
+def parse_and_remove_one_collapsed(collapsed: Path, add_comm: Optional[str] = None) -> StackToSampleCount:
+    """
+    Parse a stack-collapsed file and remove it.
+    """
+    data = collapsed.read_text()
+    collapsed.unlink()
+    return parse_one_collapsed(data, add_comm)
 
 
 def parse_many_collapsed(text: str) -> ProcessToStackSampleCounters:

--- a/gprofiler/python.py
+++ b/gprofiler/python.py
@@ -15,7 +15,7 @@ from psutil import Process
 
 from gprofiler.exceptions import CalledProcessError, ProcessStoppedException, StopEventSetException
 from gprofiler.log import get_logger_adapter
-from gprofiler.merge import parse_many_collapsed, parse_one_collapsed
+from gprofiler.merge import parse_and_remove_one_collapsed, parse_many_collapsed
 from gprofiler.profiler_base import ProfilerBase, ProfilerInterface
 from gprofiler.types import ProcessToStackSampleCounters
 from gprofiler.utils import (
@@ -66,7 +66,7 @@ class PySpyProfiler(ProfilerBase):
             raise StopEventSetException
 
         logger.info(f"Finished profiling process {process.pid} with py-spy")
-        return parse_one_collapsed(Path(local_output_path).read_text(), comm)
+        return parse_and_remove_one_collapsed(Path(local_output_path), comm)
 
     def _find_python_processes_to_profile(self) -> List[Process]:
         filtered_procs = []

--- a/gprofiler/ruby.py
+++ b/gprofiler/ruby.py
@@ -11,7 +11,7 @@ from psutil import Process
 
 from gprofiler.exceptions import ProcessStoppedException, StopEventSetException
 from gprofiler.log import get_logger_adapter
-from gprofiler.merge import parse_one_collapsed
+from gprofiler.merge import parse_and_remove_one_collapsed
 from gprofiler.profiler_base import ProfilerBase
 from gprofiler.types import ProcessToStackSampleCounters
 from gprofiler.utils import pgrep_maps, random_prefix, resource_path, run_process
@@ -57,7 +57,7 @@ class RbSpyProfiler(ProfilerBase):
             raise StopEventSetException
 
         logger.info(f"Finished profiling process {process.pid} with rbspy")
-        return parse_one_collapsed(Path(local_output_path).read_text(), comm)
+        return parse_and_remove_one_collapsed(Path(local_output_path), comm)
 
     def snapshot(self) -> ProcessToStackSampleCounters:
         processes_to_profile = _find_ruby_processes()

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -12,7 +12,6 @@ from docker import DockerClient
 from docker.models.images import Image
 
 from gprofiler.merge import parse_one_collapsed
-from gprofiler.utils import TEMPORARY_STORAGE_PATH
 from tests.utils import run_gprofiler_in_container
 
 
@@ -50,8 +49,5 @@ def test_from_executable(
         popen = Popen(command)
         popen.wait()
 
-    # no leftovers in TEMPORARY_STORAGE_PATH - only async-profiler's directory, which is kept across gProfiler runs;
-    # and perf-buildids which is never deleted (but shouldn't grow too large)
-    assert all(i in ("perf-buildids", "async-profiler") for i in os.listdir(TEMPORARY_STORAGE_PATH))
     collapsed = parse_one_collapsed(Path(output_directory / "last_profile.col").read_text())
     assert_collapsed(collapsed)

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -12,6 +12,7 @@ from docker import DockerClient
 from docker.models.images import Image
 
 from gprofiler.merge import parse_one_collapsed
+from gprofiler.utils import TEMPORARY_STORAGE_PATH
 from tests.utils import run_gprofiler_in_container
 
 
@@ -49,5 +50,8 @@ def test_from_executable(
         popen = Popen(command)
         popen.wait()
 
+    # no leftovers in TEMPORARY_STORAGE_PATH - only async-profiler's directory, which is kept across gProfiler runs;
+    # and perf-buildids which is never deleted (but shouldn't grow too large)
+    assert all(i in ("perf-buildids", "async-profiler") for i in os.listdir(TEMPORARY_STORAGE_PATH))
     collapsed = parse_one_collapsed(Path(output_directory / "last_profile.col").read_text())
     assert_collapsed(collapsed)


### PR DESCRIPTION
## Description
We do not delete the output files of py-spy and rbspy. This PR fixes that.

The issue was introduced in 1efe4a7f87d322beaa1708cb56a5913c18e316e9 (version 1.0.0) - we ceased from deleting the core temporary folder each iteration, instead it survives for the lifetime of the `GProfiler` object.
It was worsened by 0ab54a089f9c31d267b29e4a1b33060c68ff7e58 which added random a prefix in each output file - so now files of the same target PID don't override each other; so storage keeps on growing!

## Motivation and Context
Bugfix.

## How Has This Been Tested?
1. Verified manually that files are now gone.
2. Added logic to the tests to ensure it from now on.

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [x] I have added tests for new logic.
