### PR TITLE
Add timeout to py-spy run

### DIFF
--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -35,7 +35,7 @@ logger = get_logger_adapter(__name__)
 class PySpyProfiler(ProcessProfilerBase):
     MAX_FREQUENCY = 50
     _BLACKLISTED_PYTHON_PROCS = ["unattended-upgrades", "networkd-dispatcher", "supervisord", "tuned"]
-    _EXTRA_TIMEOUT = 5  # give py-spy 5 seconds to run (added to the duration)
+    _EXTRA_TIMEOUT = 10  # give py-spy some seconds to run (added to the duration)
 
     def _make_command(self, pid: int, output_path: str):
         return [

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -6,7 +6,7 @@ import glob
 import os
 import signal
 from pathlib import Path
-from subprocess import Popen
+from subprocess import Popen, TimeoutExpired
 from threading import Event
 from typing import List, Optional
 
@@ -34,7 +34,8 @@ logger = get_logger_adapter(__name__)
 
 class PySpyProfiler(ProcessProfilerBase):
     MAX_FREQUENCY = 50
-    BLACKLISTED_PYTHON_PROCS = ["unattended-upgrades", "networkd-dispatcher", "supervisord", "tuned"]
+    _BLACKLISTED_PYTHON_PROCS = ["unattended-upgrades", "networkd-dispatcher", "supervisord", "tuned"]
+    _EXTRA_TIMEOUT = 5  # give py-spy 5 seconds to run (added to the duration)
 
     def _make_command(self, pid: int, output_path: str):
         return [
@@ -62,9 +63,17 @@ class PySpyProfiler(ProcessProfilerBase):
 
         local_output_path = os.path.join(self._storage_dir, f"pyspy.{random_prefix()}.{process.pid}.col")
         try:
-            run_process(self._make_command(process.pid, local_output_path), stop_event=self._stop_event)
+            run_process(
+                self._make_command(process.pid, local_output_path),
+                stop_event=self._stop_event,
+                timeout=self._duration + self._EXTRA_TIMEOUT,
+                kill_signal=signal.SIGINT,
+            )
         except ProcessStoppedException:
             raise StopEventSetException
+        except TimeoutExpired:
+            logger.error(f"Profiling with py-spy timed out on process {process.pid}")
+            raise
 
         logger.info(f"Finished profiling process {process.pid} with py-spy")
         return parse_and_remove_one_collapsed(Path(local_output_path), comm)
@@ -79,7 +88,7 @@ class PySpyProfiler(ProcessProfilerBase):
                     continue
 
                 cmdline = process.cmdline()
-                if any(item in cmdline for item in self.BLACKLISTED_PYTHON_PROCS):
+                if any(item in cmdline for item in self._BLACKLISTED_PYTHON_PROCS):
                     continue
 
                 # PyPy is called pypy3 or pypy (for 2)

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -13,6 +13,7 @@ import platform
 import random
 import re
 import shutil
+import signal
 import socket
 import string
 import subprocess
@@ -146,13 +147,16 @@ def run_process(
     suppress_log: bool = False,
     via_staticx: bool = False,
     check: bool = True,
+    timeout: int = None,
+    kill_signal: signal.Signals = signal.SIGKILL,
     **kwargs,
 ) -> CompletedProcess:
     with start_process(cmd, via_staticx, **kwargs) as process:
         try:
             if stop_event is None:
-                stdout, stderr = process.communicate()
+                stdout, stderr = process.communicate(timeout=timeout)
             else:
+                end_time = (time.monotonic() + timeout) if timeout is not None else None
                 while True:
                     try:
                         stdout, stderr = process.communicate(timeout=1)
@@ -160,8 +164,11 @@ def run_process(
                     except TimeoutExpired:
                         if stop_event.is_set():
                             raise ProcessStoppedException from None
+                        if end_time is not None and time.monotonic() > end_time:
+                            assert timeout is not None
+                            raise TimeoutExpired(cmd, timeout) from None
         except:  # noqa
-            process.kill()
+            process.send_signal(kill_signal)
             process.wait()
             raise
         retcode = process.poll()


### PR DESCRIPTION
# Description
Adds timeouts to `run_process()` and use them when running py-spy, because we've seen py-spy hanging already.

Later on we can add timeouts to other executions of processes in gProfiler.

## Motivation and Context
Prevent py-spy hangs from hanging gProfiler entirely.

## How Has This Been Tested?
I changed `timeout=self._duration + self._EXTRA_TIMEOUT` to `timeout=self._duration - self._EXTRA_TIMEOUT` and all py-spys failed with proper error.

The CI will test the usual case of no timeout.

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
