### PR TITLE
php: Log stderr & stdout if startup fails

### DIFF
--- a/gprofiler/profilers/php.py
+++ b/gprofiler/profilers/php.py
@@ -100,6 +100,8 @@ class PHPSpyProfiler(ProfilerBase):
             wait_event(self.poll_timeout, self._stop_event, lambda: os.path.exists(self._output_path))
         except TimeoutError:
             process.kill()
+            assert process.stdout is not None and process.stderr is not None
+            logger.error(f"phpspy failed to start. stdout {process.stdout.read()!r} stderr {process.stderr.read()!r}")
             raise
         else:
             self._process = process


### PR DESCRIPTION
## Description
Provides information on why `phpspy`'s startup has failed.

## How Has This Been Tested?
```
diff --git a/gprofiler/profilers/php.py b/gprofiler/profilers/php.py
index eaa0012..f758952 100644
--- a/gprofiler/profilers/php.py
+++ b/gprofiler/profilers/php.py
@@ -92,7 +92,7 @@ class PHPSpyProfiler(ProfilerBase):
         phpspy_dir = os.path.dirname(phpspy_path)
         env = os.environ.copy()
         env["PATH"] = f"{env.get('PATH')}:{phpspy_dir}"
-        process = start_process(cmd, env=env, via_staticx=False)
+        process = start_process(["bash", "-c", "echo blaa && exit 1"], env=env, via_staticx=False)
         # Executing phpspy, expecting the output file to be created, phpspy creates it at bootstrap after argument
         # parsing.
         # If an error occurs after this stage it's probably a spied _process specific and not phpspy general error.
```
then
```
[2021-08-22 22:38:51,184] INFO: gprofiler.profilers.php: Starting profiling of PHP processes with phpspy
[2021-08-22 22:38:51,185] DEBUG: gprofiler.utils: Running command: (bash -c echo blaa && exit 1)
[2021-08-22 22:39:01,228] ERROR: gprofiler.profilers.php: phpspy failed to start. stdout b'blaa\n' stderr b''
[2021-08-22 22:39:01,229] ERROR: gprofiler: Unexpected error occurred
Traceback (most recent call last):
  File "/app/gprofiler/main.py", line 667, in main
    gprofiler.run_single()
  File "/app/gprofiler/main.py", line 307, in run_single
    with self:
  File "/app/gprofiler/main.py", line 137, in __enter__
    self.start()
  File "/app/gprofiler/main.py", line 208, in start
    prof.start()
  File "/app/gprofiler/profilers/php.py", line 100, in start
    wait_event(self.poll_timeout, self._stop_event, lambda: os.path.exists(self._output_path))
  File "/app/gprofiler/utils.py", line 122, in wait_event
    raise TimeoutError()
TimeoutError
```

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
