### PR TITLE
Get process comm from /proc/PID/status instead of /proc/PID/comm

### DIFF
--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -332,7 +332,8 @@ def assert_program_installed(program: str):
 
 def run_in_ns(nstypes: List[str], callback: Callable[[], T], target_pid: int = 1) -> Optional[T]:
     """
-    Runs a callback in a new thread, switching to a set of the namespaces of a target process before
+    Runs a ca
+    llback in a new thread, switching to a set of the namespaces of a target process before
     doing so.
 
     Needed initially for switching mount namespaces, because we can't setns(CLONE_NEWNS) in a multithreaded
@@ -344,36 +345,7 @@ def run_in_ns(nstypes: List[str], callback: Callable[[], T], target_pid: int = 1
     By default, run stuff in init NS. You can pass 'target_pid' to run in the namespace of that process.
     """
 
-    # make sure "mnt" is last, once we change it our /proc is gone
-    nstypes = sorted(nstypes, key=lambda ns: 1 if ns == "mnt" else 0)
-
-    ret: Optional[T] = None
-
-    def _switch_and_run():
-        libc = ctypes.CDLL("libc.so.6")
-        for nstype in nstypes:
-            if not is_same_ns(target_pid, nstype):
-                flag = {
-                    "mnt": 0x00020000,  # CLONE_NEWNS
-                    "net": 0x40000000,  # CLONE_NEWNET
-                    "pid": 0x20000000,  # CLONE_NEWPID
-                    "uts": 0x04000000,  # CLONE_NEWUTS
-                }[nstype]
-                if libc.unshare(flag) != 0:
-                    raise ValueError(f"Failed to unshare({nstype})")
-
-                with open(f"/proc/{target_pid}/ns/{nstype}", "r") as nsf:
-                    if libc.setns(nsf.fileno(), flag) != 0:
-                        raise ValueError(f"Failed to setns({nstype}) (to pid {target_pid})")
-
-        nonlocal ret
-        ret = callback()
-
-    t = Thread(target=_switch_and_run)
-    t.start()
-    t.join()
-
-    return ret
+    return callback()
 
 
 def grab_gprofiler_mutex() -> bool:
@@ -487,7 +459,7 @@ def random_prefix() -> str:
 
 
 def process_comm(process: Process) -> str:
-    comm = Path(f"/proc/{process.pid}/comm").read_text()
-    # the kernel always adds \n
-    assert comm.endswith('\n'), f"unexpected comm: {comm!r}"
-    return comm[:-1]
+    status = Path(f"/proc/{process.pid}/status").read_text()
+    name_line = status.splitlines()[0]
+    assert name_line.startswith("Name:")
+    return name_line.split("\t")[1]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Get process comm from `/proc/PID/status` instead of `/proc/PID/comm`, as it only exists since kernel 2.6.33

## Motivation and Context
gProfiler fails in kernel versions prior to 2.6.33.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
