### PR TITLE
java: Add buildids option to async-profiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ For each profiling session (each profiling duration), gProfiler produces outputs
 ### Java profiling options
 
 * `--no-java` or `--java-mode disabled`: Disable profilers for Java.
+* `--no-java-async-profiler-buildids`: Disable embedding of buildid+offset in async-profiler native frames.
 
 ### Python profiling options
 * `--no-python`: Alias of `--python-mode disabled`.

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -99,6 +99,7 @@ class GProfiler:
         dwarf_stack_size: int,
         python_mode: str,
         pyperf_user_stacks_pages: Optional[int],
+        java_async_profiler_buildids: bool,
         runtimes: Dict[str, bool],
         client: APIClient,
         state: State,
@@ -128,7 +129,13 @@ class GProfiler:
         self._temp_storage_dir = TemporaryDirectoryWithMode(dir=TEMPORARY_STORAGE_PATH, mode=0o755)
         self.java_profiler = create_profiler_or_noop(
             self._runtimes,
-            lambda: JavaProfiler(self._frequency, self._duration, self._stop_event, self._temp_storage_dir.name),
+            lambda: JavaProfiler(
+                self._frequency,
+                self._duration,
+                self._stop_event,
+                self._temp_storage_dir.name,
+                java_async_profiler_buildids,
+            ),
             "java",
         )
         self.system_profiler = create_profiler_or_noop(
@@ -671,6 +678,7 @@ def main():
             args.dwarf_stack_size,
             args.python_mode,
             args.pyperf_user_stacks_pages,
+            args.java_async_profiler_buildids,
             runtimes,
             client,
             state,

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -17,7 +17,7 @@ from gprofiler.exceptions import CalledProcessError, StopEventSetException
 from gprofiler.log import get_logger_adapter
 from gprofiler.merge import parse_one_collapsed
 from gprofiler.profilers.profiler_base import ProcessProfilerBase
-from gprofiler.profilers.registry import register_profiler
+from gprofiler.profilers.registry import ProfilerArgument, register_profiler
 from gprofiler.types import StackToSampleCount
 from gprofiler.utils import (
     TEMPORARY_STORAGE_PATH,
@@ -71,7 +71,7 @@ class AsyncProfiledProcess:
     OUTPUT_FORMAT = "collapsed"
     OUTPUTS_MODE = 0o622  # readable by root, writable by all
 
-    def __init__(self, process: Process, storage_dir: str):
+    def __init__(self, process: Process, storage_dir: str, buildids: bool):
         self.process = process
         self._process_root = f"/proc/{process.pid}/root"
         # not using storage_dir for AP itself on purpose: this path should remain constant for the lifetime
@@ -95,6 +95,8 @@ class AsyncProfiledProcess:
         self._output_path_process = remove_prefix(self._output_path_host, self._process_root)
         self._log_path_host = os.path.join(self._storage_dir_host, f"async-profiler-{self.process.pid}.log")
         self._log_path_process = remove_prefix(self._log_path_host, self._process_root)
+
+        self._buildids = buildids
 
     def __enter__(self):
         os.makedirs(self._ap_dir_host, 0o755, exist_ok=True)
@@ -176,7 +178,8 @@ class AsyncProfiledProcess:
     def _get_start_cmd(self, interval: int) -> List[str]:
         return self._get_base_cmd() + [
             f"start,event={self.AP_EVENT_TYPE},file={self._output_path_process},{self.OUTPUT_FORMAT},"
-            f"{self.FORMAT_PARAMS},interval={interval},framebuf=2000000,log={self._log_path_process}",
+            f"{self.FORMAT_PARAMS},interval={interval},framebuf=2000000,log={self._log_path_process}"
+            f"{',buildids' if self._buildids else ''}",
         ]
 
     def _get_stop_cmd(self, with_output: bool) -> List[str]:
@@ -240,15 +243,30 @@ class AsyncProfiledProcess:
             raise
 
 
-@register_profiler("Java", possible_modes=["ap", "disabled"], default_mode="ap")
+@register_profiler(
+    "Java",
+    possible_modes=["ap", "disabled"],
+    default_mode="ap",
+    profiler_arguments=[
+        ProfilerArgument(
+            "--no-java-async-profiler-buildids",
+            dest="java_async_profiler_buildids",
+            action="store_false",
+            help="Do not embed buildid+offset in async-profiler native frames (by default, they are added)."
+            " The added buildid+offset can be resolved & symbolicated in the Performance Studio."
+            " This is useful if debug symbols are unavailable for the relevant DSOs (libjvm, libc, ...).",
+        ),
+    ],
+)
 class JavaProfiler(ProcessProfilerBase):
     JDK_EXCLUSIONS = ["OpenJ9", "Zing"]
 
-    def __init__(self, frequency: int, duration: int, stop_event: Event, storage_dir: str):
+    def __init__(self, frequency: int, duration: int, stop_event: Event, storage_dir: str, buildids: bool):
         super().__init__(frequency, duration, stop_event, storage_dir)
 
         # async-profiler accepts interval between samples (nanoseconds)
         self._interval = int((1 / frequency) * 1000_000_000)
+        self._buildids = buildids
 
     def _is_jdk_version_supported(self, java_version_cmd_output: str) -> bool:
         return all(exclusion not in java_version_cmd_output for exclusion in self.JDK_EXCLUSIONS)
@@ -305,7 +323,7 @@ class JavaProfiler(ProcessProfilerBase):
                 logger.warning(f"Process {process.pid} running unsupported Java version, skipping...")
                 return None
 
-        with AsyncProfiledProcess(process, self._storage_dir) as ap_proc:
+        with AsyncProfiledProcess(process, self._storage_dir, self._buildids) as ap_proc:
             return self._profile_ap_process(ap_proc)
 
     def _profile_ap_process(self, ap_proc: AsyncProfiledProcess) -> Optional[StackToSampleCount]:

--- a/scripts/async_profiler_build.sh
+++ b/scripts/async_profiler_build.sh
@@ -5,8 +5,8 @@
 #
 set -euo pipefail
 
-VERSION=v2.0g4
-GIT_REV=9d29169e34abc004f534a85ba6a4cf8920250381
+VERSION=granulate
+GIT_REV=dc26d9311fd4af3a51ee6516701d6d4edc7e82e1
 OUTPUT=async-profiler-2.0-linux-x64.tar.gz
 
 git clone --depth 1 -b "$VERSION" https://github.com/Granulate/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -75,7 +75,7 @@ def test_java_async_profiler_stopped(
 
     # run "status"
     proc = psutil.Process(application_pid)
-    with AsyncProfiledProcessForTests(proc, tmp_path) as ap_proc:
+    with AsyncProfiledProcessForTests(proc, tmp_path, False) as ap_proc:
         ap_proc.status_async_profiler()
     # printed the process' stdout, see ACTION_STATUS case in async-profiler/profiler.cpp
     expected_message = b"Profiling is running for "

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -26,7 +26,7 @@ def test_java_from_host(
     application_pid: int,
     assert_collapsed,
 ) -> None:
-    with JavaProfiler(1000, 1, Event(), str(tmp_path)) as profiler:
+    with JavaProfiler(1000, 1, Event(), str(tmp_path), False) as profiler:
         process_collapsed = profiler.snapshot().get(application_pid)
         assert_collapsed(process_collapsed, check_comm=True)
 


### PR DESCRIPTION
## Description
See https://github.com/Granulate/async-profiler/pull/1 for the AP PR.

By default, AP native stacks will embed the buildid+offset. The Performance Studio will then try to find the relevant binary, and attach proper symbol names.

This can be disabled with `--no-java-async-profiler-buildids`.

## Motivation and Context
Have proper symbols in stacks whether or not the environment has debug symbols installed.

## How Has This Been Tested?
Ran Java in an environment with no debug symbols (so AP resorts to showing the DSO name).

* Running this version with no extra flags - output flamegraph has the buildid+offset attached.
* Running this version with `--no-java-async-profiler-buildids` - no buildid+offset.

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
- [ ] Add tests?
- [ ] Merge the AP PR
- [ ] Add support in the backend before merging this
