### PR TITLE
ci: Reject non-matching version between git tag and code

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,12 @@ jobs:
           echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
           ./cmp_tags.sh
           echo "GH_REPO=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+          gprofiler_version=$(python -c "exec(open('gprofiler/__init__.py').read()); print(__version__)")
+          git_tag=$(git describe --tags)
+          if [ "$gprofiler_version" != "$git_tag" ]; then
+            echo Running gprofiler_version $gprofiler_version but git_tag $git_tag
+            exit 1
+          fi
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
## Description
Latest release 1.1.5 was done w/o bumping `__version__` (my :dumb:), adding this to avoid such cases in the future.

## Motivation and Context
Avoid making human errors when releasing a version.

## How Has This Been Tested?
Tested this snippet locally on my shell. Fails if the tag doesn't match.

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
