### PR TITLE
java: Disabling java profiling on hotspot error file detection

### DIFF
--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -225,7 +225,7 @@ def test_hotspot_error_file(application_pid, tmp_path, monkeypatch, caplog):
     assert "SIGBUS" in caplog.text
     assert "libpthread.so" in caplog.text
     assert "memory_usage_in_bytes:" in caplog.text
-    assert "Java profiling has been disabled, avoiding from profiling any java process" in caplog.text
+    assert "Java profiling has been disabled, will avoid profiling any new java process" in caplog.text
     assert not JavaProfiler._should_profile
 
 
@@ -235,7 +235,7 @@ def test_disable_java_profiling(application_pid, tmp_path, monkeypatch, caplog):
     with JavaProfiler(1, 5, Event(), str(tmp_path), False, False, "cpu", 0, False, "ap") as profiler:
         assert len(profiler.snapshot()) == 0
 
-    assert "Java profiling has been disabled, skipping process" in caplog.text
+    assert "Java profiling has been disabled, skipping profiling of all java process" in caplog.text
 
 
 def test_already_loaded_ap_profiling_failure(tmp_path, monkeypatch, caplog, application_pid) -> None:

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -214,6 +214,8 @@ def test_hotspot_error_file(application_pid, tmp_path, monkeypatch, caplog):
         return result
 
     monkeypatch.setattr(AsyncProfiledProcess, "start_async_profiler", sap_and_crash)
+    # To make sure it is reverted to True (the original value) after the test
+    monkeypatch.setattr(JavaProfiler, "_should_profile", True)
 
     with JavaProfiler(1, 5, Event(), str(tmp_path), False, False, "cpu", 0, False, "ap") as profiler:
         profiler.snapshot()
@@ -223,6 +225,17 @@ def test_hotspot_error_file(application_pid, tmp_path, monkeypatch, caplog):
     assert "SIGBUS" in caplog.text
     assert "libpthread.so" in caplog.text
     assert "memory_usage_in_bytes:" in caplog.text
+    assert "Java profiling has been disabled, avoiding from profiling any java process" in caplog.text
+    assert not JavaProfiler._should_profile
+
+
+def test_disable_java_profiling(application_pid, tmp_path, monkeypatch, caplog):
+    monkeypatch.setattr(JavaProfiler, "_should_profile", False)
+    caplog.set_level(logging.DEBUG)
+    with JavaProfiler(1, 5, Event(), str(tmp_path), False, False, "cpu", 0, False, "ap") as profiler:
+        assert len(profiler.snapshot()) == 0
+
+    assert "Java profiling has been disabled, skipping process" in caplog.text
 
 
 def test_already_loaded_ap_profiling_failure(tmp_path, monkeypatch, caplog, application_pid) -> None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When a hotspot error file is detected for a profiled process, disable current and future profiling of all java processes

## Related Issue
<!--- If there's an issue related, please link it here -->
<!--- If suggesting a new feature or a medium/big change, please discuss it in an issue first. -->
<!--- For small changes, it's okay to open a PR immediately. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What does it improve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your changes are tested by the CI, you can just write that.-->
Added pytest tests

## Screenshots
<!--- (if appropriate) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
