### PR TITLE
Replace the vertical bar in method descriptors with a semicolon

### DIFF
--- a/gprofiler/merge.py
+++ b/gprofiler/merge.py
@@ -45,6 +45,7 @@ def parse_one_collapsed(collapsed: str, add_comm: Optional[str] = None) -> Stack
             continue
         try:
             stack, _, count = line.rpartition(" ")
+            stack = stack.replace("|", ";")
             if add_comm is not None:
                 stacks[f"{add_comm};{stack}"] += int(count)
             else:


### PR DESCRIPTION
## Description
AP replaces semicolons in method descriptors with a vertical bar, so that we can later split frames by the semicolon character. This patch turns the vertical bar back into a semicolon.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
