### PR TITLE
python: PyPerf w/o kernel headers :)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,12 +36,10 @@ RUN ./rbspy_build.sh
 RUN mv /rbspy/target/$(uname -m)-unknown-linux-musl/release/rbspy /rbspy/rbspy
 
 # perf
-FROM ubuntu${PERF_BUILDER_UBUNTU} AS perf-builder-base
+FROM ubuntu${PERF_BUILDER_UBUNTU} AS perf-builder
 
 COPY scripts/perf_env.sh .
 RUN ./perf_env.sh
-
-FROM perf-builder-base AS perf-builder
 
 COPY scripts/libunwind_build.sh .
 RUN ./libunwind_build.sh
@@ -58,13 +56,12 @@ RUN apt-get update && apt-get install -y git && if [ $(uname -m) = "aarch64" ]; 
 # bcc helpers
 FROM bcc-builder-base AS bcc-helpers
 
-RUN git clone -b work --depth=1 --recurse-submodules https://github.com/Jongy/bpf_get_fs_offset.git && git -C bpf_get_fs_offset reset --hard a8eb70e41295b2301aa4d1873106a2f22b6c8bdc
+RUN apt install -y clang-10
 
 COPY --from=perf-builder /bpftool /bpftool
 
-RUN apt install -y clang-10
-
-RUN cd /bpf_get_fs_offset && make BPFTOOL=/bpftool CLANG=clang-10 LLVM_STRIP=llvm-strip-10 CFLAGS=-static
+COPY scripts/bcc_helpers_build.sh .
+RUN ./bcc_helpers_build.sh
 
 FROM bcc-builder-base AS bcc-builder
 
@@ -122,6 +119,7 @@ COPY --from=bcc-builder /bcc/bcc/LICENSE.txt gprofiler/resources/python/pyperf/
 COPY --from=bcc-builder /bcc/bcc/licenses gprofiler/resources/python/pyperf/licenses
 COPY --from=bcc-builder /bcc/bcc/NOTICE gprofiler/resources/python/pyperf/
 COPY --from=bcc-helpers /bpf_get_fs_offset/get_fs_offset gprofiler/resources/python/pyperf/
+COPY --from=bcc-helpers /bpf_get_stack_offset/get_stack_offset gprofiler/resources/python/pyperf/
 
 COPY --from=pyspy-builder /py-spy/py-spy gprofiler/resources/python/py-spy
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ For each profiling session (each profiling duration), gProfiler produces outputs
     * `pyspy`/`py-spy` - Use py-spy.
     * `disabled` - Disable profilers for Python.
 
-Profiling using eBPF incurs lower overhead & provides kernel stacks. This (currently) requires kernel headers to be installed.
+Profiling using eBPF incurs lower overhead & provides kernel stacks.
 
 ### PHP profiling options
 * `--php-mode phpspy`: Enable PHP profiling with phpspy.
@@ -106,14 +106,9 @@ Run the following to have gProfiler running continuously, uploading to Granulate
 docker pull granulate/gprofiler:latest
 docker run --name granulate-gprofiler -d --restart=on-failure:10 \
     --pid=host --userns=host --privileged \
-    -v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro \
     -v /var/run/docker.sock:/var/run/docker.sock \
 	granulate/gprofiler:latest -cu --token <token> --service-name <service> [options]
 ```
-
-For profiling with eBPF, kernel headers must be accessible from within the container at
-`/lib/modules/$(uname -r)/build`. On Ubuntu, this directory is a symlink pointing to `/usr/src`.
-The command above mounts both of these directories.
 
 ## Running as an executable
 First, check if gProfiler is already running - run `pgrep gprofiler`. You should not see any output, if you do see any PIDs it means that gProfiler is running and it must be stopped before starting it again (you can stop it with `sudo pkill -TERM gprofiler`).

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -10,7 +10,5 @@ services:
     privileged: true
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - /lib/modules:/lib/modules:ro
-      - /usr/src:/usr/src:ro
 
     command: '-cu --token "<TOKEN>" --service-name "<SERVICE NAME>"'

--- a/deploy/ecs/gprofiler_task_definition.json
+++ b/deploy/ecs/gprofiler_task_definition.json
@@ -20,16 +20,6 @@
                 {
                   "containerPath": "/var/run/docker.sock",
                   "sourceVolume": "docker-socket"
-                },
-                {
-                  "containerPath": "/usr/src",
-                  "sourceVolume": "usr-src",
-                  "readOnly": true
-                },
-                {
-                  "containerPath": "/lib/modules",
-                  "sourceVolume": "lib-modules",
-                  "readOnly": true
                 }
             ],
             "user": "0:0",

--- a/deploy/k8s/gprofiler.yaml
+++ b/deploy/k8s/gprofiler.yaml
@@ -20,12 +20,6 @@ spec:
         app: granulate-gprofiler
     spec:
       volumes:
-        - name: lib-modules
-          hostPath:
-            path: /lib/modules
-        - name: usr-src
-          hostPath:
-            path: /usr/src
         - name: docker-sock # Allow containers to fetch the names
           hostPath:
             path: /var/run/docker.sock
@@ -48,12 +42,6 @@ spec:
           image: index.docker.io/granulate/gprofiler:latest
           imagePullPolicy: Always
           volumeMounts:
-            - name: lib-modules
-              mountPath: /lib/modules
-              readOnly: true
-            - name: usr-src
-              mountPath: /usr/src
-              readOnly: true
             - name: docker-sock
               mountPath: /var/run/docker.sock
           args:

--- a/gprofiler/metadata/system_metadata.py
+++ b/gprofiler/metadata/system_metadata.py
@@ -59,10 +59,14 @@ def get_libc_version() -> Tuple[str, str]:
     return "unknown", decode_libc_version(ldd_version)
 
 
+def is_container() -> bool:
+    return os.getenv("GPROFILER_IN_CONTAINER") is not None  # set by our Dockerfile
+
+
 def get_run_mode() -> str:
     if os.getenv("GPROFILER_IN_K8S") is not None:  # set in k8s/gprofiler.yaml
         return "k8s"
-    elif os.getenv("GPROFILER_IN_CONTAINER") is not None:  # set by our Dockerfile
+    elif is_container():
         return "container"
     elif is_pyinstaller():
         return "standalone_executable"

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -17,7 +17,7 @@ from gprofiler.exceptions import CalledProcessError, ProcessStoppedException, St
 from gprofiler.gprofiler_types import ProcessToStackSampleCounters, StackToSampleCount, nonnegative_integer
 from gprofiler.log import get_logger_adapter
 from gprofiler.merge import parse_many_collapsed, parse_one_collapsed_file
-from gprofiler.metadata.system_metadata import get_arch, is_container
+from gprofiler.metadata.system_metadata import get_arch
 from gprofiler.profilers.profiler_base import ProcessProfilerBase, ProfilerBase, ProfilerInterface
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
 from gprofiler.utils import (
@@ -174,11 +174,11 @@ class PythonEbpfProfiler(ProfilerBase):
     @staticmethod
     def _ebpf_environment() -> None:
         """
-        In container environments - make some changes so libbpf-based programs can run.
+        Make sure the environment is ready so that libbpf-based programs can run.
+        Technically this is needed only for container environments, but there's no reason not
+        to verify those conditions stand anyway (and during our tests - we run gProfiler's executable
+        in a container, so these steps have to run)
         """
-        if not is_container():
-            return
-
         # increase memlock (Docker defaults to 64k which is not enough for the get_offset programs)
         resource.setrlimit(resource.RLIMIT_MEMLOCK, (resource.RLIM_INFINITY, resource.RLIM_INFINITY))
 

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -133,6 +133,7 @@ class PythonEbpfError(CalledProcessError):
 class PythonEbpfProfiler(ProfilerBase):
     MAX_FREQUENCY = 1000
     PYPERF_RESOURCE = "python/pyperf/PyPerf"
+    GET_FS_OFFSET_RESOURCE = "python/pyperf/get_fs_offset"
     events_buffer_pages = 256  # 1mb and needs to be physically contiguous
     # 28mb (each symbol is 224 bytes), but needn't be physicall contiguous so don't care
     symbols_map_size = 131072
@@ -263,7 +264,17 @@ class PythonEbpfProfiler(ProfilerBase):
         # Run the process and check if the output file is properly created.
         # Wait up to 10sec for the process to terminate.
         # Allow cancellation via the stop_event.
-        cmd = [resource_path(cls.PYPERF_RESOURCE), "--output", str(test_path), "-F", "1", "--duration", "1"]
+        cmd = [
+            resource_path(cls.PYPERF_RESOURCE),
+            "--output",
+            str(test_path),
+            "-F",
+            "1",
+            "--duration",
+            "1",
+            "--get-fs-offset",
+            resource_path(cls.GET_FS_OFFSET_RESOURCE),
+        ]
         process = start_process(cmd, via_staticx=True)
         try:
             poll_process(process, cls.poll_timeout, stop_event)
@@ -285,6 +296,8 @@ class PythonEbpfProfiler(ProfilerBase):
             str(self.events_buffer_pages),
             "--symbols-map-size",
             str(self.symbols_map_size),
+            "--get-fs-offset",
+            resource_path(self.GET_FS_OFFSET_RESOURCE)
             # Duration is irrelevant here, we want to run continuously.
         ]
 

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -130,7 +130,8 @@ RUN tar -xf elfutils-0.179.tar.bz2 && \
 
 COPY --from=perf-builder /bpftool /bpftool
 
-RUN git clone -b work --depth=1 --recurse-submodules https://github.com/Jongy/bpf_get_fs_offset.git && cd bpf_get_fs_offset && git reset --hard 675620c5785a309958cadf2e4af9b46b4f3331c8
+RUN git clone -b v0.0.1 --depth=1 --recurse-submodules https://github.com/Jongy/bpf_get_fs_offset.git && cd bpf_get_fs_offset && git reset --hard 85bbdb3d3b54406944a0f6d8c77117e4d4a35f3e
+RUN git clone -b v0.0.1 --depth=1 --recurse-submodules https://github.com/Jongy/bpf_get_stack_offset.git && cd bpf_get_fs_offset && git reset --hard 7e1aa6148efe2abea54fb5ffb332da2e6426396c
 
 RUN cd /bpf_get_fs_offset && make BPFTOOL=/bpftool CLANG=clang-10 LLVM_STRIP=llvm-strip CFLAGS=-static
 
@@ -171,6 +172,7 @@ RUN cp /bcc/bcc/LICENSE.txt gprofiler/resources/python/pyperf/
 RUN cp -r /bcc/bcc/licenses gprofiler/resources/python/pyperf/licenses
 RUN cp /bcc/bcc/NOTICE gprofiler/resources/python/pyperf/
 COPY --from=bcc-helpers /bpf_get_fs_offset/get_fs_offset gprofiler/resources/python/pyperf/
+COPY --from=bcc-helpers /bpf_get_stack_offset/get_stack_offset gprofiler/resources/python/pyperf/
 
 COPY --from=pyspy-builder /py-spy/py-spy gprofiler/resources/python/py-spy
 COPY --from=rbspy-builder /rbspy/rbspy gprofiler/resources/ruby/rbspy

--- a/scripts/bcc_helpers_build.sh
+++ b/scripts/bcc_helpers_build.sh
@@ -20,10 +20,10 @@ fi
 
 LIBBPF_MAKE_FLAGS="BPFTOOL=/bpftool CLANG=clang-10 LLVM_STRIP=$LLVM_STRIP CFLAGS=-static"
 
-cd / && git clone -b v0.0.1 --depth=1 --recurse-submodules https://github.com/Jongy/bpf_get_fs_offset.git
-cd /bpf_get_fs_offset && git reset --hard 85bbdb3d3b54406944a0f6d8c77117e4d4a35f3e
+cd / && git clone -b v0.0.2 --depth=1 --recurse-submodules https://github.com/Jongy/bpf_get_fs_offset.git
+cd /bpf_get_fs_offset && git reset --hard 8326d39cf44845d4b643ed4267994afca8ccecb3
 cd /bpf_get_fs_offset && make $LIBBPF_MAKE_FLAGS
 
-cd / && git clone -b v0.0.1 --depth=1 --recurse-submodules https://github.com/Jongy/bpf_get_stack_offset.git
-cd /bpf_get_stack_offset && git reset --hard 7e1aa6148efe2abea54fb5ffb332da2e6426396c
+cd / && git clone -b v0.0.2 --depth=1 --recurse-submodules https://github.com/Jongy/bpf_get_stack_offset.git
+cd /bpf_get_stack_offset && git reset --hard bd0d4d9a0c4351710d116016e321045496a9eedc
 cd /bpf_get_stack_offset && make $LIBBPF_MAKE_FLAGS

--- a/scripts/bcc_helpers_build.sh
+++ b/scripts/bcc_helpers_build.sh
@@ -5,10 +5,25 @@
 #
 set -euo pipefail
 
-LIBBPF_MAKE_FLAGS="BPFTOOL=/bpftool CLANG=clang-10 LLVM_STRIP=llvm-strip-10 CFLAGS=-static"
+# TODO support aarch64, after we support it in PyPerf
+if [ $(uname -m) != "x86_64" ]; then
+    mkdir -p /bpf_get_fs_offset /bpf_get_stack_offset
+    touch /bpf_get_fs_offset/get_fs_offset
+    touch /bpf_get_stack_offset/get_stack_offset
+    exit 0
+fi
 
-git clone -b v0.0.1 --depth=1 --recurse-submodules https://github.com/Jongy/bpf_get_fs_offset.git && cd bpf_get_fs_offset && git reset --hard 85bbdb3d3b54406944a0f6d8c77117e4d4a35f3e
+LLVM_STRIP=llvm-strip
+if ! command -v "$LLVM_STRIP" > /dev/null 2>&1 ; then
+    LLVM_STRIP=llvm-strip-10
+fi
+
+LIBBPF_MAKE_FLAGS="BPFTOOL=/bpftool CLANG=clang-10 LLVM_STRIP=$LLVM_STRIP CFLAGS=-static"
+
+cd / && git clone -b v0.0.1 --depth=1 --recurse-submodules https://github.com/Jongy/bpf_get_fs_offset.git
+cd /bpf_get_fs_offset && git reset --hard 85bbdb3d3b54406944a0f6d8c77117e4d4a35f3e
 cd /bpf_get_fs_offset && make $LIBBPF_MAKE_FLAGS
 
-git clone -b v0.0.1 --depth=1 --recurse-submodules https://github.com/Jongy/bpf_get_stack_offset.git && cd bpf_get_fs_offset && git reset --hard 7e1aa6148efe2abea54fb5ffb332da2e6426396c
+cd / && git clone -b v0.0.1 --depth=1 --recurse-submodules https://github.com/Jongy/bpf_get_stack_offset.git
+cd /bpf_get_stack_offset && git reset --hard 7e1aa6148efe2abea54fb5ffb332da2e6426396c
 cd /bpf_get_stack_offset && make $LIBBPF_MAKE_FLAGS

--- a/scripts/bcc_helpers_build.sh
+++ b/scripts/bcc_helpers_build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) Granulate. All rights reserved.
+# Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
+#
+set -euo pipefail
+
+LIBBPF_MAKE_FLAGS="BPFTOOL=/bpftool CLANG=clang-10 LLVM_STRIP=llvm-strip-10 CFLAGS=-static"
+
+git clone -b v0.0.1 --depth=1 --recurse-submodules https://github.com/Jongy/bpf_get_fs_offset.git && cd bpf_get_fs_offset && git reset --hard 85bbdb3d3b54406944a0f6d8c77117e4d4a35f3e
+cd /bpf_get_fs_offset && make $LIBBPF_MAKE_FLAGS
+
+git clone -b v0.0.1 --depth=1 --recurse-submodules https://github.com/Jongy/bpf_get_stack_offset.git && cd bpf_get_fs_offset && git reset --hard 7e1aa6148efe2abea54fb5ffb332da2e6426396c
+cd /bpf_get_stack_offset && make $LIBBPF_MAKE_FLAGS

--- a/scripts/perf_build.sh
+++ b/scripts/perf_build.sh
@@ -45,6 +45,7 @@ EOF
 fi
 
 make -C tools/perf LDFLAGS=-static -j 8 perf
-make -C tools/bpf LDFLAGS=-static -j 8 bpftool
 cp tools/perf/perf /
+# don't need it static - it's only used during the build
+make -C tools/bpf -j 8 bpftool
 cp tools/bpf/bpftool/bpftool /

--- a/scripts/perf_build.sh
+++ b/scripts/perf_build.sh
@@ -45,4 +45,6 @@ EOF
 fi
 
 make -C tools/perf LDFLAGS=-static -j 8 perf
-cp tools/perf/perf /perf
+make -C tools/bpf LDFLAGS=-static -j 8 bpftool
+cp tools/perf/perf /
+cp tools/bpf/bpftool/bpftool /

--- a/scripts/perf_build.sh
+++ b/scripts/perf_build.sh
@@ -46,6 +46,6 @@ fi
 
 make -C tools/perf LDFLAGS=-static -j 8 perf
 cp tools/perf/perf /
-# don't need it static - it's only used during the build
-make -C tools/bpf -j 8 bpftool
+# need it static as well, even though it's used only during build (relies on libpcap, ...)
+make -C tools/bpf LDFLAGS=-static -j 8 bpftool
 cp tools/bpf/bpftool/bpftool /

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -5,7 +5,7 @@
 #
 set -e
 
-git clone --depth 1 -b kernelheaders-less https://github.com/Granulate/bcc.git && cd bcc && git reset --hard c4cf9f5d8fa1002662ae691afe14dfafbf1800d8
+git clone --depth 1 -b v1.2.0 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 3fd97d89efb79553a20e16653c2538b14674f6c6
 
 # (after clone, because we copy the licenses)
 # TODO support aarch64

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -5,7 +5,7 @@
 #
 set -e
 
-git clone --depth 1 -b kernelheaders-less https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 4769de3bbef42cb6e9096ede48d38e36e1e95572
+git clone --depth 1 -b kernelheaders-less https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 07b8eea7064c7dc9d83e0454d31e5ac707bacb7c
 
 # (after clone, because we copy the licenses)
 # TODO support aarch64

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -5,7 +5,7 @@
 #
 set -e
 
-git clone --depth 1 -b kernelheaders-less https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 938ec5b422fc10023c16926074db929a4c2c7679
+git clone --depth 1 -b kernelheaders-less https://github.com/Granulate/bcc.git && cd bcc && git reset --hard c4cf9f5d8fa1002662ae691afe14dfafbf1800d8
 
 # (after clone, because we copy the licenses)
 # TODO support aarch64

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -5,7 +5,7 @@
 #
 set -e
 
-git clone --depth 1 -b v1.1.2 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 8509fb0f8dfa096b08d0b3619686e7948165406a
+git clone --depth 1 -b kernelheaders-less https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 4769de3bbef42cb6e9096ede48d38e36e1e95572
 
 # (after clone, because we copy the licenses)
 # TODO support aarch64

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -5,7 +5,7 @@
 #
 set -e
 
-git clone --depth 1 -b kernelheaders-less https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 07b8eea7064c7dc9d83e0454d31e5ac707bacb7c
+git clone --depth 1 -b kernelheaders-less https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 938ec5b422fc10023c16926074db929a4c2c7679
 
 # (after clone, because we copy the licenses)
 # TODO support aarch64

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,9 +22,17 @@ from tests.utils import assert_function_in_collapsed, chmod_path_parts
 
 
 @fixture
-def runtime():
+def runtime() -> str:
     """
-    Parametrize this with application runtime name (java, python).
+    Parametrize this with application runtime name (java, python, ..).
+    """
+    raise NotImplementedError
+
+
+@fixture
+def profiler_type() -> str:
+    """
+    Parametrize this with runtime profiler name (ap, py-spy, ...).
     """
     raise NotImplementedError
 
@@ -45,7 +53,7 @@ def in_container(request) -> bool:
 
 
 @fixture
-def java_args():
+def java_args() -> List[str]:
     return []
 
 
@@ -257,7 +265,7 @@ def exec_container_image(request, docker_client: DockerClient) -> Optional[Image
 
 
 @fixture
-def no_kernel_headers():
+def no_kernel_headers() -> Iterable[None]:
     release = os.uname().release
     headers_dir = f"/lib/modules/{release}"
     tmp_headers = f"{headers_dir}_tmp_moved"
@@ -270,6 +278,15 @@ def no_kernel_headers():
     finally:
         if os.path.exists(tmp_headers):
             os.rename(tmp_headers, headers_dir)
+
+
+@fixture
+def profiler_flags(runtime: str, profile_type: str) -> List[str]:
+    # Execute only the tested profiler
+    flags = ["--no-java", "--no-python", "--no-php", "--no-ruby"]
+    flags.remove(f"--no-{runtime}")
+    flags.append(f"--{runtime}-mode={profiler_type}")
+    return flags
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -283,7 +283,7 @@ def no_kernel_headers() -> Iterable[None]:
 @fixture
 def profiler_flags(runtime: str, profiler_type: str) -> List[str]:
     # Execute only the tested profiler
-    flags = ["--no-java", "--no-python", "--no-php", "--no-ruby"]
+    flags = ["--no-java", "--no-python", "--no-php", "--no-ruby", "--no-nodejs"]
     flags.remove(f"--no-{runtime}")
     flags.append(f"--{runtime}-mode={profiler_type}")
     return flags

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -252,7 +252,7 @@ def assert_collapsed(runtime: str) -> Callable[[Mapping[str, int], bool], None]:
         "nodejs": "fibonacci",
     }[runtime]
 
-    return partial(assert_function_in_collapsed, function_name, runtime)
+    return partial(assert_function_in_collapsed, function_name)
 
 
 @fixture
@@ -281,7 +281,7 @@ def no_kernel_headers() -> Iterable[None]:
 
 
 @fixture
-def profiler_flags(runtime: str, profile_type: str) -> List[str]:
+def profiler_flags(runtime: str, profiler_type: str) -> List[str]:
     # Execute only the tested profiler
     flags = ["--no-java", "--no-python", "--no-php", "--no-ruby"]
     flags.remove(f"--no-{runtime}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -256,6 +256,22 @@ def exec_container_image(request, docker_client: DockerClient) -> Optional[Image
     return docker_client.images.pull(image_name)
 
 
+@fixture
+def no_kernel_headers():
+    release = os.uname().release
+    headers_dir = f"/lib/modules/{release}"
+    tmp_headers = f"{headers_dir}_tmp_moved"
+    assert not os.path.exists(tmp_headers), "leftovers! please clean it up"
+
+    try:
+        if os.path.exists(headers_dir):
+            os.rename(headers_dir, tmp_headers)
+        yield
+    finally:
+        if os.path.exists(tmp_headers):
+            os.rename(tmp_headers, headers_dir)
+
+
 def pytest_addoption(parser):
     parser.addoption("--exec-container-image", action="store", default=None)
     parser.addoption("--executable", action="store", default=None)

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -15,7 +15,17 @@ from gprofiler.merge import parse_one_collapsed
 from tests.utils import run_gprofiler_in_container
 
 
-@pytest.mark.parametrize("runtime", ["java", "python", "php", "ruby", "nodejs"])
+@pytest.mark.parametrize(
+    "runtime,profiler_type",
+    [
+        ("java", "ap"),
+        ("python", "py-spy"),
+        ("python", "pyperf"),
+        ("php", "phpspy"),
+        ("ruby", "rbspy"),
+        ("nodejs", "perf"),
+    ],
+)
 def test_from_executable(
     gprofiler_exe: Path,
     application_pid: int,
@@ -25,12 +35,14 @@ def test_from_executable(
     docker_client: DockerClient,
     output_directory: Path,
     runtime: str,
+    profiler_type: str,
 ) -> None:
     _ = application_pid  # Fixture only used for running the application.
 
     # Execute only the tested profiler
     flags = ["--no-java", "--no-python", "--no-php", "--no-ruby"]
     flags.remove(f"--no-{runtime}")
+    flags.append(f"--{runtime}-mode={profiler_type}")
 
     if exec_container_image is not None:
         gprofiler_inner_dir = Path("/app")

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -79,9 +79,7 @@ def test_java_async_profiler_cpu_mode(
         assert len(result) == 1
         process_collapsed = result[next(iter(result.keys()))]
         assert_collapsed(process_collapsed, check_comm=True)
-        assert_function_in_collapsed(
-            "do_syscall_64_[k]", "java", process_collapsed, True
-        )  # ensure kernels stacks exist
+        assert_function_in_collapsed("do_syscall_64_[k]", process_collapsed, True)  # ensure kernels stacks exist
 
 
 @pytest.mark.parametrize("in_container", [True])
@@ -111,9 +109,7 @@ def test_java_async_profiler_musl_and_cpu(
         assert len(result) == 1
         process_collapsed = result[next(iter(result.keys()))]
         assert_collapsed(process_collapsed, check_comm=True)
-        assert_function_in_collapsed(
-            "do_syscall_64_[k]", "java", process_collapsed, True
-        )  # ensure kernels stacks exist
+        assert_function_in_collapsed("do_syscall_64_[k]", process_collapsed, True)  # ensure kernels stacks exist
 
 
 def test_java_safemode_parameters(tmp_path) -> None:

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -105,6 +105,7 @@ def test_python_ebpf(
     assert_collapsed,
     gprofiler_docker_image: Image,
     runtime: str,
+    no_kernel_headers,
 ) -> None:
     with PythonEbpfProfiler(1000, 5, Event(), str(tmp_path)) as profiler:
         collapsed = profiler.snapshot()

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -131,8 +131,6 @@ def test_from_container(
     _ = application_pid  # Fixture only used for running the application.
     inner_output_directory = "/tmp/gprofiler"
     volumes = {
-        "/usr/src": {"bind": "/usr/src", "mode": "ro"},
-        "/lib/modules": {"bind": "/lib/modules", "mode": "ro"},
         str(output_directory): {"bind": inner_output_directory, "mode": "rw"},
     }
 

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -49,7 +49,6 @@ def test_pyspy(
     tmp_path: Path,
     application_pid: int,
     assert_collapsed,
-    runtime: str,
 ) -> None:
     with PySpyProfiler(1000, 1, Event(), str(tmp_path)) as profiler:
         process_collapsed = profiler.snapshot().get(application_pid)
@@ -61,7 +60,6 @@ def test_phpspy(
     tmp_path: Path,
     application_pid: int,
     assert_collapsed,
-    runtime: str,
 ) -> None:
     with PHPSpyProfiler(
         1000, PHPSPY_DURATION, Event(), str(tmp_path), php_process_filter="php", php_mode="phpspy"
@@ -76,7 +74,6 @@ def test_rbspy(
     application_pid: int,
     assert_collapsed,
     gprofiler_docker_image: Image,
-    runtime: str,
 ) -> None:
     with RbSpyProfiler(1000, 3, Event(), str(tmp_path), "rbspy") as profiler:
         process_collapsed = profiler.snapshot().get(application_pid)
@@ -89,7 +86,6 @@ def test_nodejs(
     application_pid: int,
     assert_collapsed,
     gprofiler_docker_image: Image,
-    runtime: str,
 ) -> None:
     with SystemProfiler(
         1000, 6, Event(), str(tmp_path), perf_mode="fp", perf_inject=True, perf_dwarf_stack_size=0
@@ -104,18 +100,15 @@ def test_python_ebpf(
     application_pid: int,
     assert_collapsed,
     gprofiler_docker_image: Image,
-    runtime: str,
     no_kernel_headers,
 ) -> None:
     with PythonEbpfProfiler(1000, 5, Event(), str(tmp_path)) as profiler:
         collapsed = profiler.snapshot()
         process_collapsed = collapsed.get(application_pid)
         assert_collapsed(process_collapsed, check_comm=True)
+        assert_function_in_collapsed("do_syscall_64_[k]", process_collapsed, True)  # ensure kernels stacks exist
         assert_function_in_collapsed(
-            "do_syscall_64_[k]", "python", process_collapsed, True
-        )  # ensure kernels stacks exist
-        assert_function_in_collapsed(
-            "_PyEval_EvalFrameDefault_[pn]", "python", process_collapsed, True
+            "_PyEval_EvalFrameDefault_[pn]", process_collapsed, True
         )  # ensure native user stacks exist
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,6 +7,15 @@ from docker import DockerClient
 from docker.models.containers import Container
 from docker.models.images import Image
 
+RUNTIME_PROFILERS = [
+    ("java", "ap"),
+    ("python", "py-spy"),
+    ("python", "pyperf"),
+    ("php", "phpspy"),
+    ("ruby", "rbspy"),
+    ("nodejs", "perf"),
+]
+
 
 def run_privileged_container(
     docker_client: DockerClient,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -84,9 +84,7 @@ def chmod_path_parts(path: Path, add_mode: int) -> None:
         os.chmod(subpath, os.stat(subpath).st_mode | add_mode)
 
 
-def assert_function_in_collapsed(
-    function_name: str, runtime: str, collapsed: Mapping[str, int], check_comm: bool = False
-) -> None:
+def assert_function_in_collapsed(function_name: str, collapsed: Mapping[str, int], check_comm: bool = False) -> None:
     print(f"collapsed: {collapsed}")
     assert any(
         (function_name in record) for record in collapsed.keys()


### PR DESCRIPTION
This is ~~a PoC of running~~ PyPerf w/o kernel headers.

~~Container mode doesn't work yet. Running `get_fs_offset` fails. Also when I add `memlock=999999999` and  `-v /sys/kernel/tracing....` (which bypass some of the erros). The `get_fs_offset` program still fails and I need to debug that.~~

~~Exe mode works - I have deleted my local kernel headers. and PyPerf still works :)~~

Both container & exe work.

Based on:
* https://github.com/Granulate/bcc/pull/28
* https://github.com/Jongy/bpf_get_fs_offset
* https://github.com/Jongy/bpf_get_stack_offset

Tasks left:
* [x] Make sure the sanity test (with the `no_kernel_headers` fixture) passes
* [x] Add tests for executable/container cases (not directly using `PythonEbpfProfiler`)
* [x] Merge https://github.com/Granulate/bcc/pull/28 and update the pinned git revision here
* [ ] Update installation instructions in the backend - remove the `-v /lib/modules` etc
* [x] Fix native stacks - they are broken on this branch (and this is why the tests currently fail)

Test `get_fs_offset` and `get_stack_offset` on more kernel versions:
* [x] 5.4.0-90-generic
* [x] 4.18.0-193.19.1.el8_2.x86_64
* [x] 5.11.0-1021-aws
* [x] 4.14.248-189.473.amzn2.x86_64 (this one actually required lots of fixes :sad: )