### PR TITLE
java: Allow skipping the version check

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -258,8 +258,8 @@ class AsyncProfiledProcess:
         ),
         ProfilerArgument(
             "--java-no-version-check",
-            dest="java_no_version_check",
-            action="store_true",
+            dest="java_version_check",
+            action="store_false",
             help="Skip the JDK version check (that is done before invoking async-profiler)",
         ),
     ],
@@ -274,7 +274,7 @@ class JavaProfiler(ProcessProfilerBase):
         stop_event: Event,
         storage_dir: str,
         java_async_profiler_buildids: bool,
-        java_no_version_check: bool,
+        java_version_check: bool,
         java_mode: str,
     ):
         assert java_mode == "ap", "Java profiler should not be initialized, wrong java_mode value given"
@@ -283,7 +283,7 @@ class JavaProfiler(ProcessProfilerBase):
         # async-profiler accepts interval between samples (nanoseconds)
         self._interval = int((1 / frequency) * 1000_000_000)
         self._buildids = java_async_profiler_buildids
-        self._version_check = not java_no_version_check
+        self._version_check = java_version_check
 
     def _is_jdk_version_supported(self, java_version_cmd_output: str) -> bool:
         return all(exclusion not in java_version_cmd_output for exclusion in self.JDK_EXCLUSIONS)

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -256,6 +256,12 @@ class AsyncProfiledProcess:
             " The added buildid+offset can be resolved & symbolicated in the Performance Studio."
             " This is useful if debug symbols are unavailable for the relevant DSOs (libjvm, libc, ...).",
         ),
+        ProfilerArgument(
+            "--java-no-version-check",
+            dest="java_no_version_check",
+            action="store_true",
+            help="Skip the JDK version check (that is done before invoking async-profiler)",
+        ),
     ],
 )
 class JavaProfiler(ProcessProfilerBase):
@@ -268,6 +274,7 @@ class JavaProfiler(ProcessProfilerBase):
         stop_event: Event,
         storage_dir: str,
         java_async_profiler_buildids: bool,
+        java_no_version_check: bool,
         java_mode: str,
     ):
         assert java_mode == "ap", "Java profiler should not be initialized, wrong java_mode value given"
@@ -276,6 +283,7 @@ class JavaProfiler(ProcessProfilerBase):
         # async-profiler accepts interval between samples (nanoseconds)
         self._interval = int((1 / frequency) * 1000_000_000)
         self._buildids = java_async_profiler_buildids
+        self._version_check = not java_no_version_check
 
     def _is_jdk_version_supported(self, java_version_cmd_output: str) -> bool:
         return all(exclusion not in java_version_cmd_output for exclusion in self.JDK_EXCLUSIONS)
@@ -327,7 +335,7 @@ class JavaProfiler(ProcessProfilerBase):
         # Get Java version
         # TODO we can get the "java" binary by extracting the java home from the libjvm path,
         # then check with that instead (if exe isn't java)
-        if os.path.basename(process.exe()) == "java":
+        if self._version_check and os.path.basename(process.exe()) == "java":
             if not self._is_jdk_version_supported(self._get_java_version(process)):
                 logger.warning(f"Process {process.pid} running unsupported Java version, skipping...")
                 return None

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -26,7 +26,7 @@ def test_java_from_host(
     application_pid: int,
     assert_collapsed,
 ) -> None:
-    with JavaProfiler(1000, 1, Event(), str(tmp_path), False, "ap") as profiler:
+    with JavaProfiler(1000, 1, Event(), str(tmp_path), False, False, "ap") as profiler:
         process_collapsed = profiler.snapshot().get(application_pid)
         assert_collapsed(process_collapsed, check_comm=True)
 


### PR DESCRIPTION
## Description
We've seen it fail, for whatever reasons (e.g invoking via /proc/pid/exe doesn't work).
Such safety checks should be override-able so we can skip them if we know it's okay, but
they fail us.

## How Has This Been Tested?
Ran with `--java-no-version-check` and saw that this line:
```
[2021-08-22 22:59:40,095] DEBUG: gprofiler.utils: Running command: (/proc/40/exe -version)
```
is gone.

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
