### PR TITLE
lint: Enable black's string normalization

### DIFF
--- a/deploy/dataflow/setup.py
+++ b/deploy/dataflow/setup.py
@@ -48,7 +48,7 @@ class ProfilerInstallationCommands(setuptools.Command):
         p = subprocess.Popen(
             command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True
         )
-        stdout_data, _ = p.communicate(input=b'\n')
+        stdout_data, _ = p.communicate(input=b"\n")
         print("Command output: %s" % stdout_data)
         if p.returncode != 0:
             raise RuntimeError("Command %s failed: exit code: %s" % (command, p.returncode))

--- a/gprofiler/client.py
+++ b/gprofiler/client.py
@@ -129,7 +129,7 @@ class APIClient:
         total_samples: int,
         profile_api_version: Optional[str],
         spawn_time: float,
-        metrics: 'Metrics',
+        metrics: "Metrics",
         gpid: str,
     ) -> Dict:
         return self.post(

--- a/gprofiler/docker_client.py
+++ b/gprofiler/docker_client.py
@@ -20,11 +20,11 @@ class DockerClient:
             self._client = docker.from_env()
         except Exception:
             logger.warning(
-                'Could not initiate the Docker client, so the profiling data will not include the container'
-                ' names. If you are running gProfiler in a container, please mount the Docker sock file'
-                ' by running the Docker run command with the following argument:'
+                "Could not initiate the Docker client, so the profiling data will not include the container"
+                " names. If you are running gProfiler in a container, please mount the Docker sock file"
+                " by running the Docker run command with the following argument:"
                 ' "-v /var/run/docker.sock:/var/run/docker.sock". Otherwise, please open a new issue here:'
-                ' https://github.com/Granulate/gprofiler/issues/new'
+                " https://github.com/Granulate/gprofiler/issues/new"
             )
             self._client = None
 
@@ -42,13 +42,13 @@ class DockerClient:
 
     def get_container_name(self, pid: int) -> str:
         if self._client is None:
-            return ''
+            return ""
         if pid in self._pid_to_container_name_cache:
             return self._pid_to_container_name_cache[pid]
         container_name: Optional[str] = self._safely_get_process_container_name(pid)
         if container_name is None:
-            self._pid_to_container_name_cache[pid] = ''
-            return ''
+            self._pid_to_container_name_cache[pid] = ""
+            return ""
         self._pid_to_container_name_cache[pid] = container_name
         return container_name
 
@@ -59,7 +59,7 @@ class DockerClient:
                 return None
             return self._get_container_name(container_id)
         except Exception:
-            logger.warning(f'Could not get a container name for PID {pid}', exc_info=True)
+            logger.warning(f"Could not get a container name for PID {pid}", exc_info=True)
             return None
 
     def _get_container_name(self, container_id) -> Optional[str]:
@@ -92,7 +92,7 @@ class DockerClient:
         # standard Docker uses /docker/container-id
         # k8s uses /kubepods/{burstable,besteffort}/uuid/container-id
         try:
-            with open(f"/proc/{pid}/cgroup", 'r') as cgroup_file:
+            with open(f"/proc/{pid}/cgroup", "r") as cgroup_file:
                 cgroup = cgroup_file.read()
         except FileNotFoundError:
             # The process died before we got to this point

--- a/gprofiler/log.py
+++ b/gprofiler/log.py
@@ -109,7 +109,7 @@ class RemoteLogsHandler(logging.Handler):
 
     MAX_BUFFERED_RECORDS = 100 * 1000  # max number of records to buffer locally
 
-    def __init__(self, path: str = "logs", api_client: Optional['APIClient'] = None) -> None:
+    def __init__(self, path: str = "logs", api_client: Optional["APIClient"] = None) -> None:
         super().__init__(logging.DEBUG)
         self._api_client = api_client
         self._path = path
@@ -120,7 +120,7 @@ class RemoteLogsHandler(logging.Handler):
         # The formatter is needed to format tracebacks
         self.setFormatter(logging.Formatter())
 
-    def init_api_client(self, api_client: 'APIClient'):
+    def init_api_client(self, api_client: "APIClient"):
         self._api_client = api_client
 
     def emit(self, record: LogRecord) -> None:
@@ -151,9 +151,9 @@ class RemoteLogsHandler(logging.Handler):
         run_id = extra.pop(RUN_ID_KEY, None)
         if run_id is None:
             self._logger.error("state.run_id is not defined! probably a bug!")
-            run_id = ''
+            run_id = ""
 
-        cycle_id = extra.pop(CYCLE_ID_KEY, '')
+        cycle_id = extra.pop(CYCLE_ID_KEY, "")
 
         assert self.formatter is not None
         if record.exc_info:
@@ -162,7 +162,7 @@ class RemoteLogsHandler(logging.Handler):
                 record.exc_text if record.exc_text else self.formatter.formatException(record.exc_info)
             )
         else:
-            exception_traceback = ''
+            exception_traceback = ""
 
         extra = extra if not extra.pop(NO_SERVER_EXTRA_KEY, False) else {}
 
@@ -188,7 +188,7 @@ class RemoteLogsHandler(logging.Handler):
                     " was reached",
                 )
                 self._truncated = False
-            self._api_client.post(self._path, data=self._logs[:logs_count], api_version='v1')
+            self._api_client.post(self._path, data=self._logs[:logs_count], api_version="v1")
         except (APIError, RequestException):
             self._logger.exception("Failed sending logs to server")
         else:

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -100,7 +100,7 @@ class GProfiler:
         self._stop_event = Event()
         self._static_metadata: Optional[Metadata] = None
         self._spawn_time = time.time()
-        self._gpid = ''
+        self._gpid = ""
         if collect_metadata:
             self._static_metadata = get_static_metadata(spawn_time=self._spawn_time, run_args=user_args)
         self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=10)
@@ -200,8 +200,8 @@ class GProfiler:
         for line in collapsed_data.splitlines():
             if line.startswith("#"):
                 continue
-            lines.append(line[line.find(';') + 1 :])
-        return '\n'.join(lines)
+            lines.append(line[line.find(";") + 1 :])
+        return "\n".join(lines)
 
     def start(self):
         self._stop_event.clear()
@@ -291,7 +291,7 @@ class GProfiler:
                     metrics,
                     self._gpid,
                 )
-                self._gpid = response_dict.get('gpid', '')
+                self._gpid = response_dict.get("gpid", "")
             except Timeout:
                 logger.error("Upload of profile to server timed out.")
             except APIError as e:
@@ -426,7 +426,7 @@ def parse_cmd_args():
     parser.add_argument("--token", dest="server_token", help="Server token")
     parser.add_argument("--service-name", help="Service name")
 
-    parser.add_argument('--version', action='version', version=__version__)
+    parser.add_argument("--version", action="version", version=__version__)
     parser.add_argument("-v", "--verbose", action="store_true", default=False, dest="verbose")
 
     logging_options = parser.add_argument_group("logging")

--- a/gprofiler/metadata/cloud_metadata.py
+++ b/gprofiler/metadata/cloud_metadata.py
@@ -151,7 +151,7 @@ def get_static_cloud_instance_metadata() -> Optional[Metadata]:
                 return response.__dict__
         except Exception as exception:
             raised_exceptions.append(exception)
-    formatted_exceptions = ', '.join([repr(exception) for exception in raised_exceptions])
+    formatted_exceptions = ", ".join([repr(exception) for exception in raised_exceptions])
     logger.debug(
         f"Could not get any cloud instance metadata because of the following exceptions: {formatted_exceptions}."
         " The most likely reason is that gProfiler is not installed on a an AWS, GCP or Azure instance."

--- a/gprofiler/metadata/system_metadata.py
+++ b/gprofiler/metadata/system_metadata.py
@@ -98,15 +98,15 @@ def get_mac_address() -> str:
     IFNAMSIZ = 16
     IFF_LOOPBACK = 8
     MAC_BYTES_LEN = 6
-    SIZE_OF_SHORT = struct.calcsize('H')
+    SIZE_OF_SHORT = struct.calcsize("H")
     MAX_BYTE_COUNT = 4096
 
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_IP)
 
     # run SIOCGIFCONF to get all interface names
-    buf = array.array('B', b'\0' * MAX_BYTE_COUNT)
-    ifconf = struct.pack('iL', MAX_BYTE_COUNT, buf.buffer_info()[0])
-    outbytes = struct.unpack('iL', fcntl.ioctl(s.fileno(), 0x8912, ifconf))[0]  # SIOCGIFCONF
+    buf = array.array("B", b"\0" * MAX_BYTE_COUNT)
+    ifconf = struct.pack("iL", MAX_BYTE_COUNT, buf.buffer_info()[0])
+    outbytes = struct.unpack("iL", fcntl.ioctl(s.fileno(), 0x8912, ifconf))[0]  # SIOCGIFCONF
     data = buf.tobytes()[:outbytes]
     for index in range(0, len(data), SIZE_OF_STUCT_ifreq):
         iface = data[index : index + SIZE_OF_STUCT_ifreq]
@@ -114,15 +114,15 @@ def get_mac_address() -> str:
         # iface is now a struct ifreq which starts with the interface name.
         # we can use it for further calls.
         res = fcntl.ioctl(s.fileno(), 0x8913, iface)  # SIOCGIFFLAGS
-        ifr_flags = struct.unpack(f'{IFNAMSIZ}sH', res[: IFNAMSIZ + SIZE_OF_SHORT])[1]
+        ifr_flags = struct.unpack(f"{IFNAMSIZ}sH", res[: IFNAMSIZ + SIZE_OF_SHORT])[1]
         if ifr_flags & IFF_LOOPBACK:
             continue
 
         # okay, not loopback, get its MAC address.
         res = fcntl.ioctl(s.fileno(), 0x8927, iface)  # SIOCGIFHWADDR
-        address = struct.unpack(f'{IFNAMSIZ}sH{MAC_BYTES_LEN}s', res[: IFNAMSIZ + SIZE_OF_SHORT + MAC_BYTES_LEN])[2]
-        mac = struct.unpack(f'{MAC_BYTES_LEN}B', address)
-        address = ":".join(['%02X' % i for i in mac])
+        address = struct.unpack(f"{IFNAMSIZ}sH{MAC_BYTES_LEN}s", res[: IFNAMSIZ + SIZE_OF_SHORT + MAC_BYTES_LEN])[2]
+        mac = struct.unpack(f"{MAC_BYTES_LEN}B", address)
+        address = ":".join(["%02X" % i for i in mac])
         return address
 
     return "unknown"

--- a/gprofiler/profilers/__init__.py
+++ b/gprofiler/profilers/__init__.py
@@ -5,4 +5,4 @@ from gprofiler.profilers.php import PHPSpyProfiler
 from gprofiler.profilers.python import PythonProfiler
 from gprofiler.profilers.ruby import RbSpyProfiler
 
-__all__ = ['JavaProfiler', 'SystemProfiler', 'PHPSpyProfiler', 'PythonProfiler', 'RbSpyProfiler']
+__all__ = ["JavaProfiler", "SystemProfiler", "PHPSpyProfiler", "PythonProfiler", "RbSpyProfiler"]

--- a/gprofiler/profilers/factory.py
+++ b/gprofiler/profilers/factory.py
@@ -17,12 +17,12 @@ COMMON_PROFILER_ARGUMENT_NAMES = ["frequency", "duration"]
 
 
 def get_profilers(
-    user_args: 'UserArgs', **profiler_init_kwargs: Any
-) -> Tuple[Union['SystemProfiler', 'NoopProfiler'], List['ProcessProfilerBase']]:
+    user_args: "UserArgs", **profiler_init_kwargs: Any
+) -> Tuple[Union["SystemProfiler", "NoopProfiler"], List["ProcessProfilerBase"]]:
     arch = get_arch()
     profilers_registry = get_profilers_registry()
-    process_profilers_instances: List['ProcessProfilerBase'] = []
-    system_profiler: Union['SystemProfiler', 'NoopProfiler'] = NoopProfiler()
+    process_profilers_instances: List["ProcessProfilerBase"] = []
+    system_profiler: Union["SystemProfiler", "NoopProfiler"] = NoopProfiler()
     for profiler_name, profiler_config in profilers_registry.items():
         lower_profiler_name = profiler_name.lower()
         profiler_mode = user_args.get(f"{lower_profiler_name}_mode")

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -115,7 +115,7 @@ class PerfProcess:
             suppress_log=True,
         )
         perf_data.unlink()
-        return perf_script_proc.stdout.decode('utf8')
+        return perf_script_proc.stdout.decode("utf8")
 
 
 @register_profiler(

--- a/gprofiler/profilers/php.py
+++ b/gprofiler/profilers/php.py
@@ -50,8 +50,8 @@ class PHPSpyProfiler(ProfilerBase):
     NUM_WORKERS = 16  # Num of workers following unique PHP processes (one worker per _process)
 
     # regex required for parsing phpspy output
-    SINGLE_FRAME_RE = re.compile(r'^(?P<f_index>\d+) (?P<line>.*)$')  # "1 main.php:24"
-    PID_METADATA_RE = re.compile(r'^# pid = (.*)$')  # "# pid = 455"
+    SINGLE_FRAME_RE = re.compile(r"^(?P<f_index>\d+) (?P<line>.*)$")  # "1 main.php:24"
+    PID_METADATA_RE = re.compile(r"^# pid = (.*)$")  # "# pid = 455"
     PHP_FRAME_ANNOTATION = "[php]"
 
     def __init__(
@@ -142,7 +142,7 @@ class PHPSpyProfiler(ProfilerBase):
             if not match:
                 raise CorruptedPHPSpyOutputException(f"Line {idx} ({raw_frame}) didn't match known re pattern")
 
-            if int(match.group('f_index')) != idx:
+            if int(match.group("f_index")) != idx:
                 raise CorruptedPHPSpyOutputException(
                     f"phpspy reported index {match.group('f_index')} doesn't match line index ({idx})"
                 )
@@ -151,7 +151,7 @@ class PHPSpyProfiler(ProfilerBase):
         # add the "comm" - currently just "php", until we complete https://github.com/Granulate/phpspy/pull/3
         # to get the real comm.
         parsed_frames.append("php")
-        return ';'.join(reversed(parsed_frames))
+        return ";".join(reversed(parsed_frames))
 
     @classmethod
     def _parse_phpspy_output(cls, phpspy_output: str) -> ProcessToStackSampleCounters:
@@ -165,7 +165,7 @@ class PHPSpyProfiler(ProfilerBase):
 
         results: ProcessToStackSampleCounters = defaultdict(Counter)
 
-        stacks = phpspy_output.split('\n\n')  # Last part is always empty.
+        stacks = phpspy_output.split("\n\n")  # Last part is always empty.
         last_stack, stacks = stacks[-1], stacks[:-1]
         if last_stack != "":
             logger.warning(f"phpspy output: last stack is not empty - '{last_stack}'")
@@ -173,7 +173,7 @@ class PHPSpyProfiler(ProfilerBase):
         corrupted_stacks = 0
         for stack in stacks:
             try:
-                frames = stack.split('\n')
+                frames = stack.split("\n")
                 # Last line is the PID.
                 pid_raw = frames.pop(-1)
                 pid = int(extract_metadata_section(cls.PID_METADATA_RE, pid_raw))
@@ -186,7 +186,7 @@ class PHPSpyProfiler(ProfilerBase):
 
             except Exception:
                 corrupted_stacks += 1
-                logger.exception('Unknown exception caught while parsing a phpspy stack, continuing to the next stack')
+                logger.exception("Unknown exception caught while parsing a phpspy stack, continuing to the next stack")
 
         if corrupted_stacks > 0:
             logger.warning(f"phpspy: {corrupted_stacks} corrupted stacks")

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -180,7 +180,7 @@ class PythonEbpfProfiler(ProfilerBase):
                 return
 
             try:
-                uname = subprocess.check_output(["uname", "-r"]).decode('latin-1').strip()
+                uname = subprocess.check_output(["uname", "-r"]).decode("latin-1").strip()
             except subprocess.CalledProcessError:
                 return
 
@@ -194,17 +194,17 @@ class PythonEbpfProfiler(ProfilerBase):
             lib_modules_uname_path = f"/lib/modules/{uname}"
 
             # We're using /dev/shm as it is a tmpfs mount, while /tmp isn't.
-            os.makedirs('/dev/shm/modules_mount/upper', 555)
-            os.makedirs('/dev/shm/modules_mount/workdir', 555)
+            os.makedirs("/dev/shm/modules_mount/upper", 555)
+            os.makedirs("/dev/shm/modules_mount/workdir", 555)
             subprocess.check_call(
                 [
-                    'mount',
-                    '-t',
-                    'overlay',
-                    'overlay',
-                    '-o',
-                    f'upperdir=/dev/shm/modules_mount/upper,lowerdir={lib_modules_uname_path}'
-                    ',workdir=/dev/shm/modules_mount/workdir',
+                    "mount",
+                    "-t",
+                    "overlay",
+                    "overlay",
+                    "-o",
+                    f"upperdir=/dev/shm/modules_mount/upper,lowerdir={lib_modules_uname_path}"
+                    ",workdir=/dev/shm/modules_mount/workdir",
                     lib_modules_uname_path,
                 ]
             )
@@ -213,7 +213,7 @@ class PythonEbpfProfiler(ProfilerBase):
             link_target = os.readlink(build_path)
             # We're assuming the actual headers on the host are under /usr/src,
             # otherwise we wouldn't have access from inside the container any how.
-            new_target = re.sub(r'(\.\./)+usr/src', '/usr/src', link_target, count=1)
+            new_target = re.sub(r"(\.\./)+usr/src", "/usr/src", link_target, count=1)
             os.unlink(build_path)
             os.symlink(new_target, build_path)
         except BaseException:

--- a/gprofiler/profilers/ruby.py
+++ b/gprofiler/profilers/ruby.py
@@ -56,7 +56,7 @@ class RbSpyProfiler(ProcessProfilerBase):
 
     def _profile_process(self, process: Process) -> StackToSampleCount:
         logger.info(
-            f"Profiling process {process.pid} with rbspy", cmdline=' '.join(process.cmdline()), no_extra_to_server=True
+            f"Profiling process {process.pid} with rbspy", cmdline=" ".join(process.cmdline()), no_extra_to_server=True
         )
 
         local_output_path = os.path.join(self._storage_dir, f"rbspy.{random_prefix()}.{process.pid}.col")

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -55,7 +55,7 @@ def resource_path(relative_path: str = "") -> str:
         with importlib_resources.path(package, basename) as path:
             return str(path)
     except ImportError as e:
-        raise Exception(f'Resource {relative_path!r} not found!') from e
+        raise Exception(f"Resource {relative_path!r} not found!") from e
 
 
 @lru_cache(maxsize=None)
@@ -505,7 +505,7 @@ def limit_frequency(limit: Optional[int], requested: int, msg_header: str, runti
 
 
 def random_prefix() -> str:
-    return ''.join(random.choice(string.ascii_letters) for _ in range(16))
+    return "".join(random.choice(string.ascii_letters) for _ in range(16))
 
 
 def process_comm(process: Process) -> str:
@@ -531,7 +531,7 @@ def is_pyinstaller() -> bool:
     Are we running in PyInstaller?
     """
     # https://pyinstaller.readthedocs.io/en/stable/runtime-information.html#run-time-information
-    return getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS')
+    return getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS")
 
 
 def get_staticx_dir() -> Optional[str]:

--- a/lint.sh
+++ b/lint.sh
@@ -11,6 +11,6 @@ if [[ "$1" = "--ci" ]]; then
 fi
 
 isort --settings-file .isort.cfg .
-black --line-length 120 --skip-string-normalization $check_arg .
+black --line-length 120 $check_arg .
 flake8 --config .flake8 .
 mypy .


### PR DESCRIPTION
## Description
@d3dave , it was disabled by you in #47 . I don't recall why. Now, it's become quite annoying for me to manually fix strings :sweat_smile: 

Personally I prefer `"` to `'` but I really don't mind configuring either (I suppose `black` supports it?). Just let's keep it a standard and let the linter do its job.

@alonbentamar tagging you as well because I know you're up for `'`s.