### PR TITLE
java: async-profiler: Remove framebuf parameter

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -310,7 +310,7 @@ class AsyncProfiledProcess:
     def _get_start_cmd(self, interval: int) -> List[str]:
         return self._get_base_cmd() + [
             f"start,event={self._mode},file={self._output_path_process},"
-            f"{self.OUTPUT_FORMAT},{self.FORMAT_PARAMS},interval={interval},framebuf=2000000,"
+            f"{self.OUTPUT_FORMAT},{self.FORMAT_PARAMS},interval={interval},"
             f"log={self._log_path_process}{',buildids' if self._buildids else ''}"
             f"{',fdtransfer' if self._mode == 'cpu' else ''}"
             f",safemode={self._safemode}"


### PR DESCRIPTION
## Description

Apparently it was removed in f006e0044391f. We will think of another solution to limiting
the frame buffer size (so async-profilers left alive for whatever reason, do not consume memory forever)

We'll avoid these errors once https://github.com/jvm-profiling-tools/async-profiler/pull/503 is merged :)

## How Has This Been Tested?
CI

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
