### PR TITLE
ruby: Run rbspy in silent mode

### DIFF
--- a/gprofiler/ruby.py
+++ b/gprofiler/ruby.py
@@ -31,6 +31,7 @@ class RbSpyProfiler(ProfilerBase):
         return [
             resource_path(self.RESOURCE_PATH),
             "record",
+            "--silent",
             "-r",
             str(self._frequency),
             "-d",


### PR DESCRIPTION
## Description
Runs rbspy in silent mode, to avoid unwanted output that only clutters the gProfiler logs (since it gets logged in verbose mode). I noticed it in the tests, actually: https://github.com/Granulate/gprofiler/pull/128/checks?check_run_id=2947056638

## Motivation and Context
Remove garbage from our logs.

## How Has This Been Tested?
Ran gProfiler w/o this commit - saw lots of outputs like:
```
[2021-06-29 23:11:33,721] DEBUG: gprofiler.utils: (['/app/gprofiler/resources/ruby/rbspy', 'record', '-s', '-r', '11', '-d', '5', '--nonblocking', '--on-cpu', '--format=collapsed', '--file', '/tmp/gprofiler_tmp/tmpnz5h2fnb/rbspy.FMyipkFJlKBCCPcq.198335.col', '--raw-file', '/dev/null', '-p', '198335']) stdout: b'\x1b[2J\n\x1b[0;0H\n% self  % total  name\n100.00   100.00  <main> - (irb)\n  0.00   100.00  start - /usr/local/lib/ruby/3.0.0/irb.rb\n  0.00   100.00  signal_status - /usr/local/lib/ruby/3.0.0/irb.rb\n  0.00   100.00  run - /usr/local/lib/ruby/3.0.0/irb.rb\n  0.00   100.00  loop [c function] - (unknown)\n  0.00   100.00  load [c function] - (unknown)\n  0.00   100.00  evaluate - /usr/local/lib/ruby/3.0.0/irb/workspace.rb\n  0.00   100.00  evaluate - /usr/local/lib/ruby/3.0.0/irb/context.rb\n  0.00   100.00  eval_input - /usr/local/lib/ruby/3.0.0/irb.rb\n  0.00   100.00  eval [c function] - (unknown)\n  0.00   100.00  each_top_level_state ....
```
Ran with this commit - they are gone.

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
