### PR TITLE
java: Allow different gProfiler versions to use different APs

### DIFF
--- a/gprofiler/java.py
+++ b/gprofiler/java.py
@@ -13,7 +13,6 @@ from typing import List, Optional
 import psutil
 from psutil import Process
 
-from gprofiler import __version__
 from gprofiler.exceptions import CalledProcessError, StopEventSetException
 from gprofiler.log import get_logger_adapter
 from gprofiler.merge import parse_one_collapsed
@@ -56,6 +55,11 @@ def jattach_path() -> str:
     return resource_path("java/jattach")
 
 
+@functools.lru_cache(maxsize=1)
+def get_ap_version() -> str:
+    return Path(resource_path("java/async-profiler-version")).read_text()
+
+
 class AsyncProfiledProcess:
     """
     Represents a process profiled with async-profiler.
@@ -74,9 +78,9 @@ class AsyncProfiledProcess:
         # multiple times into the process)
         # without depending on storage_dir here, we maintain the same path even if gProfiler is re-run,
         # because storage_dir changes between runs.
-        # we embed the gprofiler version in the path, so different gprofiler versions can use different AP
-        # versions.
-        self._ap_dir = os.path.join(TEMPORARY_STORAGE_PATH, f"async-profiler-{__version__}")
+        # we embed the async-profiler version in the path, so future gprofiler versions which use another version
+        # of AP case use it (will be loaded as a different DSO)
+        self._ap_dir = os.path.join(TEMPORARY_STORAGE_PATH, f"async-profiler-{get_ap_version()}")
         self._ap_dir_host = resolve_proc_root_links(self._process_root, self._ap_dir)
 
         self._libap_path_host = os.path.join(self._ap_dir_host, "libasyncProfiler.so")

--- a/gprofiler/java.py
+++ b/gprofiler/java.py
@@ -13,6 +13,7 @@ from typing import List, Optional
 import psutil
 from psutil import Process
 
+from gprofiler import __version__
 from gprofiler.exceptions import CalledProcessError, StopEventSetException
 from gprofiler.log import get_logger_adapter
 from gprofiler.merge import parse_one_collapsed
@@ -73,7 +74,9 @@ class AsyncProfiledProcess:
         # multiple times into the process)
         # without depending on storage_dir here, we maintain the same path even if gProfiler is re-run,
         # because storage_dir changes between runs.
-        self._ap_dir = os.path.join(TEMPORARY_STORAGE_PATH, "async-profiler")
+        # we embed the gprofiler version in the path, so different gprofiler versions can use different AP
+        # versions.
+        self._ap_dir = os.path.join(TEMPORARY_STORAGE_PATH, f"async-profiler-{__version__}")
         self._ap_dir_host = resolve_proc_root_links(self._process_root, self._ap_dir)
 
         self._libap_path_host = os.path.join(self._ap_dir_host, "libasyncProfiler.so")

--- a/scripts/async_profiler_build.sh
+++ b/scripts/async_profiler_build.sh
@@ -5,5 +5,14 @@
 #
 set -euo pipefail
 
-git clone --depth 1 -b v2.0g3 https://github.com/Granulate/async-profiler.git && cd async-profiler && git reset --hard 51447a849d686e899c1cd393e83f0f7c41685d95
+VERSION=v2.0g3
+OUTPUT=async-profiler-2.0-linux-x64.tar.gz
+
+git clone --depth 1 -b "$VERSION" https://github.com/Granulate/async-profiler.git && cd async-profiler && git reset --hard 51447a849d686e899c1cd393e83f0f7c41685d95
 make release
+
+# add a version file to the build directory
+echo -n "$VERSION" > async-profiler-version
+gunzip "$OUTPUT"
+tar -rf "${OUTPUT%.gz}" --transform s,^,async-profiler-2.0-linux-x64/build/, async-profiler-version
+gzip "${OUTPUT%.gz}"


### PR DESCRIPTION
## Description
By embedding the gProfiler version in AP dir, we will have different dirs for different gProfiler
releases.

**Note:** This breaks the "AP stop" logic across gProfiler versions: if I run version X, kill it brutally, then run version Y, the new AP will be loaded as a different DSO (since it has a different path) and it may cause harm (see https://github.com/jvm-profiling-tools/async-profiler/issues/395 for example). Need to think on a workaround / a different approach for allowing AP upgrades. Opening this PR for discussion.

## Motivation and Context
Allow different gProfiler versions to use different APs. So if we upgrade the AP version in a future gProfiler release, and gProfiler is upgraded on a box which already ran an old version, it will use the new binary.

## How Has This Been Tested?
* [x] Run a Java process; Run gProfiler; Change something in AP, build gProfiler (with a different `__version__`) and run again and ensure the new one is used.

## Checklist:
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
