### PR TITLE
Disable PHP profiling by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ For each profiling session (each profiling duration), gProfiler produces outputs
 Profiling using eBPF incurs lower overhead & provides kernel stacks. This (currently) requires kernel headers to be installed.
 
 ### PHP profiling options
+* `--php-mode phpspy`: Enable PHP profiling with phpspy.
 * `--no-php` or `--php-mode disabled`: Disable profilers for PHP.
 * `--php-proc-filter`: Process filter (`pgrep`) to select PHP processes for profiling (this is phpspy's `-P` option)
 

--- a/gprofiler/profilers/php.py
+++ b/gprofiler/profilers/php.py
@@ -30,7 +30,7 @@ DEFAULT_PROCESS_FILTER = "php-fpm"
     "PHP",
     possible_modes=["phpspy", "disabled"],
     supported_archs=["x86_64"],  # we don't build phpspy for others yet
-    default_mode="phpspy",
+    default_mode="disabled",
     profiler_arguments=[
         ProfilerArgument(
             "--php-proc-filter",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -190,7 +190,16 @@ def application_pid(in_container: bool, application_process: subprocess.Popen, a
 @fixture
 def runtime_specific_args(runtime: str) -> List[str]:
     return {
-        "php": ["--php-proc-filter", "php", "-d", str(PHPSPY_DURATION)],  # phpspy needs a little more time to warm-up
+        "php": [
+            # not enabled by default
+            "--php-mode",
+            "phpspy",
+            "--php-proc-filter",
+            "php",
+            # phpspy needs a little more time to warm-up
+            "-d",
+            str(PHPSPY_DURATION),
+        ],
         "python": ["-d", "3"],  # Burner python tests make syscalls and we want to record python + kernel stacks
         "nodejs": ["--nodejs-mode", "perf"],  # enable NodeJS profiling
     }.get(runtime, [])


### PR DESCRIPTION
## Description
Don't run `phpspy` by default. It seems to leak memory in some cases. Let's enable it only when needed.
