### PR TITLE
java: Allow passing safemode to async-profiler

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -313,7 +313,7 @@ class AsyncProfiledProcess:
             metavar="[0-127]",
             help="Controls the 'safemode' parameter passed to async-profiler. This is parameter denotes multiple"
             " bits that describe different stack recovery techniques which async-profiler uses (see StackRecovery"
-            " enum in async-profiler's code)."
+            " enum in async-profiler's code, in profiler.cpp)."
             " Defaults to '%(default)s' (which means 'all enabled').",
         ),
     ],

--- a/gprofiler/profilers/registry.py
+++ b/gprofiler/profilers/registry.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Type, Union
 
 
 class ProfilerArgument:
@@ -11,8 +11,9 @@ class ProfilerArgument:
         help: Optional[str] = None,
         default: Any = None,
         action: Optional[str] = None,
-        choices: List[Any] = None,
+        choices: Sequence[Any] = None,
         type: Union[Type, Callable[[str], Any]] = None,
+        metavar: str = None,
     ):
         self.name = name
         self.dest = dest
@@ -21,6 +22,7 @@ class ProfilerArgument:
         self.action = action
         self.choices = choices
         self.type = type
+        self.metavar = metavar
 
     def get_dict(self) -> Dict[str, Any]:
         return {key: value for key, value in self.__dict__.items() if value is not None}

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -85,7 +85,7 @@ def test_java_async_profiler_stopped(
     assert any("libasyncProfiler.so" in m.path for m in proc.memory_maps())
 
     # run "status"
-    with AsyncProfiledProcessForTests(proc, tmp_path, False, "itimer") as ap_proc:
+    with AsyncProfiledProcessForTests(proc, tmp_path, False, mode="itimer", safemode=0) as ap_proc:
         ap_proc.status_async_profiler()
 
         # printed the output file, see ACTION_STATUS case in async-profiler/profiler.cpp\
@@ -111,7 +111,17 @@ def test_java_async_profiler_cpu_mode(
     """
     Run Java in a container and enable async-profiler in CPU mode, make sure we get kernel stacks.
     """
-    with JavaProfiler(1000, 1, Event(), str(tmp_path), False, True, "cpu", "ap") as profiler:
+    with JavaProfiler(
+        1000,
+        1,
+        Event(),
+        str(tmp_path),
+        False,
+        True,
+        java_async_profiler_mode="cpu",
+        java_async_profiler_safemode=0,
+        java_mode="ap",
+    ) as profiler:
         process_collapsed = profiler.snapshot().get(application_pid)
         assert_collapsed(process_collapsed, check_comm=True)
         assert_function_in_collapsed(
@@ -130,7 +140,17 @@ def test_java_async_profiler_musl_and_cpu(
     Run Java in an Alpine-based container and enable async-profiler in CPU mode, make sure that musl profiling
     works and that we get kernel stacks.
     """
-    with JavaProfiler(1000, 1, Event(), str(tmp_path), False, True, "cpu", "ap") as profiler:
+    with JavaProfiler(
+        1000,
+        1,
+        Event(),
+        str(tmp_path),
+        False,
+        True,
+        java_async_profiler_mode="cpu",
+        java_async_profiler_safemode=0,
+        java_mode="ap",
+    ) as profiler:
         process_collapsed = profiler.snapshot().get(application_pid)
         assert_collapsed(process_collapsed, check_comm=True)
         assert_function_in_collapsed(

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -26,7 +26,17 @@ def test_java_from_host(
     application_pid: int,
     assert_collapsed,
 ) -> None:
-    with JavaProfiler(1000, 1, Event(), str(tmp_path), False, True, "itimer", "ap") as profiler:
+    with JavaProfiler(
+        1000,
+        1,
+        Event(),
+        str(tmp_path),
+        False,
+        True,
+        java_async_profiler_mode="itimer",
+        java_async_profiler_safemode=0,
+        java_mode="ap",
+    ) as profiler:
         process_collapsed = profiler.snapshot().get(application_pid)
         assert_collapsed(process_collapsed, check_comm=True)
 


### PR DESCRIPTION
## Description
Allows passing `safemode` to async-profiler. This lets async-profiler operate in a safer mode, see this comment for example: https://github.com/jvm-profiling-tools/async-profiler/issues/501#issuecomment-968133103

## How Has This Been Tested?
Profiling Java now w/o passing this new parameter, causes `safemode=0` to be passed (which is the default in AP's code).
Passing e.g 127 passes `safemode=127` as expected.

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
