### PR TITLE
Limit the amount of locally-buffered log records before being sent

### DIFF
--- a/gprofiler/log.py
+++ b/gprofiler/log.py
@@ -107,6 +107,8 @@ class RemoteLogsHandler(logging.Handler):
     APIClient, while logs are still accumulated from the beginning.
     """
 
+    MAX_BUFFERED_RECORDS = 100 * 1000  # max number of records to buffer locally
+
     def __init__(self, path: str = "logs", api_client: Optional['APIClient'] = None) -> None:
         super().__init__(logging.DEBUG)
         self._api_client = api_client
@@ -125,6 +127,8 @@ class RemoteLogsHandler(logging.Handler):
             return
 
         self._logs.append(self._make_dict_record(record))
+        # trim logs to last N entries
+        self._logs[: -self.MAX_BUFFERED_RECORDS] = []
 
     def _make_dict_record(self, record: LogRecord):
         formatted_timestamp = datetime.datetime.utcfromtimestamp(record.created).isoformat()


### PR DESCRIPTION
## Description
Limit the amount of locally-buffered log records before being sent.

## Motivation and Context
Avoid memory explosion if logs aren't being sent, for whatever reason.

## How Has This Been Tested?
Locally - using this:
```
diff --git a/gprofiler/log.py b/gprofiler/log.py
index dd2291c..8a17148 100644
--- a/gprofiler/log.py
+++ b/gprofiler/log.py
@@ -107,7 +107,7 @@ class RemoteLogsHandler(logging.Handler):
     APIClient, while logs are still accumulated from the beginning.
     """
 
-    MAX_BUFFERED_RECORDS = 100 * 1000  # max number of records to buffer locally
+    MAX_BUFFERED_RECORDS = 100 * 1  # max number of records to buffer locally
 
     def __init__(self, path: str = "logs", api_client: Optional['APIClient'] = None) -> None:
         super().__init__(logging.DEBUG)
@@ -178,6 +178,8 @@ class RemoteLogsHandler(logging.Handler):
         # Snapshot the current num logs because logs list might be extended meanwhile.
         logs_count = len(self._logs)
         try:
+            print(logs_count)
+            raise 1
             self._api_client.post(self._path, data=self._logs[:logs_count], api_version='v1')
         except (APIError, RequestException):
             self._logger.exception("Failed sending logs to server")
(END)
```
I verified the printed number doesn't exceed 100.

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
