### PR TITLE
python: PyPerf: Allow passing 0 for --pyperf-user-stacks-pages

### DIFF
--- a/gprofiler/gprofiler_types.py
+++ b/gprofiler/gprofiler_types.py
@@ -13,8 +13,15 @@ ProcessToStackSampleCounters = MutableMapping[int, StackToSampleCount]
 UserArgs = Dict[str, Tuple[int, bool, str]]
 
 
-def positive_integer(value):
+def positive_integer(value) -> int:
     value = int(value)
     if value <= 0:
         raise configargparse.ArgumentTypeError("invalid positive integer value: {!r}".format(value))
+    return value
+
+
+def nonnegative_integer(value) -> int:
+    value = int(value)
+    if value < 0:
+        raise configargparse.ArgumentTypeError("invalid non-negative integer value: {!r}".format(value))
     return value

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -214,7 +214,7 @@ class GProfiler:
                     raise
 
                 # others - are ignored, with a warning.
-                logger.warning(f"Failed to start {prof.__class__.__name__}, continuing without it")
+                logger.warning(f"Failed to start {prof.__class__.__name__}, continuing without it", exc_info=True)
                 self.process_profilers.remove(prof)
 
     def stop(self):

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -215,7 +215,7 @@ class PythonEbpfProfiler(ProfilerBase):
         ]
 
         if self.user_stacks_pages is not None:
-            cmd.extend(["--user-stacks-pages", self.user_stacks_pages])
+            cmd.extend(["--user-stacks-pages", str(self.user_stacks_pages)])
 
         process = start_process(cmd, via_staticx=True)
         # wait until the transient data file appears - because once returning from here, PyPerf may

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -13,7 +13,7 @@ from typing import List, Optional
 from psutil import NoSuchProcess, Process
 
 from gprofiler.exceptions import CalledProcessError, ProcessStoppedException, StopEventSetException
-from gprofiler.gprofiler_types import ProcessToStackSampleCounters, StackToSampleCount, positive_integer
+from gprofiler.gprofiler_types import ProcessToStackSampleCounters, StackToSampleCount, nonnegative_integer
 from gprofiler.log import get_logger_adapter
 from gprofiler.merge import parse_and_remove_one_collapsed, parse_many_collapsed
 from gprofiler.metadata.system_metadata import get_arch
@@ -289,7 +289,12 @@ class PythonEbpfProfiler(ProfilerBase):
     " or disabled (no runtime profilers for Python).",
     profiler_arguments=[
         ProfilerArgument(
-            "--pyperf-user-stacks-pages", dest="python_pyperf_user_stacks_pages", default=None, type=positive_integer
+            "--pyperf-user-stacks-pages",
+            dest="python_pyperf_user_stacks_pages",
+            default=None,
+            type=nonnegative_integer,
+            help="Number of user stack-pages that PyPerf will collect, this controls the maximum stack depth of native"
+            " user frames. Pass 0 to disable user native stacks altogether.",
         )
     ],
 )


### PR DESCRIPTION
## Description
The title :)

## Motivation and Context
Passing 0 works for disabling user stacks, which is sometimes desired.

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
