### PR TITLE
Bugfix/python kernel headers

### DIFF
--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -193,6 +193,7 @@ class PythonEbpfProfiler(ProfilerBase):
 
             lib_modules_uname_path = f"/lib/modules/{uname}"
 
+            # We're using /dev/shm as it is a tmpfs mount, while /tmp isn't.
             os.makedirs('/dev/shm/modules_mount/upper', 555)
             os.makedirs('/dev/shm/modules_mount/workdir', 555)
             subprocess.check_call(
@@ -210,6 +211,8 @@ class PythonEbpfProfiler(ProfilerBase):
 
             os.chmod(lib_modules_uname_path, 0o755)
             link_target = os.readlink(build_path)
+            # We're assuming the actual headers on the host are under /usr/src,
+            # otherwise we wouldn't have access from inside the container any how.
             new_target = re.sub(r'(\.\./)+usr/src', '/usr/src', link_target, count=1)
             os.unlink(build_path)
             os.symlink(new_target, build_path)

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -175,16 +175,25 @@ class PythonEbpfProfiler(ProfilerBase):
 
             os.makedirs('/dev/shm/modules_mount/upper', 555)
             os.makedirs('/dev/shm/modules_mount/workdir', 555)
-            subprocess.check_call(['mount', '-t', 'overlay', 'overlay', '-o',
-                                   f'upperdir=/dev/shm/modules_mount/upper,lowerdir={lib_modules_uname_path}'
-                                   ',workdir=/dev/shm/modules_mount/workdir', lib_modules_uname_path])
+            subprocess.check_call(
+                [
+                    'mount',
+                    '-t',
+                    'overlay',
+                    'overlay',
+                    '-o',
+                    f'upperdir=/dev/shm/modules_mount/upper,lowerdir={lib_modules_uname_path}'
+                    ',workdir=/dev/shm/modules_mount/workdir',
+                    lib_modules_uname_path,
+                ]
+            )
 
             os.chmod(lib_modules_uname_path, 0o755)
             link_target = os.readlink(build_path)
-            new_target = re.sub('(\.\./)+usr/src', '/usr/src', link_target, count=1)
+            new_target = re.sub(r'(\.\./)+usr/src', '/usr/src', link_target, count=1)
             os.unlink(build_path)
             os.symlink(new_target, build_path)
-        except:
+        except BaseException:
             logger.warning("Exception raised trying to fix /lib/modules symlink for PyPerf", exc_info=True)
 
     @classmethod


### PR DESCRIPTION
Fix a bug that was encountered on Amazon Linux 2018.3, which resulted in `gprofiler` being unable to properly locate the kernel headers, thus unable to use PyPerf.

Specifically, the bug manifests itself when:
1. running in a container
2. on the host, `/lib` is not a symlink
3. on the host, `/lib/modules/$(uname -r)/build` is a relative symlink (i.e. `../../../usr/src/...`)

Inside the `gprofiler` container `/lib` is linked to `/usr/lib`, which means that the relative link from the host becomes broken.
The solution is to fix the symlink inside the container, by:
1. mounting `/lib/modules/$(uname -r)` as an overlay inside the container
2. converting the relative link to an absolute one
3. removing and recreating the link