### PR TITLE
Java: Check for Hotspot error files after process termination

### DIFF
--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -41,6 +41,7 @@ from gprofiler.utils import (
     atomically_symlink,
     get_iso8601_format_time,
     grab_gprofiler_mutex,
+    is_process_running,
     is_root,
     is_running_in_init_pid,
     reset_umask,
@@ -347,9 +348,7 @@ class GProfiler:
                 # wait for one duration
                 self._stop_event.wait(max(self._duration - (time.monotonic() - snapshot_start), 0))
 
-                if self._controller_process is not None and (
-                    not self._controller_process.is_running() or self._controller_process.status() == "zombie"
-                ):
+                if self._controller_process is not None and not is_process_running(self._controller_process):
                     logger.info(f"Controller process {self._controller_process.pid} has exited; gProfiler stopping...")
                     break
 

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -541,11 +541,12 @@ class JavaProfiler(ProcessProfilerBase):
             return parse_one_collapsed(output, process_comm(ap_proc.process))
 
     def _check_hotspot_error(self, ap_proc):
+        pid = ap_proc.process.pid
         error_file = ap_proc.locate_hotspot_error_file()
         if not error_file:
+            logger.debug(f"No Hotspot error log for pid {pid}")
             return
 
-        pid = ap_proc.process.pid
         contents = open(error_file).read()
         m = VM_INFO_REGEX.search(contents)
         vm_info = m[1] if m else ""

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -41,6 +41,7 @@ from gprofiler.utils import (
 NATIVE_FRAMES_REGEX = re.compile(r'^Native frames:[^\n]*\n(.*?)\n\n', re.MULTILINE | re.DOTALL)
 SIGINFO_REGEX = re.compile(r'^siginfo: ([^\n]*)', re.MULTILINE | re.DOTALL)
 CONTAINER_INFO_REGEX = re.compile(r'^container \(cgroup\) information:\n(.*?)\n\n', re.MULTILINE | re.DOTALL)
+VM_INFO_REGEX = re.compile(r'^vm_info: ([^\n]*)', re.MULTILINE | re.DOTALL)
 
 logger = get_logger_adapter(__name__)
 
@@ -466,6 +467,8 @@ class JavaProfiler(ProcessProfilerBase):
     def _log_hotspot_error(self, pid, path):
         logger.info(f"Found Hotspot error log at {path}")
         contents = open(path).read()
+        if m := VM_INFO_REGEX.search(contents):
+            logger.error(f'Pid {pid} Hotspot VM info:\n{m[1]}')
         if m := SIGINFO_REGEX.search(contents):
             logger.error(f'Pid {pid} Hotspot siginfo: {m[1]}')
         if m := NATIVE_FRAMES_REGEX.search(contents):

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -90,6 +90,7 @@ class AsyncProfiledProcess:
         # there is a hidden assumption here that neither the ancestor nor the process will change their mount
         # namespace. I think it's okay to assume that.
         self._process_root = f"/proc/{get_mnt_ns_ancestor(process)}/root"
+        self.host_cwd = resolve_proc_root_links(self._process_root, process.cwd())
         # not using storage_dir for AP itself on purpose: this path should remain constant for the lifetime
         # of the target process, so AP is loaded exactly once (if we have multiple paths, AP can be loaded
         # multiple times into the process)
@@ -435,6 +436,10 @@ class JavaProfiler(ProcessProfilerBase):
             # Process still running
             ap_proc.stop_async_profiler(True)
         else:
+            # Process terminated, was it due to an error?
+            hs_err_path = f'{ap_proc.host_cwd}/hs_err_pid{ap_proc.process.pid}.log'
+            if os.path.isfile(hs_err_path):
+                logger.warning(f"Found Hotspot error log at {hs_err_path}")
             logger.debug(f"Profiled process {ap_proc.process.pid} exited before stopping async-profiler")
             # no output in this case :/
             return None

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -39,9 +39,55 @@ from gprofiler.utils import (
 )
 
 NATIVE_FRAMES_REGEX = re.compile(r"^Native frames:[^\n]*\n(.*?)\n\n", re.MULTILINE | re.DOTALL)
+"""
+See VMError::print_native_stack.
+Example:
+    Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
+    C  [libc.so.6+0x18e4e1]
+    C  [libasyncProfiler.so+0x1bb4e]  Profiler::dump(std::ostream&, Arguments&)+0xce
+    C  [libasyncProfiler.so+0x1bcae]  Profiler::runInternal(Arguments&, std::ostream&)+0x9e
+    C  [libasyncProfiler.so+0x1c242]  Profiler::run(Arguments&)+0x212
+    C  [libasyncProfiler.so+0x48d81]  Agent_OnAttach+0x1e1
+    V  [libjvm.so+0x7ea65b]
+    V  [libjvm.so+0x2f5e62]
+    V  [libjvm.so+0xb08d2f]
+    V  [libjvm.so+0xb0a0fa]
+    V  [libjvm.so+0x990552]
+    C  [libpthread.so.0+0x76db]  start_thread+0xdb
+"""
+
 SIGINFO_REGEX = re.compile(r"^siginfo: ([^\n]*)", re.MULTILINE | re.DOTALL)
+"""
+See os::print_siginfo
+Example:
+    siginfo: si_signo: 11 (SIGSEGV), si_code: 0 (SI_USER), si_pid: 537787, si_uid: 0
+"""
+
 CONTAINER_INFO_REGEX = re.compile(r"^container \(cgroup\) information:\n(.*?)\n\n", re.MULTILINE | re.DOTALL)
+"""
+See os::Linux::print_container_info
+Example:
+    container (cgroup) information:
+    container_type: cgroupv1
+    cpu_cpuset_cpus: 0-15
+    cpu_memory_nodes: 0
+    active_processor_count: 16
+    cpu_quota: -1
+    cpu_period: 100000
+    cpu_shares: -1
+    memory_limit_in_bytes: -1
+    memory_and_swap_limit_in_bytes: -2
+    memory_soft_limit_in_bytes: -1
+    memory_usage_in_bytes: 26905034752
+    memory_max_usage_in_bytes: 27891224576
+"""
+
 VM_INFO_REGEX = re.compile(r"^vm_info: ([^\n]*)", re.MULTILINE | re.DOTALL)
+"""
+This is the last line printed in VMError::report.
+Example:
+    vm_info: OpenJDK 64-Bit Server VM (25.292-b10) for linux-amd64 JRE (1.8.0_292-8u292-b10-0ubuntu1~18.04-b10), ...
+"""
 
 logger = get_logger_adapter(__name__)
 

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -481,13 +481,17 @@ class JavaProfiler(ProcessProfilerBase):
         pid = ap_proc.process.pid
         logger.info(f"Found Hotspot error log at {ap_proc.error_file_host}")
         contents = open(ap_proc.error_file_host).read()
-        if m := VM_INFO_REGEX.search(contents):
+        m = VM_INFO_REGEX.search(contents)
+        if m:
             logger.error(f"Pid {pid} Hotspot VM info:\n{m[1]}")
-        if m := SIGINFO_REGEX.search(contents):
+        m = SIGINFO_REGEX.search(contents)
+        if m:
             logger.error(f"Pid {pid} Hotspot siginfo: {m[1]}")
-        if m := NATIVE_FRAMES_REGEX.search(contents):
+        m = NATIVE_FRAMES_REGEX.search(contents)
+        if m:
             logger.error(f"Pid {pid} Hotspot native frames:\n{m[1]}")
-        if m := CONTAINER_INFO_REGEX.search(contents):
+        m = CONTAINER_INFO_REGEX.search(contents)
+        if m:
             logger.error(f"Pid {pid} Hotspot container info:\n{m[1]}")
 
     def _select_processes_to_profile(self) -> List[Process]:

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -205,6 +205,10 @@ class AsyncProfiledProcess:
         return os.path.isfile(resolve_proc_root_links(self._process_root, path))
 
     def locate_hotspot_error_file(self) -> Optional[str]:
+        """
+        Locate a fatal error log written by the Hotspot JVM, if one exists.
+        See https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/felog001.html.
+        """
         default_error_file = f"hs_err_pid{self.process.pid}.log"
         locations = [f"{default_error_file}", f"/tmp/{default_error_file}"]
         for arg in self._cmdline:

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -483,7 +483,7 @@ class JavaProfiler(ProcessProfilerBase):
         contents = open(ap_proc.error_file_host).read()
         m = VM_INFO_REGEX.search(contents)
         if m:
-            logger.error(f"Pid {pid} Hotspot VM info:\n{m[1]}")
+            logger.error(f"Pid {pid} Hotspot VM info: {m[1]}")
         m = SIGINFO_REGEX.search(contents)
         if m:
             logger.error(f"Pid {pid} Hotspot siginfo: {m[1]}")

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -437,8 +437,8 @@ class JavaProfiler(ProcessProfilerBase):
         try:
             wait_event(self._duration, self._stop_event, lambda: not ap_proc.process.is_running(), interval=1)
         except TimeoutError:
-            # Process still running
-            ap_proc.stop_async_profiler(True)
+            # Process still running. We will stop the profiler in finally block.
+            pass
         else:
             # Process terminated, was it due to an error?
             hs_err_path = f'{ap_proc.host_cwd}/hs_err_pid{ap_proc.process.pid}.log'
@@ -447,6 +447,9 @@ class JavaProfiler(ProcessProfilerBase):
             logger.debug(f"Profiled process {ap_proc.process.pid} exited before stopping async-profiler")
             # no output in this case :/
             return None
+        finally:
+            if ap_proc.process.is_running():
+                ap_proc.stop_async_profiler(True)
 
         output = ap_proc.read_output()
         if output is None:

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -535,20 +535,22 @@ class JavaProfiler(ProcessProfilerBase):
             return
 
         pid = ap_proc.process.pid
-        logger.info(f"Found Hotspot error log at {error_file}")
         contents = open(error_file).read()
         m = VM_INFO_REGEX.search(contents)
-        if m:
-            logger.error(f"Pid {pid} Hotspot VM info: {m[1]}")
+        vm_info = m[1] if m else ""
         m = SIGINFO_REGEX.search(contents)
-        if m:
-            logger.error(f"Pid {pid} Hotspot siginfo: {m[1]}")
+        siginfo = m[1] if m else ""
         m = NATIVE_FRAMES_REGEX.search(contents)
-        if m:
-            logger.error(f"Pid {pid} Hotspot native frames:\n{m[1]}")
+        native_frames = m[1] if m else ""
         m = CONTAINER_INFO_REGEX.search(contents)
-        if m:
-            logger.error(f"Pid {pid} Hotspot container info:\n{m[1]}")
+        container_info = m[1] if m else ""
+        logger.error(
+            f"Found Hotspot error log for pid {pid} at {error_file}:\n"
+            f"VM info: {vm_info}\n"
+            f"siginfo: {siginfo}\n"
+            f"native frames:\n{native_frames}\n"
+            f"container info:\n{container_info}"
+        )
 
     def _select_processes_to_profile(self) -> List[Process]:
         return pgrep_maps(r"^.+/libjvm\.so$")

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -5,6 +5,7 @@
 import errno
 import functools
 import os
+import re
 import shutil
 from pathlib import Path
 from threading import Event
@@ -36,6 +37,9 @@ from gprofiler.utils import (
     wait_event,
     write_perf_event_mlock_kb,
 )
+
+NATIVE_FRAMES_REGEX = re.compile(r'^Native frames:[^\n]*\n(.*?)\n\n', re.MULTILINE | re.DOTALL)
+SIGINFO_REGEX = re.compile(r'^siginfo: ([^\n]*)', re.MULTILINE | re.DOTALL)
 
 logger = get_logger_adapter(__name__)
 
@@ -439,7 +443,7 @@ class JavaProfiler(ProcessProfilerBase):
             # Process terminated, was it due to an error?
             hs_err_path = f'{ap_proc.host_cwd}/hs_err_pid{ap_proc.process.pid}.log'
             if os.path.isfile(hs_err_path):
-                logger.warning(f"Found Hotspot error log at {hs_err_path}")
+                self._log_hotspot_error(ap_proc.process.pid, hs_err_path)
             logger.debug(f"Profiled process {ap_proc.process.pid} exited before stopping async-profiler")
             # no output in this case :/
             return None
@@ -454,6 +458,16 @@ class JavaProfiler(ProcessProfilerBase):
         else:
             logger.info(f"Finished profiling process {ap_proc.process.pid}")
             return parse_one_collapsed(output, process_comm(ap_proc.process))
+
+    def _log_hotspot_error(self, pid, path):
+        logger.info(f"Found Hotspot error log at {path}")
+        contents = open(path).read()
+        siginfo_match = SIGINFO_REGEX.search(contents)
+        native_frames_match = NATIVE_FRAMES_REGEX.search(contents)
+        if siginfo_match:
+            logger.error(f'Pid {pid} Hotspot siginfo: {siginfo_match[1]}')
+        if native_frames_match:
+            logger.error(f'Pid {pid} Hotspot native frames:\n{native_frames_match[1]}')
 
     def _select_processes_to_profile(self) -> List[Process]:
         return pgrep_maps(r"^.+/libjvm\.so$")

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -83,7 +83,7 @@ def _locate_hotspot_error_file(process: Process) -> str:
         if arg.startswith("-XX:ErrorFile"):
             _, error_file = arg.split("=", maxsplit=1)
 
-    error_file = error_file.replace("%p", process.pid)
+    error_file = error_file.replace("%p", str(process.pid))
     if not error_file.startswith("/"):
         error_file = f"{process.cwd()}/{error_file}"
     return error_file

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -198,11 +198,15 @@ class AsyncProfiledProcess:
         remove_path(self._output_path_host, missing_ok=True)
         remove_path(self._log_path_host, missing_ok=True)
 
-    def _isfile(self, path):
+    def _existing_realpath(self, path):
+        """
+        Return path relative to process working directory if it exists. Otherwise return None.
+        """
         if not path.startswith("/"):
             # relative path
             path = f"{self._cwd}/{path}"
-        return os.path.isfile(resolve_proc_root_links(self._process_root, path))
+        path = resolve_proc_root_links(self._process_root, path)
+        return path if os.path.exists(path) else None
 
     def locate_hotspot_error_file(self) -> Optional[str]:
         """
@@ -218,7 +222,8 @@ class AsyncProfiledProcess:
                 break
 
         for path in locations:
-            if self._isfile(path):
+            path = self._existing_realpath(path)
+            if path:
                 return path
         return None
 

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -22,6 +22,7 @@ from gprofiler.metadata.system_metadata import get_arch, get_run_mode
 from gprofiler.profilers.profiler_base import ProcessProfilerBase, ProfilerBase, ProfilerInterface
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
 from gprofiler.utils import (
+    is_process_running,
     pgrep_maps,
     poll_process,
     process_comm,
@@ -87,7 +88,7 @@ class PySpyProfiler(ProcessProfilerBase):
             except CalledProcessError as e:
                 if (
                     b"Error: Failed to get process executable name. Check that the process is running.\n" in e.stderr
-                    and not process.is_running()
+                    and not is_process_running(process)
                 ):
                     logger.debug(f"Profiled process {process.pid} exited before py-spy could start")
                     return None

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -554,3 +554,7 @@ def get_mnt_ns_ancestor(process: Process) -> int:
             return process.pid
 
         process = parent
+
+
+def is_process_running(process: psutil.Process):
+    return process.is_running() and not process.status() == "zombie"

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -111,13 +111,13 @@ def start_process(cmd: Union[str, List[str]], via_staticx: bool, **kwargs) -> Po
     return popen
 
 
-def wait_event(timeout: float, stop_event: Event, condition: Callable[[], bool]) -> None:
+def wait_event(timeout: float, stop_event: Event, condition: Callable[[], bool], interval=0.1) -> None:
     end_time = time.monotonic() + timeout
     while True:
         if condition():
             break
 
-        if stop_event.wait(0.1):
+        if stop_event.wait(interval):
             raise StopEventSetException()
 
         if time.monotonic() > end_time:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,7 @@ def java_command_line(tmp_path: Path, java_args: List[str]) -> List[str]:
     # Java fails with permissions errors: "Error: Could not find or load main class Fibonacci"
     chmod_path_parts(class_path, stat.S_IRGRP | stat.S_IROTH | stat.S_IXGRP | stat.S_IXOTH)
     subprocess.run(["javac", CONTAINERS_DIRECTORY / "java/Fibonacci.java", "-d", class_path])
-    return ["java"] + java_args + ["-cp", class_path, "Fibonacci"]
+    return ["java"] + java_args + ["-cp", str(class_path), "Fibonacci"]
 
 
 @fixture
@@ -66,14 +66,14 @@ def command_line(runtime: str, java_command_line: List[str]) -> List[str]:
         "java": java_command_line,
         # note: here we run "python /path/to/lister.py" while in the container test we have
         # "CMD /path/to/lister.py", to test processes with non-python /proc/pid/comm
-        "python": ["python3", CONTAINERS_DIRECTORY / "python/lister.py"],
-        "php": ["php", CONTAINERS_DIRECTORY / "php/fibonacci.php"],
-        "ruby": ["ruby", CONTAINERS_DIRECTORY / "ruby/fibonacci.rb"],
+        "python": ["python3", str(CONTAINERS_DIRECTORY / "python/lister.py")],
+        "php": ["php", str(CONTAINERS_DIRECTORY / "php/fibonacci.php")],
+        "ruby": ["ruby", str(CONTAINERS_DIRECTORY / "ruby/fibonacci.rb")],
         "nodejs": [
             "node",
             "--perf-prof",
             "--interpreted-frames-native-stack",
-            CONTAINERS_DIRECTORY / "nodejs/fibonacci.js",
+            str(CONTAINERS_DIRECTORY / "nodejs/fibonacci.js"),
         ],
     }[runtime]
 

--- a/tests/containers/java/Dockerfile
+++ b/tests/containers/java/Dockerfile
@@ -4,4 +4,4 @@ WORKDIR /app
 ADD Fibonacci.java /app
 RUN javac Fibonacci.java
 
-CMD ["java", "Fibonacci"]
+CMD ["sh", "-c", "java Fibonacci; sleep 10000"]

--- a/tests/containers/java/musl.Dockerfile
+++ b/tests/containers/java/musl.Dockerfile
@@ -4,4 +4,4 @@ WORKDIR /app
 ADD Fibonacci.java /app
 RUN javac Fibonacci.java
 
-CMD ["java", "Fibonacci"]
+CMD ["sh", "-c", "java Fibonacci; sleep 10000"]

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -34,11 +34,11 @@ def test_async_profiler_already_running(application_pid, assert_collapsed, tmp_p
     caplog.set_level(logging.INFO)
     with JavaProfiler(11, 1, Event(), str(tmp_path), False, False, "cpu", 0, False, "ap") as profiler:
         process = profiler._select_processes_to_profile()[0]
-        with AsyncProfiledProcess(process, profiler._storage_dir, False, profiler._mode, 0) as ap_proc:
+        with AsyncProfiledProcess(process, profiler._storage_dir, False, profiler._mode, False) as ap_proc:
             assert ap_proc.start_async_profiler(11)
         assert any("libasyncProfiler.so" in m.path for m in process.memory_maps())
         # run "status"
-        with AsyncProfiledProcessForTests(process, str(tmp_path), False, mode="itimer", safemode=0) as ap_proc:
+        with AsyncProfiledProcessForTests(process, profiler._storage_dir, False, mode="itimer", safemode=False) as ap_proc:
             ap_proc.status_async_profiler()
             # printed the output file, see ACTION_STATUS case in async-profiler/profiler.cpp
             assert "Profiling is running for " in ap_proc.read_output()

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -47,6 +47,7 @@ def test_async_profiler_already_running(application_pid, assert_collapsed, tmp_p
 
         # then start again
         result = profiler.snapshot()
+        assert len(result) == 1
         collapsed = result[next(iter(result.keys()))]
         assert "Found async-profiler already started" in caplog.text
         assert "Finished profiling process" in caplog.text
@@ -75,6 +76,7 @@ def test_java_async_profiler_cpu_mode(
         java_mode="ap",
     ) as profiler:
         result = profiler.snapshot()
+        assert len(result) == 1
         process_collapsed = result[next(iter(result.keys()))]
         assert_collapsed(process_collapsed, check_comm=True)
         assert_function_in_collapsed(
@@ -106,6 +108,7 @@ def test_java_async_profiler_musl_and_cpu(
         java_mode="ap",
     ) as profiler:
         result = profiler.snapshot()
+        assert len(result) == 1
         process_collapsed = result[next(iter(result.keys()))]
         assert_collapsed(process_collapsed, check_comm=True)
         assert_function_in_collapsed(

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -28,6 +28,9 @@ def runtime() -> str:
 
 
 def test_async_profiler_already_running(application_pid, assert_collapsed, tmp_path, caplog):
+    """
+    Test we're able to restart async-profiler in case it's already running in the process and get results normally.
+    """
     caplog.set_level(logging.INFO)
     with JavaProfiler(11, 1, Event(), str(tmp_path), False, False, "cpu", 0, False, "ap") as profiler:
         process = profiler._select_processes_to_profile()[0]

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -161,15 +161,38 @@ def test_java_async_profiler_musl_and_cpu(
 
 @pytest.mark.parametrize("in_container", [False])
 @pytest.mark.parametrize("check_app_exited", [False])
+@pytest.mark.parametrize("java_args", [[], ["-XX:ErrorFile=/tmp/my_custom_error_file.log"]])
 def test_hotspot_error_file(application_process, tmp_path, monkeypatch, caplog):
     start_async_profiler = AsyncProfiledProcess.start_async_profiler
 
     # Simulate crashing process
     def sap_and_crash(self, *args, **kwargs):
         result = start_async_profiler(self, *args, **kwargs)
-        application_process.send_signal(signal.SIGBUS)
-        # Note: unless we wait here the process remains "defunct" and psutil reports it as still running.
-        application_process.wait()
+        self.process.send_signal(signal.SIGBUS)
+        return result
+
+    monkeypatch.setattr(AsyncProfiledProcess, "start_async_profiler", sap_and_crash)
+
+    with JavaProfiler(1, 5, Event(), str(tmp_path), False, False, "cpu", 0, "ap") as profiler:
+        profiler.snapshot()
+
+    assert len(caplog.records) > 0
+    message = caplog.records[0].message
+    assert "Found Hotspot error log" in message
+    assert "OpenJDK" in message
+    assert "SIGBUS" in message
+    assert "libpthread.so" in message
+    assert "memory_usage_in_bytes:" in message
+
+
+@pytest.mark.parametrize("in_container", [True])
+def test_container_hotspot_error_file(application_pid, tmp_path, monkeypatch, caplog):
+    start_async_profiler = AsyncProfiledProcess.start_async_profiler
+
+    # Simulate crashing process
+    def sap_and_crash(self, *args, **kwargs):
+        result = start_async_profiler(self, *args, **kwargs)
+        self.process.send_signal(signal.SIGBUS)
         return result
 
     monkeypatch.setattr(AsyncProfiledProcess, "start_async_profiler", sap_and_crash)

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -11,7 +11,7 @@ import pytest  # type: ignore
 from packaging.version import Version
 
 from gprofiler.profilers.java import AsyncProfiledProcess, JavaProfiler, parse_jvm_version
-from tests.utils import assert_function_in_collapsed, run_gprofiler_in_container
+from tests.utils import assert_function_in_collapsed
 
 
 # adds the "status" command to AsyncProfiledProcess from gProfiler.
@@ -38,7 +38,9 @@ def test_async_profiler_already_running(application_pid, assert_collapsed, tmp_p
             assert ap_proc.start_async_profiler(11)
         assert any("libasyncProfiler.so" in m.path for m in process.memory_maps())
         # run "status"
-        with AsyncProfiledProcessForTests(process, profiler._storage_dir, False, mode="itimer", safemode=False) as ap_proc:
+        with AsyncProfiledProcessForTests(
+            process, profiler._storage_dir, False, mode="itimer", safemode=False
+        ) as ap_proc:
             ap_proc.status_async_profiler()
             # printed the output file, see ACTION_STATUS case in async-profiler/profiler.cpp
             assert "Profiling is running for " in ap_proc.read_output()

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -162,9 +162,11 @@ def test_java_safemode_version_check(
         java_safemode=True,
         java_mode="ap",
     ) as profiler:
+        process = profiler._select_processes_to_profile()[0]
+        jvm_version = parse_jvm_version(profiler._get_java_version(process))
         profiler.snapshot()
 
-    assert "Unsupported java version" in caplog.text
+    assert f"Unsupported java version {jvm_version.version}" in caplog.text
 
 
 def test_java_safemode_build_number_check(

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -2,8 +2,8 @@
 # Copyright (c) Granulate. All rights reserved.
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
-import signal
 import logging
+import signal
 from pathlib import Path
 from threading import Event
 

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -38,7 +38,9 @@ def test_java_from_host(
         java_safemode=False,
         java_mode="ap",
     ) as profiler:
-        process_collapsed = profiler.snapshot().get(application_pid)
+        result = profiler.snapshot()
+        assert len(result) == 1
+        process_collapsed = result[next(iter(result.keys()))]
         assert_collapsed(process_collapsed, check_comm=True)
 
 


### PR DESCRIPTION
## Description
If java process terminates due to an error, detect it and report a log message. In addition, extract siginfo, native frames, vm info, and container info from the hotspot log and report them in our log.

## Motivation and Context
Debugging async-profiler misbehaviors.

## How Has This Been Tested?
1. Changed async-profiler to force a crash.
2. Started OpenJDK example process.
3. Ran gprofiler built from this branch.
4. Ran crashing async-profiler.

### Log output
```
[15:40:25] Found Hotspot error log at /proc/1/root/home/ubuntu/jbb/21-11-16_153905/hs_err_pid32629.log
[15:40:25] Pid 32629 Hotspot VM info: OpenJDK 64-Bit Server VM (25.292-b10) for linux-amd64 JRE (1.8.0_292-8u292-b10-0ubuntu1~18.04-b10), built on Apr 21 2021 11:46:09 by "buildd" with gcc 7.5.0
[15:40:25] Pid 32629 Hotspot siginfo: si_signo: 11 (SIGSEGV), si_code: 1 (SEGV_MAPERR), si_addr: 0x0000000000000004
[15:40:25] Pid 32629 Hotspot native frames:
C  [libc.so.6+0x18e4e1]
C  [libasyncProfiler.so+0x1bb4e]  Profiler::dump(std::ostream&, Arguments&)+0xce
C  [libasyncProfiler.so+0x1bcae]  Profiler::runInternal(Arguments&, std::ostream&)+0x9e
C  [libasyncProfiler.so+0x1c242]  Profiler::run(Arguments&)+0x212
C  [libasyncProfiler.so+0x48d81]  Agent_OnAttach+0x1e1
V  [libjvm.so+0x7ea65b]
V  [libjvm.so+0x2f5e62]
V  [libjvm.so+0xb08d2f]
V  [libjvm.so+0xb0a0fa]
V  [libjvm.so+0x990552]
C  [libpthread.so.0+0x76db]  start_thread+0xdb
[15:40:25] Pid 32629 Hotspot container info:
container_type: cgroupv1
cpu_cpuset_cpus: 0-3
cpu_memory_nodes: 0
active_processor_count: 4
cpu_quota: -1
cpu_period: 100000
cpu_shares: -1
memory_limit_in_bytes: -1
memory_and_swap_limit_in_bytes: -2
memory_soft_limit_in_bytes: -1
memory_usage_in_bytes: 5046411264
memory_max_usage_in_bytes: 7147831296
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
