### PR TITLE
Use /proc/pid/comm as the first stack of process profiles

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -23,6 +23,7 @@ from gprofiler.utils import (
     TEMPORARY_STORAGE_PATH,
     get_process_nspid,
     pgrep_maps,
+    process_comm,
     remove_path,
     remove_prefix,
     resolve_proc_root_links,
@@ -351,8 +352,6 @@ class JavaProfiler(ProcessProfilerBase):
                     f"async-profiler is still running in {ap_proc.process.pid}, even after trying to stop it!"
                 )
 
-        comm = ap_proc.process.name()
-
         self._stop_event.wait(self._duration)
 
         if ap_proc.process.is_running():
@@ -374,7 +373,7 @@ class JavaProfiler(ProcessProfilerBase):
             return None
         else:
             logger.info(f"Finished profiling process {ap_proc.process.pid}")
-            return parse_one_collapsed(output, comm)
+            return parse_one_collapsed(output, process_comm(ap_proc.process))
 
     def _select_processes_to_profile(self) -> List[Process]:
         return pgrep_maps(r"^.+/libjvm\.so$")

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -21,6 +21,7 @@ from gprofiler.profilers.registry import ProfilerArgument, register_profiler
 from gprofiler.utils import (
     pgrep_maps,
     poll_process,
+    process_comm,
     random_prefix,
     resource_path,
     run_process,
@@ -60,7 +61,6 @@ class PySpyProfiler(ProcessProfilerBase):
     def _profile_process(self, process: Process) -> Optional[StackToSampleCount]:
         try:
             logger.info(f"Profiling process {process.pid}", cmdline=process.cmdline(), no_extra_to_server=True)
-            comm = process.name()
         except NoSuchProcess:
             return None
 
@@ -87,7 +87,7 @@ class PySpyProfiler(ProcessProfilerBase):
             raise
 
         logger.info(f"Finished profiling process {process.pid} with py-spy")
-        return parse_and_remove_one_collapsed(Path(local_output_path), comm)
+        return parse_and_remove_one_collapsed(Path(local_output_path), process_comm(process))
 
     def _select_processes_to_profile(self) -> List[Process]:
         filtered_procs = []

--- a/gprofiler/profilers/ruby.py
+++ b/gprofiler/profilers/ruby.py
@@ -15,7 +15,7 @@ from gprofiler.log import get_logger_adapter
 from gprofiler.merge import parse_and_remove_one_collapsed
 from gprofiler.profilers.profiler_base import ProcessProfilerBase
 from gprofiler.profilers.registry import register_profiler
-from gprofiler.utils import pgrep_maps, random_prefix, resource_path, run_process
+from gprofiler.utils import pgrep_maps, process_comm, random_prefix, resource_path, run_process
 
 logger = get_logger_adapter(__name__)
 
@@ -51,7 +51,6 @@ class RbSpyProfiler(ProcessProfilerBase):
 
     def _profile_process(self, process: Process) -> StackToSampleCount:
         logger.info(f"Profiling process {process.pid}", cmdline=' '.join(process.cmdline()), no_extra_to_server=True)
-        comm = process.name()
 
         local_output_path = os.path.join(self._storage_dir, f"rbspy.{random_prefix()}.{process.pid}.col")
         try:
@@ -60,7 +59,7 @@ class RbSpyProfiler(ProcessProfilerBase):
             raise StopEventSetException
 
         logger.info(f"Finished profiling process {process.pid} with rbspy")
-        return parse_and_remove_one_collapsed(Path(local_output_path), comm)
+        return parse_and_remove_one_collapsed(Path(local_output_path), process_comm(process))
 
     def _select_processes_to_profile(self) -> List[Process]:
         return pgrep_maps(r"(?:^.+/ruby[^/]*$)")

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -484,3 +484,10 @@ def limit_frequency(limit: Optional[int], requested: int, msg_header: str, runti
 
 def random_prefix() -> str:
     return ''.join(random.choice(string.ascii_letters) for _ in range(16))
+
+
+def process_comm(process: Process) -> str:
+    comm = Path(f"/proc/{process.pid}/comm").read_text()
+    # the kernel always adds \n
+    assert comm.endswith('\n'), f"unexpected comm: {comm!r}"
+    return comm[:-1]


### PR DESCRIPTION
## Description
psutil.Process.name() seems to get it from /proc/pid/stat, but it returns
very long strings (over the 16 bytes of comm) so it doesn't make sense. It seems like
its return value is the first entry from /proc/pid/cmdline.

Anyway, we'll just get /proc/pid/comm to be accurate with what "perf" gets.

@DanielShaulov , I think it's better than `basename(readlink(/proc/pid/exe))` because it maintains consistency with perf.

## Motivation and Context
Consistency with perf + avoid overly long strings.

## How Has This Been Tested?
- [x] I'll `ln -s $(which python) aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` and make sure that the name is capped at 16, while previously it wasn't.

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
