### PR TITLE
Use "granulate-gprofiler" as container name

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Aggregations are only available when uploading to the Granulate Performance Stud
 Run the following to have gProfiler running continuously, uploading to Granulate Performance Studio:
 ```bash
 docker pull granulate/gprofiler:latest
-docker run --name gprofiler -d --restart=always \
+docker run --name granulate-gprofiler -d --restart=always \
     --pid=host --userns=host --privileged \
     -v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro \
     -v /var/run/docker.sock:/var/run/docker.sock \

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   gprofiler:
     image: granulate/gprofiler:latest
     restart: always
-    container_name: "gprofiler"
+    container_name: "granulate-gprofiler"
     pid: "host"
     userns_mode: "host"
     privileged: true

--- a/deploy/k8s/gprofiler.yaml
+++ b/deploy/k8s/gprofiler.yaml
@@ -35,7 +35,7 @@ spec:
         runAsGroup: 0
       restartPolicy: Always
       containers:
-        - name: gprofiler
+        - name: granulate-gprofiler
           securityContext:
             privileged: true
           resources:


### PR DESCRIPTION
Better than just "gprofiler".