### PR TITLE
python: py-spy: Use SIGTERM to stop it

### DIFF
--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -71,7 +71,7 @@ class PySpyProfiler(ProcessProfilerBase):
                 self._make_command(process.pid, local_output_path),
                 stop_event=self._stop_event,
                 timeout=self._duration + self._EXTRA_TIMEOUT,
-                kill_signal=signal.SIGTERM,
+                kill_signal=signal.SIGKILL,
             )
         except ProcessStoppedException:
             raise StopEventSetException

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -71,7 +71,7 @@ class PySpyProfiler(ProcessProfilerBase):
                 self._make_command(process.pid, local_output_path),
                 stop_event=self._stop_event,
                 timeout=self._duration + self._EXTRA_TIMEOUT,
-                kill_signal=signal.SIGINT,
+                kill_signal=signal.SIGTERM,
             )
         except ProcessStoppedException:
             raise StopEventSetException


### PR DESCRIPTION
See py-spy commit https://github.com/benfred/py-spy/commit/290584dde76834599d66d74b64165dfe9a357ef5,
SIGINT just raises a flag telling it to stop (makes sense, since it still dumps output etc).
But if py-spy is stuck for whatever reason, it won't be stopped by this signal.

SIGTERM is not handled by py-spy so it will exit immediately.