### PR TITLE
Add an option to use the legacy profile upload API

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ gProfiler can be run in a continuous mode, profiling periodically, using the `--
 Note that when using `--continuous` with `--output-dir`, a new file will be created during *each* sampling interval.
 Aggregations are only available when uploading to the Granulate Performance Studio.
 
-
 ## Running as a Docker container
 Run the following to have gProfiler running continuously, uploading to Granulate Performance Studio:
 ```bash

--- a/README.md
+++ b/README.md
@@ -85,8 +85,6 @@ gProfiler can be run in a continuous mode, profiling periodically, using the `--
 Note that when using `--continuous` with `--output-dir`, a new file will be created during *each* sampling interval.
 Aggregations are only available when uploading to the Granulate Performance Studio.
 
-### Legacy profile upload mode
-In some cases, using the old V1 profile upload endpoint is useful. If that's the case, you may use the `--legacy-profile-api-version v1` flag to enable the legacy mode.
 
 ## Running as a Docker container
 Run the following to have gProfiler running continuously, uploading to Granulate Performance Studio:

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ gProfiler can be run in a continuous mode, profiling periodically, using the `--
 Note that when using `--continuous` with `--output-dir`, a new file will be created during *each* sampling interval.
 Aggregations are only available when uploading to the Granulate Performance Studio.
 
+### Legacy profile upload mode
+In some cases, using the old V1 profile upload endpoint is useful. If that's the case, you may use the `--legacy-profile-api-version v1` flag to enable the legacy mode.
+
 ## Running as a Docker container
 Run the following to have gProfiler running continuously, uploading to Granulate Performance Studio:
 ```bash

--- a/gprofiler/client.py
+++ b/gprofiler/client.py
@@ -118,7 +118,7 @@ class APIClient:
         end_time: datetime.datetime,
         profile: str,
         total_samples: int,
-        legacy_profile_api_version: Optional[str],
+        profile_api_version: Optional[str],
     ) -> Dict:
         return self.post(
             "profiles",
@@ -129,6 +129,6 @@ class APIClient:
                 "profile": profile,
             },
             timeout=self._upload_timeout,
-            api_version="v2" if legacy_profile_api_version is None else legacy_profile_api_version,
+            api_version="v2" if profile_api_version is None else profile_api_version,
             params={"samples": str(total_samples), "version": __version__},
         )

--- a/gprofiler/client.py
+++ b/gprofiler/client.py
@@ -113,7 +113,12 @@ class APIClient:
         return self.get("health_check")
 
     def submit_profile(
-        self, start_time: datetime.datetime, end_time: datetime.datetime, profile: str, total_samples: int
+        self,
+        start_time: datetime.datetime,
+        end_time: datetime.datetime,
+        profile: str,
+        total_samples: int,
+        legacy_profile_api_version: Optional[str],
     ) -> Dict:
         return self.post(
             "profiles",
@@ -124,6 +129,6 @@ class APIClient:
                 "profile": profile,
             },
             timeout=self._upload_timeout,
-            api_version="v2",
+            api_version="v2" if legacy_profile_api_version is None else legacy_profile_api_version,
             params={"samples": str(total_samples), "version": __version__},
         )

--- a/gprofiler/merge.py
+++ b/gprofiler/merge.py
@@ -209,8 +209,8 @@ def _parse_perf_script(script: Optional[str]) -> ProcessToStackSampleCounters:
     return pid_to_collapsed_stacks_counters
 
 
-def _make_profile_metadata(docker_client: Optional[DockerClient]) -> str:
-    if docker_client is not None:
+def _make_profile_metadata(docker_client: Optional[DockerClient], add_container_names: bool) -> str:
+    if docker_client is not None and add_container_names:
         container_names = docker_client.container_names
         docker_client.reset_cache()
         enabled = True
@@ -227,13 +227,14 @@ def _make_profile_metadata(docker_client: Optional[DockerClient]) -> str:
     )
 
 
-def _get_container_name(pid: int, docker_client: Optional[DockerClient]):
-    return docker_client.get_container_name(pid) if docker_client is not None else ""
+def _get_container_name(pid: int, docker_client: Optional[DockerClient], add_container_names: bool):
+    return docker_client.get_container_name(pid) if add_container_names and docker_client is not None else ""
 
 
 def concatenate_profiles(
     process_profiles: ProcessToStackSampleCounters,
     docker_client: Optional[DockerClient],
+    add_container_names: bool,
 ) -> Tuple[str, int]:
     """
     Concatenate all stacks from all stack mappings in process_profiles.
@@ -245,12 +246,12 @@ def concatenate_profiles(
     lines = []
 
     for pid, stacks in process_profiles.items():
-        container_name = _get_container_name(pid, docker_client)
+        container_name = _get_container_name(pid, docker_client, add_container_names)
         for stack, count in stacks.items():
             total_samples += count
-            lines.append(f"{container_name};{stack} {count}")
+            lines.append(f"{container_name + ';' if add_container_names else ''}{stack} {count}")
 
-    lines.insert(0, _make_profile_metadata(docker_client))
+    lines.insert(0, _make_profile_metadata(docker_client, add_container_names))
     return "\n".join(lines), total_samples
 
 
@@ -258,6 +259,7 @@ def merge_profiles(
     perf_pid_to_stacks_counter: ProcessToStackSampleCounters,
     process_profiles: ProcessToStackSampleCounters,
     docker_client: Optional[DockerClient],
+    add_container_names: bool,
 ) -> Tuple[str, int]:
     # merge process profiles into the global perf results.
     for pid, stacks in process_profiles.items():
@@ -283,4 +285,4 @@ def merge_profiles(
         # swap them: use the samples from the runtime profiler.
         perf_pid_to_stacks_counter[pid] = stacks
 
-    return concatenate_profiles(perf_pid_to_stacks_counter, docker_client)
+    return concatenate_profiles(perf_pid_to_stacks_counter, docker_client, add_container_names)


### PR DESCRIPTION
Because the legacy V1 profile upload method is still useful in some scenarios, I've added the option to use a new gProfiler with the legacy endpoint. 

## Description
I've added the new `--legacy-profile-api-version` option, which currently supports the `V1` value. If this option is enabled, then the gProfiler will not get the container names of stacks and each line in the profile content will not begin with the `;` character. In addition, the `client` will use the `V1` API endpoint when uploading profiles.

## Related Issue
<!--- If there's an issue related, please link it here -->
<!--- If suggesting a new feature or a medium/big change, please discuss it in an issue first. -->
<!--- For small changes, it's okay to open a PR immediately. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What does it improve? -->

## How Has This Been Tested?
Ran the gProfiler with and without the new option. I've made sure that the correct API endpoint is used, and the profile content is as expected.

## Screenshots
<!--- (if appropriate) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
