### PR TITLE
python: Allow passing "--python-mode py-spy" as well as "pyspy"

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ For each profiling session (each profiling duration), gProfiler produces outputs
 * `--python-mode`: Controls which profiler is used for Python.
     * `auto` - (default) try with PyPerf (eBPF), fall back to py-spy.
     * `pyperf` - Use PyPerf with no py-spy fallback.
-    * `pyspy` - Use py-spy.
+    * `pyspy`/`py-spy` - Use py-spy.
     * `disabled` - Disable profilers for Python.
 
 Profiling using eBPF incurs lower overhead & provides kernel stacks. This (currently) requires kernel headers to be installed.

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -282,7 +282,8 @@ class PythonEbpfProfiler(ProfilerBase):
 
 @register_profiler(
     "Python",
-    possible_modes=["auto", "pyperf", "pyspy", "disabled"],
+    # py-spy is like pyspy, it's confusing and I mix between them
+    possible_modes=["auto", "pyperf", "pyspy", "py-spy", "disabled"],
     default_mode="auto",
     # we build pyspy for both, pyperf only for x86_64.
     # TODO: this inconsistency shows that py-spy and pyperf should have different Profiler classes,
@@ -317,6 +318,9 @@ class PythonProfiler(ProfilerInterface):
         python_mode: str,
         python_pyperf_user_stacks_pages: Optional[int],
     ):
+        if python_mode == "py-spy":
+            python_mode = "pyspy"
+
         assert python_mode in ("auto", "pyperf", "pyspy"), f"unexpected mode: {python_mode}"
 
         if get_arch() != "x86_64":


### PR DESCRIPTION
## Description
Improves user friendliness

## How Has This Been Tested?
I tried both `pyspy` and `py-spy`.

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
