### PR TITLE
tests: ruby: Pin version to 2.6.7

### DIFF
--- a/tests/containers/ruby/Dockerfile
+++ b/tests/containers/ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6
+FROM ruby:2.6.7
 
 WORKDIR /app
 ADD fibonacci.rb /app


### PR DESCRIPTION
## Description
2.6.8 was released and rbspy doesn't support it yet, so tests fails.
