### PR TITLE
python, ruby: Properly wrap all code paths with removal of temporary files

### DIFF
--- a/gprofiler/merge.py
+++ b/gprofiler/merge.py
@@ -54,13 +54,11 @@ def parse_one_collapsed(collapsed: str, add_comm: Optional[str] = None) -> Stack
     return stacks
 
 
-def parse_and_remove_one_collapsed(collapsed: Path, add_comm: Optional[str] = None) -> StackToSampleCount:
+def parse_one_collapsed_file(collapsed: Path, add_comm: Optional[str] = None) -> StackToSampleCount:
     """
-    Parse a stack-collapsed file and remove it.
+    Parse a stack-collapsed file.
     """
-    data = collapsed.read_text()
-    collapsed.unlink()
-    return parse_one_collapsed(data, add_comm)
+    return parse_one_collapsed(collapsed.read_text(), add_comm)
 
 
 def parse_many_collapsed(text: str) -> ProcessToStackSampleCounters:

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -15,7 +15,7 @@ from psutil import NoSuchProcess, Process
 from gprofiler.exceptions import CalledProcessError, ProcessStoppedException, StopEventSetException
 from gprofiler.gprofiler_types import ProcessToStackSampleCounters, StackToSampleCount, nonnegative_integer
 from gprofiler.log import get_logger_adapter
-from gprofiler.merge import parse_and_remove_one_collapsed, parse_many_collapsed
+from gprofiler.merge import parse_many_collapsed, parse_one_collapsed_file
 from gprofiler.metadata.system_metadata import get_arch
 from gprofiler.profilers.profiler_base import ProcessProfilerBase, ProfilerBase, ProfilerInterface
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
@@ -24,6 +24,7 @@ from gprofiler.utils import (
     poll_process,
     process_comm,
     random_prefix,
+    removed_path,
     resource_path,
     run_process,
     start_process,
@@ -66,29 +67,30 @@ class PySpyProfiler(ProcessProfilerBase):
             return None
 
         local_output_path = os.path.join(self._storage_dir, f"pyspy.{random_prefix()}.{process.pid}.col")
-        try:
-            run_process(
-                self._make_command(process.pid, local_output_path),
-                stop_event=self._stop_event,
-                timeout=self._duration + self._EXTRA_TIMEOUT,
-                kill_signal=signal.SIGKILL,
-            )
-        except ProcessStoppedException:
-            raise StopEventSetException
-        except TimeoutExpired:
-            logger.error(f"Profiling with py-spy timed out on process {process.pid}")
-            raise
-        except CalledProcessError as e:
-            if (
-                b"Error: Failed to get process executable name. Check that the process is running.\n" in e.stderr
-                and not process.is_running()
-            ):
-                logger.debug(f"Profiled process {process.pid} exited before py-spy could start")
-                return None
-            raise
+        with removed_path(local_output_path):
+            try:
+                run_process(
+                    self._make_command(process.pid, local_output_path),
+                    op_event=self._stop_event,
+                    timeout=self._duration + self._EXTRA_TIMEOUT,
+                    kill_signal=signal.SIGKILL,
+                )
+            except ProcessStoppedException:
+                raise StopEventSetException
+            except TimeoutExpired:
+                logger.error(f"Profiling with py-spy timed out on process {process.pid}")
+                raise
+            except CalledProcessError as e:
+                if (
+                    b"Error: Failed to get process executable name. Check that the process is running.\n" in e.stderr
+                    and not process.is_running()
+                ):
+                    logger.debug(f"Profiled process {process.pid} exited before py-spy could start")
+                    return None
+                raise
 
-        logger.info(f"Finished profiling process {process.pid} with py-spy")
-        return parse_and_remove_one_collapsed(Path(local_output_path), process_comm(process))
+            logger.info(f"Finished profiling process {process.pid} with py-spy")
+            return parse_one_collapsed_file(Path(local_output_path), process_comm(process))
 
     def _select_processes_to_profile(self) -> List[Process]:
         filtered_procs = []

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -71,7 +71,7 @@ class PySpyProfiler(ProcessProfilerBase):
             try:
                 run_process(
                     self._make_command(process.pid, local_output_path),
-                    op_event=self._stop_event,
+                    stop_event=self._stop_event,
                     timeout=self._duration + self._EXTRA_TIMEOUT,
                     kill_signal=signal.SIGKILL,
                 )

--- a/gprofiler/profilers/ruby.py
+++ b/gprofiler/profilers/ruby.py
@@ -12,10 +12,10 @@ from psutil import Process
 from gprofiler.exceptions import ProcessStoppedException, StopEventSetException
 from gprofiler.gprofiler_types import StackToSampleCount
 from gprofiler.log import get_logger_adapter
-from gprofiler.merge import parse_and_remove_one_collapsed
+from gprofiler.merge import parse_one_collapsed_file
 from gprofiler.profilers.profiler_base import ProcessProfilerBase
 from gprofiler.profilers.registry import register_profiler
-from gprofiler.utils import pgrep_maps, process_comm, random_prefix, resource_path, run_process
+from gprofiler.utils import pgrep_maps, process_comm, random_prefix, removed_path, resource_path, run_process
 
 logger = get_logger_adapter(__name__)
 
@@ -58,13 +58,14 @@ class RbSpyProfiler(ProcessProfilerBase):
         logger.info(f"Profiling process {process.pid}", cmdline=' '.join(process.cmdline()), no_extra_to_server=True)
 
         local_output_path = os.path.join(self._storage_dir, f"rbspy.{random_prefix()}.{process.pid}.col")
-        try:
-            run_process(self._make_command(process.pid, local_output_path), stop_event=self._stop_event)
-        except ProcessStoppedException:
-            raise StopEventSetException
+        with removed_path(local_output_path):
+            try:
+                run_process(self._make_command(process.pid, local_output_path), stop_event=self._stop_event)
+            except ProcessStoppedException:
+                raise StopEventSetException
 
-        logger.info(f"Finished profiling process {process.pid} with rbspy")
-        return parse_and_remove_one_collapsed(Path(local_output_path), process_comm(process))
+            logger.info(f"Finished profiling process {process.pid} with rbspy")
+            return parse_one_collapsed_file(Path(local_output_path), process_comm(process))
 
     def _select_processes_to_profile(self) -> List[Process]:
         return pgrep_maps(r"(?:^.+/ruby[^/]*$)")

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -18,12 +18,13 @@ import string
 import subprocess
 import sys
 import time
+from contextlib import contextmanager
 from functools import lru_cache
 from pathlib import Path
 from subprocess import CompletedProcess, Popen, TimeoutExpired
 from tempfile import TemporaryDirectory
 from threading import Event, Thread
-from typing import Callable, List, Optional, Tuple, TypeVar, Union
+from typing import Callable, Iterator, List, Optional, Tuple, TypeVar, Union
 
 import importlib_resources
 import psutil
@@ -311,6 +312,14 @@ def remove_path(path: str, missing_ok: bool = False) -> None:
     except FileNotFoundError:
         if not missing_ok:
             raise
+
+
+@contextmanager
+def removed_path(path: str) -> Iterator[None]:
+    try:
+        yield
+    finally:
+        remove_path(path, missing_ok=True)
 
 
 def is_same_ns(pid: int, nstype: str) -> bool:


### PR DESCRIPTION
## Description
Wrap all code paths with removal of temporary output files, properly this time.

## Motivation and Context
Avoid leaving leftovers which, over time, increase gProfiler's disk usage.

## How Has This Been Tested?
* CI
* Will test manually with cases that previously resulted in a file being leaked (e.g timeout / error)

## Checklist:
- [x] ~~Implement for Java & others~~ another PR
