### PR TITLE
java: async-profiler v2.5 and CPU mode with fdtransfer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,6 +108,7 @@ COPY --from=phpspy-builder /binutils/binutils-2.25/bin/bin/strings gprofiler/res
 COPY --from=async-profiler-builder /async-profiler/build/jattach gprofiler/resources/java/jattach
 COPY --from=async-profiler-builder /async-profiler/build/async-profiler-version gprofiler/resources/java/async-profiler-version
 COPY --from=async-profiler-builder /async-profiler/build/libasyncProfiler.so gprofiler/resources/java/libasyncProfiler.so
+COPY --from=async-profiler-builder /async-profiler/build/fdtransfer gprofiler/resources/java/fdtransfer
 
 COPY --from=rbspy-builder /rbspy/rbspy gprofiler/resources/ruby/rbspy
 

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -284,9 +284,9 @@ class AsyncProfiledProcess:
             "--java-async-profiler-mode",
             dest="java_async_profiler_mode",
             choices=["cpu", "itimer"],
-            default="cpu",
+            default="itimer",
             help="Select async-profiler's mode: 'cpu' (based on perf_events & fdtransfer) or 'itimer' (no perf_events)."
-            " Defaults to 'cpu'.",
+            " Defaults to '%(default)s'.",
         ),
     ],
 )

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -27,8 +27,9 @@ def perf_path() -> str:
 class PerfProcess:
     _dump_timeout_s = 5
     _poll_timeout_s = 5
-    _mmap_size_fp = 129  # default number of pages used by "perf record" when perf_event_mlock_kb=516
-    _mmap_size_dwarf = 257  # doubling the previous
+    # default number of pages used by "perf record" when perf_event_mlock_kb=516
+    # we use double for dwarf.
+    _mmap_sizes = {"fp": 129, "dwarf": 257}
 
     def __init__(
         self,
@@ -63,7 +64,7 @@ class PerfProcess:
             # this number scales linearly with the number of active cores (so we don't need to do this calculation
             # here)
             "-m",
-            str(self._mmap_size_fp) if self._type == "fp" else str(self._mmap_size_dwarf),
+            str(self._mmap_sizes[self._type]),
         ] + self._extra_args
 
     def start(self) -> None:

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -84,12 +84,14 @@ class PerfProcess:
         self._process.send_signal(signal.SIGUSR2)
 
     def wait_and_script(self) -> str:
-        perf_data = wait_for_file_by_prefix(f"{self._output_path}.", self._dump_timeout_s, self._stop_event)
-
-        # using read1() which performs just a single read() call and doesn't read until EOF
-        # (unlike Popen.communicate())
-        assert self._process is not None
-        logger.debug(f"perf stderr: {self._process.stderr.read1(4096)}")
+        try:
+            perf_data = wait_for_file_by_prefix(f"{self._output_path}.", self._dump_timeout_s, self._stop_event)
+        finally:
+            # always read its stderr
+            # using read1() which performs just a single read() call and doesn't read until EOF
+            # (unlike Popen.communicate())
+            assert self._process is not None
+            logger.debug(f"perf stderr: {self._process.stderr.read1(4096)}")
 
         if self._inject_jit:
             inject_data = Path(f"{str(perf_data)}.inject")

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -164,13 +164,23 @@ def run_process(
     check: bool = True,
     timeout: int = None,
     kill_signal: signal.Signals = signal.SIGKILL,
+    communicate: bool = True,
     **kwargs,
 ) -> CompletedProcess:
+    stdout = None
+    stderr = None
     with start_process(cmd, via_staticx, **kwargs) as process:
         try:
             if stop_event is None:
-                stdout, stderr = process.communicate(timeout=timeout)
+                assert timeout is None
+                if communicate:
+                    # wait for stderr & stdout to be closed
+                    stdout, stderr = process.communicate(timeout=timeout)
+                else:
+                    # just wait for the process to exit
+                    process.wait()
             else:
+                assert communicate
                 end_time = (time.monotonic() + timeout) if timeout is not None else None
                 while True:
                     try:

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -175,7 +175,7 @@ def run_process(
         try:
             communicate_kwargs = dict(input=stdin) if stdin is not None else {}
             if stop_event is None:
-                assert timeout is None
+                assert timeout is None, f"expected no timeout, got {timeout!r}"
                 if communicate:
                     # wait for stderr & stdout to be closed
                     stdout, stderr = process.communicate(timeout=timeout, **communicate_kwargs)
@@ -183,7 +183,7 @@ def run_process(
                     # just wait for the process to exit
                     process.wait()
             else:
-                assert communicate
+                assert communicate, "expected communicate=True if stop_event is given"
                 end_time = (time.monotonic() + timeout) if timeout is not None else None
                 while True:
                     try:

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -501,3 +501,14 @@ def process_comm(process: Process) -> str:
     name_line = status.splitlines()[0]
     assert name_line.startswith("Name:\t")
     return name_line.split("\t", 1)[1]
+
+
+PERF_EVENT_MLOCK_KB = "/proc/sys/kernel/perf_event_mlock_kb"
+
+
+def read_perf_event_mlock_kb() -> int:
+    return int(Path(PERF_EVENT_MLOCK_KB).read_text())
+
+
+def write_perf_event_mlock_kb(value: int) -> None:
+    Path(PERF_EVENT_MLOCK_KB).write_text(str(value))

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -126,6 +126,7 @@ COPY --from=centos:6 /usr/bin/xargs gprofiler/resources/php/xargs
 COPY --from=async-profiler-builder /async-profiler/build/jattach gprofiler/resources/java/jattach
 COPY --from=async-profiler-builder /async-profiler/build/async-profiler-version gprofiler/resources/java/async-profiler-version
 COPY --from=async-profiler-builder /async-profiler/build/libasyncProfiler.so gprofiler/resources/java/libasyncProfiler.so
+COPY --from=async-profiler-builder /async-profiler/build/fdtransfer gprofiler/resources/java/fdtransfer
 
 COPY --from=burn-builder /go/burn/burn gprofiler/resources/burn
 

--- a/scripts/async_profiler_build.sh
+++ b/scripts/async_profiler_build.sh
@@ -5,8 +5,8 @@
 #
 set -euo pipefail
 
-VERSION=v2.0g5
-GIT_REV=3f1505bbf4a4ec1575b54804e1fbc7b9f38ad96b
+VERSION=v2.5g1
+GIT_REV="02cb785f7cc0024581a1802126f51ed94d5b0475"
 
 git clone --depth 1 -b "$VERSION" https://github.com/Granulate/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
 set +eu  # this funny script has errors :shrug:

--- a/tests/containers/java/Fibonacci.java
+++ b/tests/containers/java/Fibonacci.java
@@ -2,12 +2,26 @@
 // Copyright (c) Granulate. All rights reserved.
 // Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 //
+import java.io.File;
+
 public class Fibonacci {
     private static long fibonacci(final int n) {
         return n <= 1 ? n : fibonacci(n - 1) + fibonacci(n - 2);
     }
 
     public static void main(final String[] args) {
+        Thread thread = new Thread() {
+            public void run() {
+                while (true) {
+                    try {
+                        new File("/").list();
+                    } catch (Exception e) {
+                    }
+                }
+            }
+        };
+        thread.start();
+
         while (true) {
             fibonacci(30);
         }

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -75,7 +75,7 @@ def test_java_async_profiler_stopped(
 
     # run "status"
     proc = psutil.Process(application_pid)
-    with AsyncProfiledProcessForTests(proc, tmp_path, False) as ap_proc:
+    with AsyncProfiledProcessForTests(proc, tmp_path, False, "cpu") as ap_proc:
         ap_proc.status_async_profiler()
     # printed the process' stdout, see ACTION_STATUS case in async-profiler/profiler.cpp
     expected_message = b"Profiling is running for "

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -76,6 +76,7 @@ def test_java_async_profiler_stopped(
         container.kill("SIGKILL")
     finally:
         if container is not None:
+            print("gProfiler container logs:", container.logs().decode(), sep="\n")
             container.remove(force=True)
 
     # run "status"

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -26,7 +26,7 @@ def test_java_from_host(
     application_pid: int,
     assert_collapsed,
 ) -> None:
-    with JavaProfiler(1000, 1, Event(), str(tmp_path), False, False, "ap") as profiler:
+    with JavaProfiler(1000, 1, Event(), str(tmp_path), False, "itimer", "ap") as profiler:
         process_collapsed = profiler.snapshot().get(application_pid)
         assert_collapsed(process_collapsed, check_comm=True)
 

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -26,7 +26,7 @@ def test_java_from_host(
     application_pid: int,
     assert_collapsed,
 ) -> None:
-    with JavaProfiler(1000, 1, Event(), str(tmp_path), False, "itimer", "ap") as profiler:
+    with JavaProfiler(1000, 1, Event(), str(tmp_path), False, True, "itimer", "ap") as profiler:
         process_collapsed = profiler.snapshot().get(application_pid)
         assert_collapsed(process_collapsed, check_comm=True)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -36,7 +36,11 @@ def run_privileged_container(
         assert isinstance(container_or_logs, bytes), container_or_logs
         container, logs = None, container_or_logs.decode()
 
-    print("Container logs:", logs)  # print, so failing tests display it
+    # print, so failing tests display it
+    print(
+        "Container logs:",
+        logs if len(logs) > 0 else "(empty, possibly because container was detached and is running now)",
+    )
     return container, logs
 
 


### PR DESCRIPTION
## Description
Bases on https://github.com/jvm-profiling-tools/async-profiler/pull/411 to use AP's CPU mode.

## Motivation and Context
We'll have kernel stacks for profiled Java processes :)

## How Has This Been Tested?
Locally. ~~I'll add some test as well.~~ added a test

## Checklist:
- [ ] I have read the **CONTRIBUTING** document.
- [x] Wait for the next AP release (haven't updated it yet)
- [ ] I have updated the relevant documentation.
- [x] I have added tests for new logic.
