### PR TITLE
Continue if the start() method of any profiler fails (and avoid using it)

### DIFF
--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -214,7 +214,7 @@ class GProfiler:
                     raise
 
                 # others - are ignored, with a warning.
-                logger.warn(f"Failed to start {prof.__class__.__name__}, continuing without it")
+                logger.warning(f"Failed to start {prof.__class__.__name__}, continuing without it")
                 self.process_profilers.remove(prof)
 
     def stop(self):

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -204,8 +204,18 @@ class GProfiler:
         self._stop_event.clear()
         self._system_metrics_monitor.start()
 
-        for prof in self.all_profilers:
-            prof.start()
+        for prof in list(self.all_profilers):
+            try:
+                prof.start()
+            except Exception:
+                # the SystemProfiler is handled separately - let the user run with '--perf-mode none' if they
+                # wish so.
+                if prof is self.system_profiler:
+                    raise
+
+                # others - are ignored, with a warning.
+                logger.warn(f"Failed to start {prof.__class__.__name__}, continuing without it")
+                self.process_profilers.remove(prof)
 
     def stop(self):
         logger.info("Stopping ...")


### PR DESCRIPTION
## Description
The title

## Motivation and Context
If initialization of e.g `phpspy` fails, it may be relevant for the user (if they want to profile PHP) and it may not be. More commonly, it won't be, as there are many profilers. So it's best if initialization failures are just logged, instead of hard failing.

## How Has This Been Tested?
```
diff --git a/gprofiler/profilers/php.py b/gprofiler/profilers/php.py
index b7fe39f..47e49fb 100644
--- a/gprofiler/profilers/php.py
+++ b/gprofiler/profilers/php.py
@@ -92,7 +92,7 @@ class PHPSpyProfiler(ProfilerBase):
         phpspy_dir = os.path.dirname(phpspy_path)
         env = os.environ.copy()
         env["PATH"] = f"{env.get('PATH')}:{phpspy_dir}"
-        process = start_process(cmd, env=env, via_staticx=False)
+        process = start_process(["bash", "-c", "echo blaa && exit 1"], env=env, via_staticx=False)
         # Executing phpspy, expecting the output file to be created, phpspy creates it at bootstrap after argument
         # parsing.
         # If an error occurs after this stage it's probably a spied _process specific and not phpspy general error.
```

then

```
[2021-08-22 22:47:58,198] INFO: gprofiler.profilers.php: Starting profiling of PHP processes with phpspy
[2021-08-22 22:47:58,199] DEBUG: gprofiler.utils: Running command: (bash -c echo blaa && exit 1)
[2021-08-22 22:48:08,233] WARNING: gprofiler: Failed to start PHPSpyProfiler, continuing without it
```

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
