### PR TITLE
docker_client: Use a less strict regex for Docker container IDs

### DIFF
--- a/gprofiler/docker_client.py
+++ b/gprofiler/docker_client.py
@@ -9,7 +9,7 @@ import docker
 
 from gprofiler.log import get_logger_adapter
 
-DOCKER_CGROUPS = [re.compile(r"/docker-([a-z0-9]{64})\.scope")]
+CONTAINER_ID_PATTERN = re.compile(r"[a-f0-9]{64}")
 
 logger = get_logger_adapter(__name__)
 
@@ -97,11 +97,10 @@ class DockerClient:
         except FileNotFoundError:
             # The process died before we got to this point
             return None
+
         for line in cgroup.split():
-            if any(s in line for s in (':/docker/', ':/ecs/', ':/kubepods')):
-                return line.split("/")[-1]
-            for p in DOCKER_CGROUPS:
-                m = p.search(line)
-                if m is not None:
-                    return m.group(1)
+            found = CONTAINER_ID_PATTERN.findall(line)
+            if found:
+                return found[-1]
+
         return None


### PR DESCRIPTION
## Description
Use a less strict regex for Docker container IDs, previously we attempted to match on the form `/system.slice/docker-xxxx.scope`, this PR allows us to match on any `docker-xxxx.scope` form, such as `/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podxxxxxx.slice/docker-xxxx.scope` that I have encountered.

## How Has This Been Tested?
Tested the expressions in my IPython :)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
