### PR TITLE
Upgrade python profilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ gProfiler invokes `perf` in system wide mode, collecting profiling data for all 
 Alongside `perf`, gProfiler invokes runtime-specific profilers for processes based on these environments:
 * Java runtimes (version 7+) based on the HotSpot JVM, including the Oracle JDK and other builds of OpenJDK like AdoptOpenJDK and Azul Zulu.
   * Uses async-profiler.
-* The CPython interpreter, versions 2.7 and 3.5-3.9.
+* The CPython interpreter, versions 2.7 and 3.5-3.10.
   * eBPF profiling (based on PyPerf) requires Linux 4.14 or higher; see [Python profiling options](#python-profiling-options) for more info.
   * If eBPF is not available for whatever reason, py-spy is used.
 * PHP (Zend Engine), versions 7.0-8.0.

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -5,7 +5,7 @@
 #
 set -e
 
-git clone --depth 1 -b v1.1.1 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 9da70cdbbb2ddb0c364c9ad167764b11104eed08
+git clone --depth 1 -b v1.1.2 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 8509fb0f8dfa096b08d0b3619686e7948165406a
 
 # (after clone, because we copy the licenses)
 # TODO support aarch64

--- a/scripts/pyspy_build.sh
+++ b/scripts/pyspy_build.sh
@@ -5,6 +5,6 @@
 #
 set -euo pipefail
 
-git clone --depth 1 -b v0.3.9g1 https://github.com/Granulate/py-spy.git && git -C py-spy reset --hard c05720104c3e7f93a4670497284282821c552bee
+git clone --depth 1 -b v0.3.10g1 https://github.com/Granulate/py-spy.git && git -C py-spy reset --hard 480deec8b5dde3cd331d1a793106981c1796d172
 cd py-spy
 cargo build --release --target=$(uname -m)-unknown-linux-musl


### PR DESCRIPTION
* Upgrade py-spy to v0.3.10 (include Python 3.10 support :)
* Upgrade PyPerf to v1.1.2 (allow longer file names).

Rebasing our py-spy patches resulted in no changes:
```
$ git range-diff v0.3.9..v0.3.9g1 v0.3.10..v0.3.10g1 | cat
1:  7952b8c = 1:  b23d457 Don't gather thread activity for all threads when --nonblocking is provided
2:  250396d = 2:  f30e48f Don't grab stack trace of non-GIL threads when --gil is provided
3:  c057201 = 3:  480deec Add a suffix to the stacks to easily identify Python stacks (#1)
```