### PR TITLE
python: pyperf: Automatically fix up numerous output-files situations

### DIFF
--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -243,8 +243,11 @@ class PythonEbpfProfiler(ProfilerBase):
         if self._stop_event.wait(self._duration):
             raise StopEventSetException()
         collapsed_path = self._dump()
-        collapsed_text = collapsed_path.read_text()
-        collapsed_path.unlink()
+        try:
+            collapsed_text = collapsed_path.read_text()
+        finally:
+            # always remove, even if we get read/decode errors
+            collapsed_path.unlink()
         return parse_many_collapsed(collapsed_text)
 
     def _terminate(self) -> Optional[int]:

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -148,6 +148,7 @@ def wait_for_file_by_prefix(prefix: str, timeout: float, stop_event: Event) -> P
             f"One output file expected, but found {len(output_files)}."
             f" Removing all and using the last one. {output_files}"
         )
+        # timestamp format guarantees alphabetical order == chronological order.
         output_files.sort()
         for f in output_files[:-1]:
             os.unlink(f)

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -137,7 +137,22 @@ def wait_for_file_by_prefix(prefix: str, timeout: float, stop_event: Event) -> P
 
     output_files = glob.glob(glob_pattern)
     # All the snapshot samples should be in one file
-    assert len(output_files) == 1, "expected single file but got: " + str(output_files)
+    if len(output_files) != 1:
+        # this can happen if:
+        # * the profiler generating those files is erroneous
+        # * the profiler received many signals (and it generated files based on signals)
+        # * errors in gProfiler led to previous output fails remain not removed
+        # in any case, we remove all old files, and assume the last one (after sorting by timestamp)
+        # is the one we want.
+        logger.warning(
+            f"One output file expected, but found {len(output_files)}."
+            f" Removing all and using the last one. {output_files}"
+        )
+        output_files.sort()
+        for f in output_files[:-1]:
+            os.unlink(f)
+        output_files = output_files[-1:]
+
     return Path(output_files[0])
 
 


### PR DESCRIPTION
## Description
We used to bail out on this case (that `assert`).
If it ever happens, for whatever reason, it will continue happening forever for that invocation of gProfiler, because we don't take care of it and just keep bailing out on every iteration.

This has 2 parts:
* Always remove the output file, even if reading / decoding of it fails.
* If numerous output files are found, remove all and use the last.

I saw it triggered by a `UnicodeDecodeError` inside `read_text`. This PR, of course, does not solve that issue, but only attempts to fix up profiling in case that issue was only a one-timer.

## Motivation and Context
Automatically fix up the described error case, without user intervention/restart.

## How Has This Been Tested?
T.B.A

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
