### PR TITLE
bugfix: gProfiler excessive restarts when run in a container and failing to grab the mutex

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Aggregations are only available when uploading to the Granulate Performance Stud
 Run the following to have gProfiler running continuously, uploading to Granulate Performance Studio:
 ```bash
 docker pull granulate/gprofiler:latest
-docker run --name gprofiler -d --restart=always \
+docker run --name gprofiler -d --restart=on-failure:10 \
     --pid=host --userns=host --privileged \
     -v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro \
     -v /var/run/docker.sock:/var/run/docker.sock \

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -554,7 +554,7 @@ def verify_preconditions(args):
         sys.exit(1)
 
     if not grab_gprofiler_mutex():
-        sys.exit(1)
+        sys.exit(0)
 
     if args.log_usage and get_run_mode() not in ("k8s", "container"):
         # TODO: we *can* move into another cpuacct cgroup, to let this work also when run as a standalone


### PR DESCRIPTION
Change exit code to 0 when failing to grab the mutex. This help gprofiler container avoid
excessive restarts when running using K8s or docker

## Description
Exiting with exit code 0 when failing to grab the mutex. 

## Checklist:
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
