### PR TITLE
java: Cleanup & fixes for the next release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ FROM ubuntu${GPROFILER_BUILDER_UBUNTU}
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install --no-install-recommends -y curl python3-pip git
+RUN apt-get update && apt-get install --no-install-recommends -y python3-pip git
 
 # Aarch64 has no .whl file for psutil - so it's trying to build from source.
 RUN if [ $(uname -m) = "aarch64" ]; then apt-get install -y build-essential python3.8-dev; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,8 +107,7 @@ FROM ubuntu${GPROFILER_BUILDER_UBUNTU}
 
 WORKDIR /app
 
-# kmod - for modprobe kheaders if it's available
-RUN apt-get update && apt-get install --no-install-recommends -y curl python3-pip kmod git
+RUN apt-get update && apt-get install --no-install-recommends -y curl python3-pip git
 
 # Aarch64 has no .whl file for psutil - so it's trying to build from source.
 RUN if [ $(uname -m) = "aarch64" ]; then apt-get install -y build-essential python3.8-dev; fi

--- a/gprofiler/kernel_messages.py
+++ b/gprofiler/kernel_messages.py
@@ -21,7 +21,10 @@ class Provider(ABC):
 
 class EmptyProvider(Provider):
     def __init__(self):
-        print("This kernel does not support the new /dev/kmsg interface for reading messages.")
+        print(
+            "This kernel does not support the new /dev/kmsg interface for reading messages,"
+            " or you lack the permissions for it."
+        )
         print("Profilee error monitoring not available.")
         print()
         logger.warning("Profilee error monitoring not available.")

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -765,7 +765,8 @@ class JavaProfiler(ProcessProfilerBase):
             self._saved_mlock = read_perf_event_mlock_kb()
             write_perf_event_mlock_kb(self._new_perf_event_mlock_kb)
 
-        proc_events.register_exit_callback(self._proc_exit_callback)
+        # needs to run in init net NS
+        run_in_ns(["net"], lambda: proc_events.register_exit_callback(self._proc_exit_callback), 1)
 
     def stop(self) -> None:
         super().stop()

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -548,7 +548,7 @@ class JavaProfiler(ProcessProfilerBase):
 
     @classmethod
     def _disable_profiling(cls):
-        logger.error("Java profiling has been disabled, will avoid profiling any new java process")
+        logger.warning("Java profiling has been disabled, will avoid profiling any new java process")
         cls._should_profile = False
 
     def _is_jvm_type_supported(self, java_version_cmd_output: str) -> bool:
@@ -563,15 +563,15 @@ class JavaProfiler(ProcessProfilerBase):
             return False
 
         if jvm_version.version.major not in self.MINIMAL_SUPPORTED_VERSIONS:
-            logger.error("Unsupported JVM version", jvm_version=repr(jvm_version))
+            logger.warning("Unsupported JVM version", jvm_version=repr(jvm_version))
             return False
         min_version, min_build = self.MINIMAL_SUPPORTED_VERSIONS[jvm_version.version.major]
         if jvm_version.version < min_version:
-            logger.error("Unsupported JVM version", jvm_version=repr(jvm_version))
+            logger.warning("Unsupported JVM version", jvm_version=repr(jvm_version))
             return False
         elif jvm_version.version == min_version:
             if jvm_version.build < min_build:
-                logger.error("Unsupported JVM version", jvm_version=repr(jvm_version))
+                logger.warning("Unsupported JVM version", jvm_version=repr(jvm_version))
                 return False
 
         return True
@@ -619,7 +619,7 @@ class JavaProfiler(ProcessProfilerBase):
 
     def _check_jvm_type_supported(self, process: Process, java_version_output: str) -> bool:
         if not self._is_jvm_type_supported(java_version_output):
-            logger.error("Unsupported JVM type", java_version_output=java_version_output)
+            logger.warning("Unsupported JVM type", java_version_output=java_version_output)
             return False
 
         return True
@@ -630,7 +630,7 @@ class JavaProfiler(ProcessProfilerBase):
             # TODO we can get the "java" binary by extracting the java home from the libjvm path,
             # then check with that instead (if exe isn't java)
             if process_basename != "java":
-                logger.error(
+                logger.warning(
                     "Non-java basenamed process, skipping... (disable --java-safemode to profile it anyway)",
                     pid=process.pid,
                     exe=process.exe(),
@@ -643,7 +643,7 @@ class JavaProfiler(ProcessProfilerBase):
                 return False
 
             if not self._is_jvm_version_supported(java_version_output):
-                logger.error(
+                logger.warning(
                     "Process running unsupported Java version, skipping..."
                     " (disable --java-safemode to profile it anyway)",
                     pid=process.pid,
@@ -728,7 +728,7 @@ class JavaProfiler(ProcessProfilerBase):
         native_frames = m[1] if m else ""
         m = CONTAINER_INFO_REGEX.search(contents)
         container_info = m[1] if m else ""
-        logger.error(
+        logger.warning(
             f"Found Hotspot error log for pid {pid} at {error_file}:\n"
             f"VM info: {vm_info}\n"
             f"siginfo: {siginfo}\n"
@@ -790,12 +790,12 @@ class JavaProfiler(ProcessProfilerBase):
             _, _, text = message
             entry = get_oom_entry(text)
             if entry and entry.pid in self._profiled_pids:
-                logger.error("Profiled Java process OOM", oom=json.dumps(entry._asdict()))
+                logger.warning("Profiled Java process OOM", oom=json.dumps(entry._asdict()))
                 self._disable_profiling()  # paranoia
 
             entry = get_signal_entry(text)
             if entry and entry.pid in self._profiled_pids:
-                logger.error("Profiled Java process signalled", signal=json.dumps(entry._asdict()))
+                logger.warning("Profiled Java process signalled", signal=json.dumps(entry._asdict()))
                 self._disable_profiling()  # paranoia
 
     def _handle_new_kernel_messages(self):

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -665,7 +665,12 @@ class JavaProfiler(ProcessProfilerBase):
         if not self._is_profiling_supported(process):
             return None
 
-        self._profiled_pids.add(process.pid)
+        # track profiled PIDs only if proc_events are in use, otherwise there is no use in them.
+        # TODO: it is possible to run in contexts where we're unable to use proc_events but are able to listen
+        # on kernel messages. we can add another mechanism to track PIDs (such as, prune PIDs which have exited)
+        # then use the kernel messages listener without proc_events.
+        if self._enabled_proc_events:
+            self._profiled_pids.add(process.pid)
 
         logger.info(f"Profiling process {process.pid} with async-profiler")
         with AsyncProfiledProcess(

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -791,10 +791,12 @@ class JavaProfiler(ProcessProfilerBase):
             entry = get_oom_entry(text)
             if entry and entry.pid in self._profiled_pids:
                 logger.error("Profiled Java process OOM", oom=json.dumps(entry._asdict()))
+                self._disable_profiling()  # paranoia
 
             entry = get_signal_entry(text)
             if entry and entry.pid in self._profiled_pids:
                 logger.error("Profiled Java process signalled", signal=json.dumps(entry._asdict()))
+                self._disable_profiling()  # paranoia
 
     def _handle_new_kernel_messages(self):
         try:

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -562,11 +562,11 @@ class JavaProfiler(ProcessProfilerBase):
             return False
 
         if jvm_version.version.major not in self.MINIMAL_SUPPORTED_VERSIONS:
-            logger.error(f"Unsupported java version {jvm_version.version}")
+            logger.error("Unsupported java version", jvm_version=repr(jvm_version))
             return False
         min_version, min_build = self.MINIMAL_SUPPORTED_VERSIONS[jvm_version.version.major]
         if jvm_version.version < min_version:
-            logger.error(f"Unsupported java version {jvm_version.version}")
+            logger.error("Unsupported java version", jvm_version=repr(jvm_version))
             return False
         elif jvm_version.version == min_version:
             if jvm_version.build < min_build:

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -545,7 +545,7 @@ class JavaProfiler(ProcessProfilerBase):
         try:
             self._kernel_messages_provider = DefaultMessagesProvider()
         except Exception:
-            logger.warning("Failed to start kernel messages listener")
+            logger.warning("Failed to start kernel messages listener", exc_info=True)
             self._kernel_messages_provider = EmptyProvider()
         self._enabled_proc_events = False
 

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -771,7 +771,7 @@ class JavaProfiler(ProcessProfilerBase):
             write_perf_event_mlock_kb(self._new_perf_event_mlock_kb)
 
         try:
-            # needs to run in init net NS
+            # needs to run in init net NS - see netlink_kernel_create() call on init_net in cn_init().
             run_in_ns(["net"], lambda: proc_events.register_exit_callback(self._proc_exit_callback), 1)
         except Exception:
             logger.warning("Failed to enable proc_events listener for exited Java processes", exc_info=True)

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -773,9 +773,9 @@ class JavaProfiler(ProcessProfilerBase):
         run_in_ns(["net"], lambda: proc_events.register_exit_callback(self._proc_exit_callback), 1)
 
     def stop(self) -> None:
-        super().stop()
         if self._saved_mlock is not None:
             write_perf_event_mlock_kb(self._saved_mlock)
+        super().stop()
 
     def _proc_exit_callback(self, tid: int, pid: int, exit_code: int):
         # Notice that we only check the exit code of the main thread here.

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -563,15 +563,15 @@ class JavaProfiler(ProcessProfilerBase):
             return False
 
         if jvm_version.version.major not in self.MINIMAL_SUPPORTED_VERSIONS:
-            logger.error("Unsupported java version", jvm_version=repr(jvm_version))
+            logger.error("Unsupported JVM version", jvm_version=repr(jvm_version))
             return False
         min_version, min_build = self.MINIMAL_SUPPORTED_VERSIONS[jvm_version.version.major]
         if jvm_version.version < min_version:
-            logger.error("Unsupported java version", jvm_version=repr(jvm_version))
+            logger.error("Unsupported JVM version", jvm_version=repr(jvm_version))
             return False
         elif jvm_version.version == min_version:
             if jvm_version.build < min_build:
-                logger.error(f"Unsupported build number {jvm_version.build} for java version {jvm_version.version}")
+                logger.error("Unsupported JVM version", jvm_version=repr(jvm_version))
                 return False
 
         return True
@@ -619,7 +619,7 @@ class JavaProfiler(ProcessProfilerBase):
 
     def _check_jvm_type_supported(self, process: Process, java_version_output: str) -> bool:
         if not self._is_jvm_type_supported(java_version_output):
-            logger.error(f"Process {process.pid} running unsupported JVM ({java_version_output!r}), skipping...")
+            logger.error("Unsupported JVM type", java_version_output=java_version_output)
             return False
 
         return True
@@ -631,8 +631,9 @@ class JavaProfiler(ProcessProfilerBase):
             # then check with that instead (if exe isn't java)
             if process_basename != "java":
                 logger.error(
-                    f"Non-java basenamed process {process.pid} ({process.exe()!r}), skipping..."
-                    " (disable --java-safemode to profile it anyway)"
+                    "Non-java basenamed process, skipping... (disable --java-safemode to profile it anyway)",
+                    pid=process.pid,
+                    exe=process.exe(),
                 )
                 return False
 
@@ -643,8 +644,10 @@ class JavaProfiler(ProcessProfilerBase):
 
             if not self._is_jvm_version_supported(java_version_output):
                 logger.error(
-                    f"Process {process.pid} running unsupported Java version ({java_version_output!r}), skipping..."
-                    " (disable --java-safemode to profile it anyway)"
+                    "Process running unsupported Java version, skipping..."
+                    " (disable --java-safemode to profile it anyway)",
+                    pid=process.pid,
+                    java_version_output=java_version_output,
                 )
                 return False
         else:

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -812,4 +812,4 @@ class JavaProfiler(ProcessProfilerBase):
         finally:
             self._handle_new_kernel_messages()
             self._profiled_pids -= self._pids_to_remove
-            self._pids_to_remove = set()
+            self._pids_to_remove.clear()

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -21,7 +21,7 @@ from psutil import Process
 
 from gprofiler.exceptions import CalledProcessError
 from gprofiler.gprofiler_types import StackToSampleCount
-from gprofiler.kernel_messages import DefaultMessagesProvider
+from gprofiler.kernel_messages import DefaultMessagesProvider, EmptyProvider
 from gprofiler.log import get_logger_adapter
 from gprofiler.merge import parse_one_collapsed
 from gprofiler.profilers.profiler_base import ProcessProfilerBase
@@ -544,7 +544,11 @@ class JavaProfiler(ProcessProfilerBase):
             logger.debug("Java safemode enabled")
         self._profiled_pids: Set[int] = set()
         self._pids_to_remove: Set[int] = set()
-        self._kernel_messages_provider = DefaultMessagesProvider()
+        try:
+            self._kernel_messages_provider = DefaultMessagesProvider()
+        except Exception:
+            logger.warning("Failed to start kernel messages listener")
+            self._kernel_messages_provider = EmptyProvider()
         self._enabled_proc_events = False
 
     @classmethod

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -190,7 +190,9 @@ def test_java_safemode_build_number_check(
         jvm_version = parse_jvm_version(profiler._get_java_version(process))
         monkeypatch.setitem(JavaProfiler.MINIMAL_SUPPORTED_VERSIONS, 8, (jvm_version.version, 999))
         profiler.snapshot()
-        assert f"Unsupported build number {jvm_version.build} for java version {jvm_version.version}" in caplog.text
+
+    assert "Unsupported JVM version" in caplog.text
+    assert repr(jvm_version) in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -167,8 +167,9 @@ def test_java_safemode_version_check(
         jvm_version = parse_jvm_version(profiler._get_java_version(process))
         profiler.snapshot()
 
-    assert "Unsupported JVM version" in caplog.text
-    assert repr(jvm_version) in caplog.text
+    assert next(filter(lambda r: r.message == "Unsupported JVM version", caplog.records)).gprofiler_adapter_extra[
+        "jvm_version"
+    ] == repr(jvm_version)
 
 
 def test_java_safemode_build_number_check(
@@ -191,8 +192,9 @@ def test_java_safemode_build_number_check(
         monkeypatch.setitem(JavaProfiler.MINIMAL_SUPPORTED_VERSIONS, 8, (jvm_version.version, 999))
         profiler.snapshot()
 
-    assert "Unsupported JVM version" in caplog.text
-    assert repr(jvm_version) in caplog.text
+    assert next(filter(lambda r: r.message == "Unsupported JVM version", caplog.records)).gprofiler_adapter_extra[
+        "jvm_version"
+    ] == repr(jvm_version)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -167,7 +167,8 @@ def test_java_safemode_version_check(
         jvm_version = parse_jvm_version(profiler._get_java_version(process))
         profiler.snapshot()
 
-    assert f"Unsupported java version {jvm_version.version}" in caplog.text
+    assert "Unsupported JVM version" in caplog.text
+    assert repr(jvm_version) in caplog.text
 
 
 def test_java_safemode_build_number_check(


### PR DESCRIPTION
* Put log params in extras for easier parsing
* Merge PIDs tracking
* Make sure that kernel messages & proc_events are checked for PIDs (i.e don't remove from the profiled PIDs list immediately)
* Start proc_events in init net NS because it wouldn't work otherwise.

After https://github.com/Granulate/gprofiler/pull/226