### PR TITLE
Log CPU usage

### DIFF
--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -32,6 +32,7 @@ from gprofiler.ruby import RbSpyProfiler
 from gprofiler.state import State, init_state
 from gprofiler.utils import (
     TEMPORARY_STORAGE_PATH,
+    CpuUsageLogger,
     TemporaryDirectoryWithMode,
     atomically_symlink,
     get_hostname,
@@ -97,6 +98,7 @@ class GProfiler:
         runtimes: Dict[str, bool],
         client: APIClient,
         state: State,
+        cpu_usage_logger: CpuUsageLogger,
         include_container_names=True,
         remote_logs_handler: Optional[RemoteLogsHandler] = None,
         php_process_filter: str = PHPSpyProfiler.DEFAULT_PROCESS_FILTER,
@@ -162,6 +164,7 @@ class GProfiler:
             self._docker_client: Optional[DockerClient] = DockerClient()
         else:
             self._docker_client = None
+        self._cpu_usage_logger = cpu_usage_logger
 
     def __enter__(self):
         self.start()
@@ -338,6 +341,8 @@ class GProfiler:
 
     def run_continuous(self, interval):
         with self:
+            self._cpu_usage_logger.init_cycles()
+
             while not self._stop_event.is_set():
                 start_time = time.monotonic()
                 self._state.init_new_cycle()
@@ -349,6 +354,7 @@ class GProfiler:
                     self._send_remote_logs()  # function is safe, wrapped with try/except block inside
                 time_spent = time.monotonic() - start_time
                 self._stop_event.wait(max(interval - time_spent, 0))
+                self._cpu_usage_logger.log_cycle()
 
 
 def parse_cmd_args():
@@ -390,6 +396,13 @@ def parse_cmd_args():
 
     parser.add_argument(
         "--rotating-output", action="store_true", default=False, help="Keep only the last profile result"
+    )
+
+    parser.add_argument(
+        "--log-cpu-usage",
+        action="store_true",
+        default=False,
+        help="Log CPU usage (per cgroup) on each profiling iteration. Works only when gProfiler runs as a container",
     )
 
     java_options = parser.add_argument_group("Java")
@@ -604,6 +617,8 @@ def main():
 
     setup_signals()
     reset_umask()
+    # assume we run in the root cgroup (when containerized, that's our view)
+    cpu_usage_logger = CpuUsageLogger(logger, "/", args.log_cpu_usage)
 
     try:
         logger.info(f"Running gprofiler (version {__version__}), commandline: {' '.join(sys.argv[1:])!r}")
@@ -663,6 +678,7 @@ def main():
             runtimes,
             client,
             state,
+            cpu_usage_logger,
             not args.disable_container_names,
             remote_logs_handler,
             args.php_process_filter,
@@ -678,6 +694,8 @@ def main():
         pass
     except Exception:
         logger.exception("Unexpected error occurred")
+
+    cpu_usage_logger.log_run()
 
 
 if __name__ == "__main__":

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -37,6 +37,7 @@ from gprofiler.utils import (
     atomically_symlink,
     get_hostname,
     get_iso8601_format_time,
+    get_run_mode,
     grab_gprofiler_mutex,
     is_root,
     is_running_in_init_pid,
@@ -586,6 +587,12 @@ def verify_preconditions(args):
 
     if not grab_gprofiler_mutex():
         print("Could not acquire gProfiler's lock. Is it already running?", file=sys.stderr)
+        sys.exit(1)
+
+    if args.log_cpu_usage and get_run_mode() not in ("k8s", "container"):
+        # TODO: we *can* move into another cpuacct cgroup, to let this work also when run as a standalone
+        # executable.
+        print("--log-cpu-usage is available only when run as a container!")
         sys.exit(1)
 
 

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -528,6 +528,7 @@ class CpuUsageLogger:
         """
         Reads the current snapshot of cpuacct.usage for a cgroup.
         """
+        assert self._enabled, "shouldn't reach here!"
         return int(self._cpuacct_usage.read_text())
 
     def init_cycles(self):

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -512,3 +512,61 @@ def get_hostname() -> str:
 
 def random_prefix() -> str:
     return ''.join(random.choice(string.ascii_letters) for _ in range(16))
+
+
+class CpuUsageLogger:
+    NSEC_PER_SEC = 1000000000
+
+    def __init__(self, logger: logging.LoggerAdapter, cgroup: str, enabled: bool):
+        self._logger = logger
+        self._cpuacct_usage = Path(f"/sys/fs/cgroup/{cgroup}cpuacct/cpuacct.usage")
+        self._enabled = enabled
+        self._last_usage: Optional[int] = None
+        self._last_ts: Optional[float] = None
+
+    def _read_cgroup_cpu_usage(self) -> int:
+        """
+        Reads the current snapshot of cpuacct.usage for a cgroup.
+        """
+        return int(self._cpuacct_usage.read_text())
+
+    def init_cycles(self):
+        if not self._enabled:
+            return
+
+        self._last_usage = self._read_cgroup_cpu_usage()
+        self._last_ts = time.monotonic()
+
+    def log_cycle(self):
+        if not self._enabled:
+            return
+
+        assert self._last_usage is not None and self._last_ts is not None, "didn't call init_cycles()?"
+
+        now_usage = self._read_cgroup_cpu_usage()
+        now_ts = time.monotonic()
+
+        diff_usage = now_usage - self._last_usage
+        diff_usage_s = diff_usage / self.NSEC_PER_SEC
+        diff_ts = now_ts - self._last_ts
+
+        self._logger.debug(
+            f"CPU usage this cycle: {diff_usage_s:.3f}"
+            f" seconds {diff_usage_s / diff_ts * 100:.2f}% ({diff_usage} cgroup time)"
+        )
+
+        self._last_usage = now_usage
+        self._last_ts = now_ts
+
+    def log_run(self):
+        if not self._enabled:
+            return
+
+        total_usage = self._read_cgroup_cpu_usage()
+        total_usage_s = total_usage / self.NSEC_PER_SEC
+        total_ts = time.time() - psutil.Process().create_time()  # uptime of this process
+
+        self._logger.debug(
+            f"Total CPU usage this run: {total_usage / self.NSEC_PER_SEC:.3f} seconds"
+            f" {total_usage_s / total_ts * 100:.2f}% ({total_usage} cgroup time)"
+        )


### PR DESCRIPTION
## Description
Add `--log-cpu-usage` which prints the CPU usage (as measured by cgroups) of each profiling session, and also when gProfiler exits.

## Motivation and Context
To allow us to measure optimizations & check for regressions.

## How Has This Been Tested?
Ran it locally and verified the numbers make sense. Also ran `yes > /dev/null` alongside in the container, and this pumps the reported value.

## Checklist:
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
