### PR TITLE
Build & push Docker image manifest that includes Aarch64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,13 +31,35 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       # TODO: Add docker layer caching when GitHub Actions cache is stabilized and works good with "satackey/action-docker-layer-caching@v0.0.11"
       - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v2
-        with:
-          push: true
-          tags: ${{ env.GH_REPO }}:latest,${{ env.GH_REPO }}:${{ env.RELEASE_VERSION }}
+        run: |
+          set -x
+          export DOCKER_BUILDKIT=1
+
+          BASE_IMAGE="${{ env.GH_REPO }}:${{ env.RELEASE_VERSION }}"
+          LATEST_IMAGE="${{ env.GH_REPO }}:latest"
+          X86_64_IMAGE="$BASE_IMAGE-x86_64"
+          AARCH64_IMAGE="$BASE_IMAGE-aarch64"
+
+          # build & push Aarch64
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          docker buildx create --name multiarch --driver docker-container --use
+          ./scripts/build_aarch64_container.sh -t "$AARCH64_IMAGE" --push
+
+          # build & push x86_64
+          docker build -t "$X86_64_IMAGE" .
+          docker push "$X86_64_IMAGE"
+
+          # create manifests for the tag + for 'latest'
+          docker manifest create "$BASE_IMAGE" "$X86_64_IMAGE" "$AARCH64_IMAGE"
+          docker manifest push "$BASE_IMAGE"
+          docker manifest create "$LATEST_IMAGE" "$X86_64_IMAGE" "$AARCH64_IMAGE"
+          docker manifest push "$LATEST_IMAGE"
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/scripts/build_aarch64_container.sh
+++ b/scripts/build_aarch64_container.sh
@@ -22,4 +22,4 @@ docker buildx build --platform=linux/arm64 \
     --build-arg AP_BUILDER_CENTOS=$CENTOS_VERSION \
     --build-arg BURN_BUILDER_GOLANG=$GOLANG_VERSION \
     --build-arg GPROFILER_BUILDER_UBUNTU=$UBUNTU_VERSION \
-    .
+    . $@

--- a/scripts/libunwind_build.sh
+++ b/scripts/libunwind_build.sh
@@ -11,7 +11,15 @@ tar -xf libunwind-1.5.0.tar.gz
 curl https://github.com/libunwind/libunwind/commit/831459ee961e7d673bbd83e40d0823227c66db33.patch | sed s/unw_ltoa/ltoa/g > libunwind-container-support.patch
 pushd libunwind-1.5.0
 patch -p1 < ../libunwind-container-support.patch
-./configure --prefix=/usr --disable-tests --disable-documentation && make install -j
+
+if [ $(uname -m) = "aarch64" ]; then
+    # higher value for make -j kills the GH runner (build gets OOM)
+    nproc=2
+else
+    nproc=
+fi
+
+./configure --prefix=/usr --disable-tests --disable-documentation && make install -j $nproc
 popd
 rm -r libunwind-1.5.0
 rm libunwind-1.5.0.tar.gz


### PR DESCRIPTION
## Description
Implements CD for Aarch64 images. After this PR, images pushed by our CD will be a "manifest list" (whatever that means) that has 2 images, the Aarch64 one and the x86_64 one.

## How Has This Been Tested?
I ran it in a private repo and verified the resulting image are pull-able and run-able on both Aarch64 and x86_64.

I do want to test it with older Docker version (I don't know if older versions handle all of this manifests thing)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
