### PR TITLE
Simplify async-profiler's build & COPY statements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,9 @@ WORKDIR /app
 # binutils - for phpspy (uses objdump)
 RUN apt-get update && apt-get install --no-install-recommends -y curl python3-pip kmod binutils
 
+COPY scripts/build.sh scripts/build.sh
+RUN ./scripts/build.sh
+
 COPY --from=bcc-builder /bcc/root/share/bcc/examples/cpp/PyPerf gprofiler/resources/python/pyperf/
 # copy licenses and notice file.
 COPY --from=bcc-builder /bcc/bcc/LICENSE.txt gprofiler/resources/python/pyperf/
@@ -89,9 +92,6 @@ RUN tar -xzf /tmp/async-profiler-2.0-linux-x64.tar.gz -C gprofiler/resources/jav
 
 RUN mkdir -p gprofiler/resources/ruby
 COPY --from=rbspy-builder /rbspy/target/x86_64-unknown-linux-musl/release/rbspy gprofiler/resources/ruby/rbspy
-
-COPY scripts/build.sh scripts/build.sh
-RUN ./scripts/build.sh
 
 # done separately from the 'pip3 install -e' below; so we don't reinstall all dependencies on each
 # code change.

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,6 @@ RUN mkdir -p gprofiler/resources/java
 COPY --from=async-profiler-builder /async-profiler/async-profiler-2.0-linux-x64.tar.gz /tmp
 RUN tar -xzf /tmp/async-profiler-2.0-linux-x64.tar.gz -C gprofiler/resources/java --strip-components=2 async-profiler-2.0-linux-x64/build && rm /tmp/async-profiler-2.0-linux-x64.tar.gz
 
-RUN mkdir -p gprofiler/resources/ruby
 COPY --from=rbspy-builder /rbspy/target/x86_64-unknown-linux-musl/release/rbspy gprofiler/resources/ruby/rbspy
 
 # done separately from the 'pip3 install -e' below; so we don't reinstall all dependencies on each

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,9 +86,9 @@ COPY --from=perf-builder /perf gprofiler/resources/perf
 COPY --from=phpspy-builder /phpspy/phpspy gprofiler/resources/php/phpspy
 COPY --from=phpspy-builder /binutils/binutils-2.25/bin/bin/objdump gprofiler/resources/php/objdump
 
-RUN mkdir -p gprofiler/resources/java
-COPY --from=async-profiler-builder /async-profiler/async-profiler-2.0-linux-x64.tar.gz /tmp
-RUN tar -xzf /tmp/async-profiler-2.0-linux-x64.tar.gz -C gprofiler/resources/java --strip-components=2 async-profiler-2.0-linux-x64/build && rm /tmp/async-profiler-2.0-linux-x64.tar.gz
+COPY --from=async-profiler-builder /async-profiler/build/jattach gprofiler/resources/java/jattach
+COPY --from=async-profiler-builder /async-profiler/build/async-profiler-version gprofiler/resources/java/async-profiler-version
+COPY --from=async-profiler-builder /async-profiler/build/libasyncProfiler.so gprofiler/resources/java/libasyncProfiler.so
 
 COPY --from=rbspy-builder /rbspy/target/x86_64-unknown-linux-musl/release/rbspy gprofiler/resources/ruby/rbspy
 

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -121,9 +121,9 @@ COPY --from=phpspy-builder /binutils/binutils-2.25/bin/bin/strings gprofiler/res
 COPY --from=centos:6 /usr/bin/awk gprofiler/resources/php/awk
 COPY --from=centos:6 /usr/bin/xargs gprofiler/resources/php/xargs
 
-RUN mkdir -p gprofiler/resources/java
-COPY --from=async-profiler-builder /async-profiler/async-profiler-2.0-linux-x64.tar.gz /tmp
-RUN tar -xzf /tmp/async-profiler-2.0-linux-x64.tar.gz -C gprofiler/resources/java --strip-components=2 async-profiler-2.0-linux-x64/build && rm /tmp/async-profiler-2.0-linux-x64.tar.gz
+COPY --from=async-profiler-builder /async-profiler/build/jattach gprofiler/resources/java/jattach
+COPY --from=async-profiler-builder /async-profiler/build/async-profiler-version gprofiler/resources/java/async-profiler-version
+COPY --from=async-profiler-builder /async-profiler/build/libasyncProfiler.so gprofiler/resources/java/libasyncProfiler.so
 
 
 COPY gprofiler gprofiler

--- a/scripts/async_profiler_build.sh
+++ b/scripts/async_profiler_build.sh
@@ -7,16 +7,12 @@ set -euo pipefail
 
 VERSION=v2.0g5
 GIT_REV=3f1505bbf4a4ec1575b54804e1fbc7b9f38ad96b
-OUTPUT=async-profiler-2.0-linux-x64.tar.gz
 
 git clone --depth 1 -b "$VERSION" https://github.com/Granulate/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
 set +eu  # this funny script has errors :shrug:
 source scl_source enable devtoolset-7
 set -eu
-make release
+make all
 
 # add a version file to the build directory
-echo -n "$VERSION" > async-profiler-version
-gunzip "$OUTPUT"
-tar -rf "${OUTPUT%.gz}" --transform s,^,async-profiler-2.0-linux-x64/build/, async-profiler-version
-gzip "${OUTPUT%.gz}"
+echo -n "$VERSION" > build/async-profiler-version

--- a/scripts/perf_env.sh
+++ b/scripts/perf_env.sh
@@ -41,7 +41,7 @@ cd /tmp
 curl -L ftp://sourceware.org/pub/elfutils/0.179/elfutils-0.179.tar.bz2 -o elfutils-0.179.tar.bz2
 tar -xf elfutils-0.179.tar.bz2
 pushd elfutils-0.179
-./configure --disable-debuginfod --prefix=/usr && make && make install
+./configure --disable-debuginfod --prefix=/usr && make -j 8 && make install
 popd
 rm -r elfutils-0.179
 rm elfutils-0.179.tar.bz2


### PR DESCRIPTION
Nothing major, just simplify the build script & remove the complex COPY & `tar -xf` lines. Copy only the files we need from the build.