### PR TITLE
Differentiate between "lock taken" and "error while trying to take the lock"

### DIFF
--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -553,7 +553,6 @@ def verify_preconditions(args):
         sys.exit(1)
 
     if not grab_gprofiler_mutex():
-        print("Could not acquire gProfiler's lock. Is it already running?", file=sys.stderr)
         sys.exit(1)
 
     if args.log_cpu_usage and get_run_mode() not in ("k8s", "container"):

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -406,7 +406,10 @@ def grab_gprofiler_mutex() -> bool:
     res = run_in_ns(["net"], _take_lock)
     if res is None:
         # exception in run_in_ns
-        print("Could not acquire gProfiler's lock due to an error. Are you running gProfiler in privileged mode?")
+        print(
+            "Could not acquire gProfiler's lock due to an error. Are you running gProfiler in privileged mode?",
+            file=sys.stderr,
+        )
         return False
     elif res[0]:
         assert res[1] is not None

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -386,7 +386,7 @@ def grab_gprofiler_mutex() -> bool:
     """
     GPROFILER_LOCK = "\x00gprofiler_lock"
 
-    def _take_lock() -> Tuple[bool, Optional[socket.socket]]:  # like Rust's Result :(
+    def _take_lock() -> Tuple[bool, Optional[socket.socket]]:  # like Rust's Result<Option> :(
         s = socket.socket(socket.AF_UNIX)
 
         try:

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -419,7 +419,11 @@ def grab_gprofiler_mutex() -> bool:
         gprofiler_mutex = res[1]
         return True
     else:
-        print("Could not acquire gProfiler's lock. Is it already running?", file=sys.stderr)
+        print(
+            "Could not acquire gProfiler's lock. Is it already running?"
+            " Try 'sudo netstat -xp | grep gprofiler' to see which process holds the lock.",
+            file=sys.stderr,
+        )
         return False
 
 


### PR DESCRIPTION
## Description
Errors while trying to take the lock are common (well, now it's the first "privileged" thing we're trying to do).

Running as a container w/o `--privileged` currently yields:
```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/app/gprofiler/utils.py", line 362, in _switch_and_run
    if not is_same_ns(target_pid, nstype):
  File "/app/gprofiler/utils.py", line 291, in is_same_ns
    return os.stat(f"/proc/self/ns/{nstype}").st_ino == os.stat(f"/proc/{pid}/ns/{nstype}").st_ino
PermissionError: [Errno 13] Permission denied: '/proc/1/ns/net'
Could not acquire gProfiler's lock. Is it already running?
```

The exception is not very clear, and the message "is it already running" doesn't help.

After this PR:
```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/app/gprofiler/utils.py", line 355, in _switch_and_run
    if not is_same_ns(target_pid, nstype):
  File "/app/gprofiler/utils.py", line 317, in is_same_ns
    return os.stat(f"/proc/self/ns/{nstype}").st_ino == os.stat(f"/proc/{pid}/ns/{nstype}").st_ino
PermissionError: [Errno 13] Permission denied: '/proc/1/ns/net'
Could not acquire gProfiler's lock due to an error. Are you running gProfiler in privileged mode?
```

Better.

## Motivation and Context
Better UX on errors

## How Has This Been Tested?
Tested w/o `--privileged` and verified the exception is as I showed above.
Tested w/ `--privileged` and ran 2 profilers - I get the old `Could not acquire gProfiler's lock. Is it already running?` correctly.

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
