### PR TITLE
utils: pgrep_maps(): Ignore "No such process" errors

### DIFF
--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -199,7 +199,10 @@ def pgrep_maps(match: str) -> List[Process]:
 
     error_lines = []
     for line in result.stderr.splitlines():
-        if not (line.startswith(b"grep: /proc/") and line.endswith(b"/maps: No such file or directory")):
+        if not (
+            line.startswith(b"grep: /proc/")
+            and (line.endswith(b"/maps: No such file or directory") or line.endswith(b"/maps: No such process"))
+        ):
             error_lines.append(line)
     if error_lines:
         logger.error(f"Unexpected 'grep' error output (first 10 lines): {error_lines[:10]}")


### PR DESCRIPTION
## Description
Seen this racy error in the CI. Apparently it's a valid return value from the kernel for this `read`.

## Motivation and Context
Avoid logging ERRORs on non-error stuff.

## How Has This Been Tested?
CI

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
