### PR TITLE
Create ProcessProfilerBase and treat NoSuchProcess as DEBUG

### DIFF
--- a/gprofiler/java.py
+++ b/gprofiler/java.py
@@ -322,7 +322,7 @@ class JavaProfiler(ProfilerBase):
         if ap_proc.process.is_running():
             ap_proc.stop_async_profiler(True)
         else:
-            logger.info(f"Profiled process {ap_proc.process.pid} exited before stopping async-profiler")
+            logger.debug(f"Profiled process {ap_proc.process.pid} exited before stopping async-profiler")
             # no output in this case :/
             return None
 
@@ -358,6 +358,8 @@ class JavaProfiler(ProfilerBase):
                         results[futures[future]] = result
                 except StopEventSetException:
                     raise
+                except psutil.NoSuchProcess:
+                    logger.debug(f"Process process went down during profiling {futures[future]}", exc_info=True)
                 except Exception:
                     logger.exception(f"Failed to profile Java process {futures[future]}")
 

--- a/gprofiler/python.py
+++ b/gprofiler/python.py
@@ -11,7 +11,7 @@ from subprocess import Popen
 from threading import Event
 from typing import List, Optional
 
-from psutil import Process
+from psutil import NoSuchProcess, Process
 
 from gprofiler.exceptions import CalledProcessError, ProcessStoppedException, StopEventSetException
 from gprofiler.log import get_logger_adapter
@@ -110,6 +110,8 @@ class PySpyProfiler(ProfilerBase):
                     results[futures[future]] = future.result()
                 except StopEventSetException:
                     raise
+                except NoSuchProcess:
+                    logger.debug(f"Process process went down during profiling {futures[future]}", exc_info=True)
                 except Exception:
                     logger.exception(f"Failed to profile Python process {futures[future]}")
 

--- a/gprofiler/ruby.py
+++ b/gprofiler/ruby.py
@@ -7,7 +7,7 @@ import os
 from pathlib import Path
 from typing import List
 
-from psutil import Process
+from psutil import NoSuchProcess, Process
 
 from gprofiler.exceptions import ProcessStoppedException, StopEventSetException
 from gprofiler.log import get_logger_adapter
@@ -75,6 +75,8 @@ class RbSpyProfiler(ProfilerBase):
                     results[futures[future]] = future.result()
                 except StopEventSetException:
                     raise
+                except NoSuchProcess:
+                    logger.debug(f"Process process went down during profiling {futures[future]}", exc_info=True)
                 except Exception:
                     logger.exception(f"Failed to profile Ruby process {futures[future]}")
 

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from subprocess import CompletedProcess, Popen, TimeoutExpired
 from tempfile import TemporaryDirectory
 from threading import Event, Thread
-from typing import Callable, Iterator, List, Optional, Tuple, Union
+from typing import Callable, List, Optional, Tuple, Union
 
 import distro  # type: ignore
 import importlib_resources
@@ -167,14 +167,16 @@ def run_process(
     return result
 
 
-def pgrep_exe(match: str) -> Iterator[Process]:
+def pgrep_exe(match: str) -> List[Process]:
     pattern = re.compile(match)
+    procs = []
     for process in psutil.process_iter():
         try:
             if pattern.match(process.exe()):
-                yield process
+                procs.append(process)
         except psutil.NoSuchProcess:  # process might have died meanwhile
             continue
+    return procs
 
 
 def pgrep_maps(match: str) -> List[Process]:


### PR DESCRIPTION
## Description
Started with logging NoSuchProcess exceptions from profilers as DEBUG, not ERROR.

Then created `ProcessProfilerBase` to reduce code dup, it was time...

## Motivation and Context
Reduce the error logs & reduce code dup.

## How Has This Been Tested?
CI

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
