### PR TITLE
Initial Aarch64 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,8 +80,7 @@ FROM ubuntu${GPROFILER_BUILDER_UBUNTU}
 WORKDIR /app
 
 # kmod - for modprobe kheaders if it's available
-# binutils - for phpspy (uses objdump)
-RUN apt-get update && apt-get install --no-install-recommends -y curl python3-pip kmod binutils
+RUN apt-get update && apt-get install --no-install-recommends -y curl python3-pip kmod
 
 COPY scripts/build.sh scripts/build.sh
 RUN ./scripts/build.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,25 @@
-# rust:latest 1.52.1
-# using the same builder for both pyspy and rbspy since they share build dependencies
-FROM rust@sha256:9c106c1222abe1450f45774273f36246ebf257623ed51280dbc458632d14c9fc AS pyspy-rbspy-builder-common
+# these need to be defined before any FROM - otherwise, the ARGs expand to empty strings.
+
+# pyspy & rbspy, using the same builder for both pyspy and rbspy since they share build dependencies - rust:latest 1.52.1
+ARG RUST_BUILDER_VERSION=@sha256:9c106c1222abe1450f45774273f36246ebf257623ed51280dbc458632d14c9fc
+# pyperf - ubuntu 20.04
+ARG PYPERF_BUILDER_UBUNTU=@sha256:cf31af331f38d1d7158470e095b132acd126a7180a54f263d386da88eb681d93
+# perf - ubuntu:16.04
+ARG PERF_BUILDER_UBUNTU=@sha256:d7bb0589725587f2f67d0340edb81fd1fcba6c5f38166639cf2a252c939aa30c
+# phpspy - ubuntu:20.04
+ARG PHPSPY_BUILDER_UBUNTU=@sha256:cf31af331f38d1d7158470e095b132acd126a7180a54f263d386da88eb681d93
+# async-profiler, requires CentOS 6, so the built DSO can be loaded into machines running with old glibc - centos:6
+ARG AP_BUILDER_CENTOS=@sha256:dec8f471302de43f4cfcf82f56d99a5227b5ea1aa6d02fa56344986e1f4610e7
+# gprofiler - ubuntu 20.04
+ARG GPROFILER_BUILDER_UBUNTU=@sha256:cf31af331f38d1d7158470e095b132acd126a7180a54f263d386da88eb681d93
+
+# pyspy & rbspy builder base
+FROM rust${RUST_BUILDER_VERSION} AS pyspy-rbspy-builder-common
 
 COPY scripts/prepare_x86_64-unknown-linux-musl.sh .
 RUN ./prepare_x86_64-unknown-linux-musl.sh
 
+# pyspy
 FROM pyspy-rbspy-builder-common AS pyspy-builder
 COPY scripts/pyspy_build.sh .
 RUN ./pyspy_build.sh
@@ -15,8 +30,7 @@ COPY scripts/rbspy_build.sh .
 RUN ./rbspy_build.sh
 
 # perf
-# ubuntu:16.04
-FROM ubuntu@sha256:d7bb0589725587f2f67d0340edb81fd1fcba6c5f38166639cf2a252c939aa30c AS perf-builder
+FROM ubuntu${PERF_BUILDER_UBUNTU} AS perf-builder
 
 COPY scripts/perf_env.sh .
 RUN ./perf_env.sh
@@ -28,15 +42,16 @@ COPY scripts/perf_build.sh .
 RUN ./perf_build.sh
 
 # pyperf (bcc)
-# ubuntu 20.04
-FROM ubuntu@sha256:cf31af331f38d1d7158470e095b132acd126a7180a54f263d386da88eb681d93 AS bcc-builder
+FROM ubuntu${PYPERF_BUILDER_UBUNTU} AS bcc-builder
 
+COPY scripts/exit_if_not_x86_64.sh .
 RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y git curl build-essential iperf llvm-9-dev libclang-9-dev \
+RUN apt-get install -y git
+RUN . ./exit_if_not_x86_64.sh; DEBIAN_FRONTEND=noninteractive apt-get install -y curl build-essential iperf llvm-9-dev libclang-9-dev \
   cmake python3 flex bison libelf-dev libz-dev liblzma-dev
 
 COPY ./scripts/libunwind_build.sh .
-RUN ./libunwind_build.sh
+RUN . ./exit_if_not_x86_64.sh; ./libunwind_build.sh
 
 WORKDIR /bcc
 
@@ -44,16 +59,15 @@ COPY ./scripts/pyperf_build.sh .
 RUN ./pyperf_build.sh
 
 # phpspy
-# ubuntu:20.04
-FROM ubuntu@sha256:cf31af331f38d1d7158470e095b132acd126a7180a54f263d386da88eb681d93 as phpspy-builder
-RUN apt update && apt install -y git wget make gcc
+FROM ubuntu${PHPSPY_BUILDER_UBUNTU} AS phpspy-builder
+
+COPY scripts/exit_if_not_x86_64.sh .
+RUN . ./exit_if_not_x86_64.sh; apt update && apt install -y git wget make gcc
 COPY scripts/phpspy_build.sh .
 RUN ./phpspy_build.sh
 
 # async-profiler
-# requires CentOS 6, so the built DSO can be loaded into machines running with old glibc.
-# centos:6
-FROM centos@sha256:dec8f471302de43f4cfcf82f56d99a5227b5ea1aa6d02fa56344986e1f4610e7 AS async-profiler-builder
+FROM centos${AP_BUILDER_CENTOS} AS async-profiler-builder
 COPY scripts/async_profiler_env.sh .
 RUN ./async_profiler_env.sh
 COPY scripts/async_profiler_build.sh .
@@ -61,8 +75,7 @@ RUN ./async_profiler_build.sh
 
 
 # the gProfiler image itself, at last.
-# ubuntu 20.04
-FROM ubuntu@sha256:cf31af331f38d1d7158470e095b132acd126a7180a54f263d386da88eb681d93
+FROM ubuntu${GPROFILER_BUILDER_UBUNTU}
 
 WORKDIR /app
 
@@ -72,6 +85,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y curl python3-pi
 
 COPY scripts/build.sh scripts/build.sh
 RUN ./scripts/build.sh
+
+# Aarch64 has no .whl file for psutil - so it's trying to build from source.
+RUN if [ $(uname -m) = "aarch64" ]; then apt-get install -y build-essential python3.8-dev; fi
 
 COPY --from=bcc-builder /bcc/root/share/bcc/examples/cpp/PyPerf gprofiler/resources/python/pyperf/
 # copy licenses and notice file.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ across native programs<sup id="a1">[1](#perf-native)</sup> (includes Golang), Ja
 gProfiler can upload its results to the [Granulate Performance Studio](https://profiler.granulate.io/), which aggregates the results from different instances over different periods of time and can give you a holistic view of what is happening on your entire cluster.
 To upload results, you will have to register and generate a token on the website.
 
-gProfiler runs on Linux.
+gProfiler runs on Linux (on x86_64; Aarch64 support is not complete yet and not all runtime profilers are supported).
 
 ![Granulate Performance Studio example view](https://user-images.githubusercontent.com/58514213/124375504-36b0b200-dcab-11eb-8d64-caf20687a29f.gif)
 
@@ -100,6 +100,8 @@ Note that when using `--continuous` with `--output-dir`, a new file will be crea
 Aggregations are only available when uploading to the Granulate Performance Studio.
 
 ## Running as a Docker container
+Supported both for x86_64 and Aarch64.
+
 Run the following to have gProfiler running continuously, uploading to Granulate Performance Studio:
 ```bash
 docker pull granulate/gprofiler:latest
@@ -115,6 +117,8 @@ For profiling with eBPF, kernel headers must be accessible from within the conta
 The command above mounts both of these directories.
 
 ## Running as an executable
+Supported only on x86_64!
+
 Run the following to have gprofiler running continuously, uploading to Granulate Performance Studio:
 ```bash
 wget https://github.com/Granulate/gprofiler/releases/latest/download/gprofiler
@@ -155,16 +159,16 @@ python3 -m gprofiler [options]
 gProfiler invokes `perf` in system wide mode, collecting profiling data for all running processes.
 Alongside `perf`, gProfiler invokes runtime-specific profilers for processes based on these environments:
 * Java runtimes (version 7+) based on the HotSpot JVM, including the Oracle JDK and other builds of OpenJDK like AdoptOpenJDK and Azul Zulu.
-  * Uses async-profiler.
+  * Uses async-profiler (supports x86_64 and Aarch64)
 * The CPython interpreter, versions 2.7 and 3.5-3.9.
-  * eBPF profiling (based on PyPerf) requires Linux 4.14 or higher; see [Python profiling options](#python-profiling-options) for more info.
-  * If eBPF is not available for whatever reason, py-spy is used.
+  * eBPF profiling (based on PyPerf) requires Linux 4.14 or higher; see [Python profiling options](#python-profiling-options) for more info (currently supports only x86_64).
+  * If eBPF is not available for whatever reason, py-spy is used (currently supports only x86_64).
 * PHP (Zend Engine), versions 7.0-8.0.
-  * Uses [Granulate's fork](https://github.com/Granulate/phpspy/) of the phpspy project.
+  * Uses [Granulate's fork](https://github.com/Granulate/phpspy/) of the phpspy project (currently supports only x86_64).
 * Ruby versions (versions 1.9.1 to 3.0.1)
-  * Uses [Granulate's fork](https://github.com/Granulate/rbspy) of the [rbspy](https://github.com/rbspy/rbspy) profiler.
+  * Uses [Granulate's fork](https://github.com/Granulate/rbspy) of the [rbspy](https://github.com/rbspy/rbspy) profiler (currently supports only x86_64).
 * NodeJS (version >= 10 for functioning `--perf-prof`):
-  * Uses `perf inject --jit` and NodeJS's ability to generate jitdump files. See [NodeJS profiling options](#nodejs-profiling-options).
+  * Uses `perf inject --jit` and NodeJS's ability to generate jitdump files. See [NodeJS profiling options](#nodejs-profiling-options) (supports x86_64 and Aarch64).
 
 The runtime-specific profilers produce stack traces that include runtime information (i.e, stacks of Java/Python functions), unlike `perf` which produces native stacks of the JVM / CPython interpreter.
 The runtime stacks are then merged into the data collected by `perf`, substituting the *native* stacks `perf` has collected for those processes.

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -171,25 +171,28 @@ class GProfiler:
         logger.info(f"Saved collapsed stacks to {collapsed_path}")
 
         if self._flamegraph:
-            flamegraph_path = base_filename + ".html"
-            flamegraph_data = (
-                Path(resource_path("flamegraph/flamegraph_template.html"))
-                .read_text()
-                .replace(
-                    "{{{JSON_DATA}}}",
-                    run_process(
-                        [resource_path("burn"), "convert", "--type=folded", collapsed_path], suppress_log=True
-                    ).stdout.decode(),
+            if os.path.exists(resource_path("burn")):
+                flamegraph_path = base_filename + ".html"
+                flamegraph_data = (
+                    Path(resource_path("flamegraph/flamegraph_template.html"))
+                    .read_text()
+                    .replace(
+                        "{{{JSON_DATA}}}",
+                        run_process(
+                            [resource_path("burn"), "convert", "--type=folded", collapsed_path], suppress_log=True
+                        ).stdout.decode(),
+                    )
+                    .replace("{{{START_TIME}}}", start_ts)
+                    .replace("{{{END_TIME}}}", end_ts)
                 )
-                .replace("{{{START_TIME}}}", start_ts)
-                .replace("{{{END_TIME}}}", end_ts)
-            )
-            Path(flamegraph_path).write_text(flamegraph_data)
+                Path(flamegraph_path).write_text(flamegraph_data)
 
-            # point last_flamegraph.html at the new file; and possibly, delete the previous one.
-            self._update_last_output("last_flamegraph.html", flamegraph_path)
+                # point last_flamegraph.html at the new file; and possibly, delete the previous one.
+                self._update_last_output("last_flamegraph.html", flamegraph_path)
 
-            logger.info(f"Saved flamegraph to {flamegraph_path}")
+                logger.info(f"Saved flamegraph to {flamegraph_path}")
+            else:
+                logger.info("'burn' not available, not writing flamegraph!")
 
     @staticmethod
     def _strip_container_data(collapsed_data):

--- a/gprofiler/metadata/system_metadata.py
+++ b/gprofiler/metadata/system_metadata.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import time
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Dict, Optional, Tuple
 
 import distro  # type: ignore
@@ -237,3 +238,8 @@ def _initialize_system_info():
     run_in_ns(["mnt", "uts", "net"], get_infos)
 
     return hostname, distribution, libc_version, mac_address, local_ip
+
+
+@lru_cache(maxsize=None)
+def get_arch() -> str:
+    return platform.uname().machine

--- a/gprofiler/profilers/factory.py
+++ b/gprofiler/profilers/factory.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:
     from gprofiler.gprofiler_types import UserArgs
     from gprofiler.profilers.profiler_base import ProcessProfilerBase
 
+from gprofiler.metadata.system_metadata import get_arch
 from gprofiler.profilers.perf import SystemProfiler
 from gprofiler.profilers.registry import get_profilers_registry
 
@@ -18,6 +19,7 @@ COMMON_PROFILER_ARGUMENT_NAMES = ["frequency", "duration"]
 def get_profilers(
     user_args: 'UserArgs', **profiler_init_kwargs: Any
 ) -> Tuple[Union['SystemProfiler', 'NoopProfiler'], List['ProcessProfilerBase']]:
+    arch = get_arch()
     profilers_registry = get_profilers_registry()
     process_profilers_instances: List['ProcessProfilerBase'] = []
     system_profiler: Union['SystemProfiler', 'NoopProfiler'] = NoopProfiler()
@@ -25,6 +27,10 @@ def get_profilers(
         lower_profiler_name = profiler_name.lower()
         profiler_mode = user_args.get(f"{lower_profiler_name}_mode")
         if profiler_mode in ("none", "disabled"):
+            continue
+
+        if arch not in profiler_config.supported_archs:
+            logger.warning(f"Disabling {profiler_name} because it doesn't support this architecture ({arch})")
             continue
 
         profiler_kwargs = profiler_init_kwargs.copy()

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -248,6 +248,7 @@ class AsyncProfiledProcess:
     "Java",
     possible_modes=["ap", "disabled"],
     default_mode="ap",
+    supported_archs=["x86_64", "aarch64"],
     profiler_arguments=[
         ProfilerArgument(
             "--java-async-profiler-buildids",

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -111,6 +111,7 @@ class PerfProcess:
     "Perf",
     possible_modes=["fp", "dwarf", "smart", "disabled"],
     default_mode="fp",
+    supported_archs=["x86_64", "aarch64"],
     profiler_mode_argument_help="Run perf with either FP (Frame Pointers), DWARF, or run both and intelligently merge"
     " them by choosing the best result per process. If 'disabled' is chosen, do not invoke"
     " 'perf' at all. The output, in that case, is the concatenation of the results from all"

--- a/gprofiler/profilers/php.py
+++ b/gprofiler/profilers/php.py
@@ -29,6 +29,7 @@ DEFAULT_PROCESS_FILTER = "php-fpm"
 @register_profiler(
     "PHP",
     possible_modes=["phpspy", "disabled"],
+    supported_archs=["x86_64"],  # we don't build phpspy for others yet
     default_mode="phpspy",
     profiler_arguments=[
         ProfilerArgument(

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -279,6 +279,7 @@ class PythonEbpfProfiler(ProfilerBase):
     "Python",
     possible_modes=["auto", "pyperf", "pyspy", "disabed"],
     default_mode="auto",
+    supported_archs=["x86_64"],  # we don't build neither pyspy nor pyperf for others yet
     profiler_mode_argument_help="Select the Python profiling mode: auto (try PyPerf, resort to py-spy if it fails), "
     "pyspy (always use py-spy), pyperf (always use PyPerf, and avoid py-spy even if it fails)"
     " or disabled (no runtime profilers for Python).",

--- a/gprofiler/profilers/registry.py
+++ b/gprofiler/profilers/registry.py
@@ -32,13 +32,15 @@ class ProfilerConfig:
         profiler_mode_help: str,
         disablement_help: str,
         profiler_class,
-        possible_modes: List[str] = None,
+        possible_modes: List[str],
+        supported_archs: List[str],
         default_mode: str = "enabled",
         arguments: List[ProfilerArgument] = None,
     ):
-        self.profiler_mode_help: str = profiler_mode_help
-        self.possible_modes: Optional[List[str]] = possible_modes
-        self.default_mode: str = default_mode
+        self.profiler_mode_help = profiler_mode_help
+        self.possible_modes = possible_modes
+        self.supported_archs = supported_archs
+        self.default_mode = default_mode
         self.profiler_args: List[ProfilerArgument] = arguments if arguments is not None else []
         self.disablement_help = disablement_help
         self.profiler_class = profiler_class
@@ -50,7 +52,8 @@ profilers_config: Dict[str, ProfilerConfig] = {}
 def register_profiler(
     profiler_name: str,
     default_mode: str,
-    possible_modes: List,
+    possible_modes: List[str],
+    supported_archs: List[str],
     profiler_mode_argument_help: Optional[str] = None,
     profiler_arguments: Optional[List[ProfilerArgument]] = None,
     disablement_help: Optional[str] = None,
@@ -72,6 +75,7 @@ def register_profiler(
             disablement_help,
             profiler_class,
             possible_modes,
+            supported_archs,
             default_mode,
             profiler_arguments,
         )

--- a/gprofiler/profilers/ruby.py
+++ b/gprofiler/profilers/ruby.py
@@ -20,7 +20,12 @@ from gprofiler.utils import pgrep_maps, process_comm, random_prefix, resource_pa
 logger = get_logger_adapter(__name__)
 
 
-@register_profiler("Ruby", possible_modes=["rbspy", "disabled"], default_mode="rbspy")
+@register_profiler(
+    "Ruby",
+    possible_modes=["rbspy", "disabled"],
+    supported_archs=["x86_64"],  # we don't build rbspy for others yet
+    default_mode="rbspy",
+)
 class RbSpyProfiler(ProcessProfilerBase):
     RESOURCE_PATH = "ruby/rbspy"
     MAX_FREQUENCY = 100

--- a/scripts/async_profiler_env.sh
+++ b/scripts/async_profiler_env.sh
@@ -6,10 +6,13 @@
 set -euo pipefail
 
 function fix_legacy_repos() {
-    # fix legacy yum repos. slightly adapted from https://stackoverflow.com/a/53848450
-    # this basically comments out all mirrorlist URLs, uncomments all baseurls (all seem to be commented)
-    # and replaces the domain from mirror.centos.org to vault.centos.org.
-    sed -i -e 's|^mirrorlist|#mirrorlist|' -e 's|^# *baseurl|baseurl|' -e 's|mirror.centos.org|vault.centos.org|' /etc/yum.repos.d/*
+    # needed only on x86_64 (which uses CentOS 6)
+    if [ $(uname -m) = "x86_64" ]; then
+        # fix legacy yum repos. slightly adapted from https://stackoverflow.com/a/53848450
+        # this basically comments out all mirrorlist URLs, uncomments all baseurls (all seem to be commented)
+        # and replaces the domain from mirror.centos.org to vault.centos.org.
+        sed -i -e 's|^mirrorlist|#mirrorlist|' -e 's|^# *baseurl|baseurl|' -e 's|mirror.centos.org|vault.centos.org|' /etc/yum.repos.d/*
+    fi
 }
 
 fix_legacy_repos

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,5 +19,8 @@ function curl_with_timecond() {
 }
 
 # burn
-curl_with_timecond https://github.com/Granulate/burn/releases/download/v1.0.1g2/burn gprofiler/resources/burn
-chmod +x gprofiler/resources/burn
+# TODO build for Aarch64
+if [ $(uname -m) = "x86_64" ]; then
+    curl_with_timecond https://github.com/Granulate/burn/releases/download/v1.0.1g2/burn gprofiler/resources/burn
+    chmod +x gprofiler/resources/burn
+fi

--- a/scripts/build_aarch64_container.sh
+++ b/scripts/build_aarch64_container.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) Granulate. All rights reserved.
+# Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
+#
+set -euo pipefail
+
+# ubuntu is 20.04
+# rust is 1.54.0
+# centos is 7
+
+docker buildx build --platform=linux/arm64 \
+    --build-arg RUST_BUILDER_VERSION=@sha256:33a923c30700bb627d1389b6819cfb18af2a585b2901df045924eba1ac0a9c30 \
+    --build-arg PYPERF_BUILDER_UBUNTU=@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3 \
+    --build-arg PERF_BUILDER_UBUNTU=@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3 \
+    --build-arg PHPSPY_BUILDER_UBUNTU=@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3 \
+    --build-arg AP_BUILDER_CENTOS=@sha256:0f4ec88e21daf75124b8a9e5ca03c37a5e937e0e108a255d890492430789b60e \
+    --build-arg GPROFILER_BUILDER_UBUNTU=@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3 \
+    .

--- a/scripts/perf_build.sh
+++ b/scripts/perf_build.sh
@@ -10,5 +10,38 @@ curl -SL https://codeload.github.com/Granulate/linux/zip/40a7823cf90a7e69ce8af88
 unzip -qq linux.zip
 rm linux.zip
 cd linux-*/
-make -C tools/perf LDFLAGS=-static
+
+# Aarch64's libc has no "PIC" version. libtraceevent has some dynamic plugins it's trying to build.
+# we don't use them (and we don't even deploy them) so this patch disables their build.
+# (I couldn't find any way to do it with a build config to "make -C tools/perf" sadly)
+if [ $(uname -m) = "aarch64" ]; then
+    patch -p1 <<'EOF'
+diff --git a/tools/lib/traceevent/plugins/Makefile b/tools/lib/traceevent/plugins/Makefile
+--- a/tools/lib/traceevent/plugins/Makefile
++++ b/tools/lib/traceevent/plugins/Makefile
+@@ -127,19 +127,6 @@ build := -f $(srctree)/tools/build/Makefile.build dir=. obj
+
+ DYNAMIC_LIST_FILE := $(OUTPUT)libtraceevent-dynamic-list
+
+-PLUGINS  = plugin_jbd2.so
+-PLUGINS += plugin_hrtimer.so
+-PLUGINS += plugin_kmem.so
+-PLUGINS += plugin_kvm.so
+-PLUGINS += plugin_mac80211.so
+-PLUGINS += plugin_sched_switch.so
+-PLUGINS += plugin_function.so
+-PLUGINS += plugin_futex.so
+-PLUGINS += plugin_xen.so
+-PLUGINS += plugin_scsi.so
+-PLUGINS += plugin_cfg80211.so
+-PLUGINS += plugin_tlb.so
+-
+ PLUGINS    := $(addprefix $(OUTPUT),$(PLUGINS))
+ PLUGINS_IN := $(PLUGINS:.so=-in.o)
+
+EOF
+
+fi
+
+make -C tools/perf LDFLAGS=-static -j 8 perf
 cp tools/perf/perf /perf

--- a/scripts/phpspy_build.sh
+++ b/scripts/phpspy_build.sh
@@ -30,7 +30,7 @@ pushd /binutils
 wget http://ftp.gnu.org/gnu/binutils/binutils-$BINUTILS_VERSION.tar.gz
 tar xzf binutils-$BINUTILS_VERSION.tar.gz
 cd binutils-$BINUTILS_VERSION
-./configure --disable-nls --prefix=$(pwd)/bin
+./configure --disable-nls --prefix=$(pwd)/bin --disable-ld --disable-gdb
 make configure-host
 make LDFLAGS="-all-static"
 make install

--- a/scripts/phpspy_build.sh
+++ b/scripts/phpspy_build.sh
@@ -5,6 +5,15 @@
 #
 set -euo pipefail
 
+# TODO support aarch64
+if [ $(uname -m) != "x86_64" ]; then
+    mkdir -p /phpspy
+    touch /phpspy/phpspy
+    mkdir -p /binutils/binutils-2.25/bin/bin/
+    touch /binutils/binutils-2.25/bin/bin/objdump
+    exit 0
+fi
+
 # First build phpspy
 pushd /
 git clone --depth=1 -b v0.6.0-g4 --recursive https://github.com/Granulate/phpspy.git && git -C phpspy reset --hard af1d74ebd4f9c27486e82397eafde1c450f06510

--- a/scripts/prepare_x86_64-unknown-linux-musl.sh
+++ b/scripts/prepare_x86_64-unknown-linux-musl.sh
@@ -5,6 +5,11 @@
 #
 set -euo pipefail
 
+# TODO support aarch64
+if [ $(uname -m) != "x86_64" ]; then
+    exit 0
+fi
+
 # prepares the environment for building py-spy:
 # 1. installs the rust target x86_64-unknown-linux-musl - this can build static binaries
 # 2. downloads, builds & installs libunwind with musl

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -6,6 +6,15 @@
 set -e
 
 git clone --depth 1 -b v1.1.1 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 9da70cdbbb2ddb0c364c9ad167764b11104eed08
+
+# (after clone, because we copy the licenses)
+# TODO support aarch64
+if [ $(uname -m) != "x86_64" ]; then
+    mkdir -p /bcc/root/share/bcc/examples/cpp/
+    touch /bcc/root/share/bcc/examples/cpp/PyPerf
+    exit 0
+fi
+
 mkdir build
 cd build
 cmake -DPYTHON_CMD=python3 -DINSTALL_CPP_EXAMPLES=y -DCMAKE_INSTALL_PREFIX=/bcc/root ..

--- a/scripts/pyspy_build.sh
+++ b/scripts/pyspy_build.sh
@@ -5,6 +5,13 @@
 #
 set -euo pipefail
 
+# TODO support aarch64
+if [ $(uname -m) != "x86_64" ]; then
+    mkdir -p /py-spy/target/x86_64-unknown-linux-musl/release
+    touch /py-spy/target/x86_64-unknown-linux-musl/release/py-spy
+    exit 0
+fi
+
 git clone --depth 1 -b v0.3.7g3 https://github.com/Granulate/py-spy.git && git -C py-spy reset --hard 0aa5adace9c5d59cbf46b9c5b59ac92fb23b3e5a
 cd py-spy
 cargo build --release --target=x86_64-unknown-linux-musl

--- a/scripts/rbspy_build.sh
+++ b/scripts/rbspy_build.sh
@@ -5,6 +5,13 @@
 #
 set -euo pipefail
 
+# TODO support aarch64
+if [ $(uname -m) != "x86_64" ]; then
+    mkdir -p /rbspy/target/x86_64-unknown-linux-musl/release
+    touch /rbspy/target/x86_64-unknown-linux-musl/release/rbspy
+    exit 0
+fi
+
 git clone --depth 1 -b v0.7.0g1 https://github.com/Granulate/rbspy.git && git -C rbspy reset --hard 5f27dc892e70973bc1d6430b1c208ec152448e18
 cd rbspy
 cargo build --release --target=x86_64-unknown-linux-musl


### PR DESCRIPTION
## Description
This PR adds support for building gProfiler's container as Aarch64.

Only part of the features are supported & enabled:
* `perf` is built
* async-profiler is built
* gProfiler is built as a *container*

This is all done via `scripts/build_aarch64_container.sh`.

The following are *not* supported:
* py-spy, PyPerf, rbspy, phpspy and burn - they are not built & their respective profilers are disabled (in the case of burn, local flamegraphs are not generated - only collapsed files are written).
* `pyi.Dockerfile` is not supported - gProfiler can not be built as an executable.

async-profiler was chosen to be supported first; `perf` is obvious.
Machines based on Aarch64 are modern and usually (if not always) have containers support, hence containers are supported first. We can add exe support later.

I have tried hard to use the same Dockerfile & to retain it a simple Dockerfile - i.e, avoided falling back to generating it via some script. So, x86_64 can still be built in a standard fashion - `docker build .` The Aarch64 related consts are embedded in `scripts/build_aarch64_container.sh` which contains the relevant `docker buildx build` command.

What might be improved here is the set of hacks I used to maintain a single Dockerfile. CR fellows, tell me if you think this one is too complex and I'll try to simplify things. Otherwise I suppose it's not too bad and I actually improved a bunch of things along the way ;)

This doesn't run as part of the CI at the moment (`docker buildx build` is very slow over qemu). I'll check if we can get some Aarch64 machine for the CI so it could run this build & tests regularly.

## Motivation and Context
Allows profiling on Linux Aarch64 :)

## How Has This Been Tested?
Tested `perf` and async-profiler with some demo apps on this machine:
```
centos@xxx:~$ uname -a
Linux xxx 4.18.0-305.10.2.el8_4.aarch64 #1 SMP Tue Jul 20 17:47:41 UTC 2021 aarch64 aarch64 aarch64 GNU/Linux
```

* [ ] Run gProfiler's test suite on Aarch64

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
