### PR TITLE
Move namespace utils to granulate_utils and make granulate_utils a submodule

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,4 +2,4 @@
 max-line-length = 120
 # options for compatibility with black - see https://black.readthedocs.io/en/stable/compatible_configs.html#flake8
 extend-ignore = E203, W503
-exclude = .git,__pycache__,build,gprofiler.egg-info,venv
+exclude = .git,__pycache__,build,gprofiler.egg-info,venv,granulate-utils

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
 
     - name: Checkout Code
       uses: actions/checkout@v2
+      with:
+        submodules: true
 
       # the tests need the gprofiler image built (from Dockerfile). I run it separately here, because "docker build" prints the build logs
       # more nicely. the tests will then be able to use the built image.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
 
     - name: Checkout Code
       uses: actions/checkout@v2
+      with:
+        submodules: true
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,7 @@ jobs:
        uses: actions/checkout@v2
        with:
          fetch-depth: 0
+         submodules: true
      - name: Get and verify tag value
        run: |
          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
@@ -140,6 +141,8 @@ jobs:
 
       - name: Checkout Code
         uses: actions/checkout@v2
+        with:
+          submodules: true
 
       - name: Download the executable from previous job
         uses: actions/download-artifact@v2
@@ -161,6 +164,7 @@ jobs:
        uses: actions/checkout@v2
        with:
          fetch-depth: 0
+         submodules: true
      - name: Get and verify tag value
        run: |
          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          submodules: true
       - name: Get and verify tag value
         run: |
           echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "granulate-utils"]
+	path = granulate-utils
+	url = git@github.com:Granulate/granulate-utils.git

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,3 +2,4 @@
 line_length = 120
 multi_line_output = 3
 include_trailing_comma = true
+skip = granulate-utils

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,6 +144,7 @@ RUN pip3 install --upgrade pip
 # done separately from the 'pip3 install -e' below; so we don't reinstall all dependencies on each
 # code change.
 COPY requirements.txt ./
+COPY granulate-utils ./granulate-utils
 RUN pip3 install --no-cache-dir -r requirements.txt
 
 COPY LICENSE.md MANIFEST.in README.md setup.py  ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,7 @@ FROM ubuntu${GPROFILER_BUILDER_UBUNTU}
 WORKDIR /app
 
 # kmod - for modprobe kheaders if it's available
-RUN apt-get update && apt-get install --no-install-recommends -y curl python3-pip kmod git
+RUN apt-get update && apt-get install --no-install-recommends -y curl python3-pip kmod
 
 # Aarch64 has no .whl file for psutil - so it's trying to build from source.
 RUN if [ $(uname -m) = "aarch64" ]; then apt-get install -y build-essential python3.8-dev; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,7 +144,8 @@ RUN pip3 install --upgrade pip
 # done separately from the 'pip3 install -e' below; so we don't reinstall all dependencies on each
 # code change.
 COPY requirements.txt ./
-COPY granulate-utils ./granulate-utils
+COPY granulate-utils/setup.py granulate-utils/requirements.txt granulate-utils/README.md granulate-utils/
+COPY granulate-utils/granulate_utils granulate-utils/granulate_utils
 RUN pip3 install --no-cache-dir -r requirements.txt
 
 COPY LICENSE.md MANIFEST.in README.md setup.py  ./

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,3 +5,4 @@ mypy==0.901
 isort==5.8.0
 types-requests==0.1.9
 types-dataclasses==0.1.5
+types-psutil==5.8.0

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -16,6 +16,7 @@ from threading import Event
 from typing import Iterable, Optional
 
 import configargparse
+from granulate_utils.linux.ns import is_running_in_init_pid
 from psutil import NoSuchProcess, Process
 from requests import RequestException, Timeout
 
@@ -43,7 +44,6 @@ from gprofiler.utils import (
     grab_gprofiler_mutex,
     is_process_running,
     is_root,
-    is_running_in_init_pid,
     reset_umask,
     resource_path,
     run_process,

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -14,6 +14,7 @@ from typing import List, Optional, Set
 
 import psutil
 from granulate_utils.linux import proc_events
+from granulate_utils.linux.ns import get_mnt_ns_ancestor, resolve_proc_root_links, run_in_ns
 from granulate_utils.linux.oom import get_oom_entry
 from granulate_utils.linux.signals import get_signal_entry
 from packaging.version import Version
@@ -28,7 +29,6 @@ from gprofiler.profilers.profiler_base import ProcessProfilerBase
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
 from gprofiler.utils import (
     TEMPORARY_STORAGE_PATH,
-    get_mnt_ns_ancestor,
     get_process_nspid,
     is_process_running,
     pgrep_maps,
@@ -36,9 +36,7 @@ from gprofiler.utils import (
     read_perf_event_mlock_kb,
     remove_path,
     remove_prefix,
-    resolve_proc_root_links,
     resource_path,
-    run_in_ns,
     run_process,
     touch_path,
     wait_event,

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -5,10 +5,9 @@
 import os
 import signal
 from pathlib import Path
+from subprocess import Popen
 from threading import Event
 from typing import List, Optional
-
-import psutil
 
 from gprofiler.exceptions import StopEventSetException
 from gprofiler.log import get_logger_adapter
@@ -46,7 +45,7 @@ class PerfProcess:
         self._type = "dwarf" if is_dwarf else "fp"
         self._inject_jit = inject_jit
         self._extra_args = extra_args + (["-k", "1"] if self._inject_jit else [])
-        self._process: Optional[psutil.Process] = None
+        self._process: Optional[Popen] = None
 
     def _get_perf_cmd(self) -> List[str]:
         return [
@@ -99,8 +98,8 @@ class PerfProcess:
             # always read its stderr
             # using read1() which performs just a single read() call and doesn't read until EOF
             # (unlike Popen.communicate())
-            assert self._process is not None
-            logger.debug(f"perf stderr: {self._process.stderr.read1(4096)}")
+            assert self._process is not None and self._process.stderr is not None
+            logger.debug(f"perf stderr: {self._process.stderr.read1(4096)}")  # type: ignore
 
         if self._inject_jit:
             inject_data = Path(f"{str(perf_data)}.inject")

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -2,7 +2,6 @@
 # Copyright (c) Granulate. All rights reserved.
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
-import ctypes
 import datetime
 import errno
 import fcntl
@@ -23,11 +22,12 @@ from functools import lru_cache
 from pathlib import Path
 from subprocess import CompletedProcess, Popen, TimeoutExpired
 from tempfile import TemporaryDirectory
-from threading import Event, Thread
-from typing import Callable, Iterator, List, Optional, Tuple, TypeVar, Union
+from threading import Event
+from typing import Callable, Iterator, List, Optional, Tuple, Union
 
 import importlib_resources
 import psutil
+from granulate_utils.linux.ns import run_in_ns
 from psutil import Process
 
 from gprofiler.exceptions import (
@@ -37,8 +37,6 @@ from gprofiler.exceptions import (
     StopEventSetException,
 )
 from gprofiler.log import get_logger_adapter
-
-T = TypeVar("T")
 
 logger = get_logger_adapter(__name__)
 
@@ -277,35 +275,6 @@ def get_iso8601_format_time(time: datetime.datetime) -> str:
     return time.replace(microsecond=0).isoformat()
 
 
-def resolve_proc_root_links(proc_root: str, ns_path: str) -> str:
-    """
-    Resolves "ns_path" which (possibly) resides in another mount namespace.
-
-    If ns_path contains absolute symlinks, it can't be accessed merely by /proc/pid/root/ns_path,
-    because the resolved absolute symlinks will "escape" the /proc/pid/root base.
-
-    To work around that, we resolve the path component by component; if any component "escapes", we
-    add the /proc/pid/root prefix once again.
-    """
-    parts = Path(ns_path).parts
-    assert parts[0] == "/", f"expected {ns_path!r} to be absolute"
-
-    path = proc_root
-    for part in parts[1:]:  # skip the /
-        next_path = os.path.join(path, part)
-        if os.path.islink(next_path):
-            link = os.readlink(next_path)
-            if os.path.isabs(link):
-                # absolute - prefix with proc_root
-                next_path = proc_root + link
-            else:
-                # relative: just join
-                next_path = os.path.join(path, link)
-        path = next_path
-
-    return path
-
-
 def remove_prefix(s: str, prefix: str) -> str:
     # like str.removeprefix of Python 3.9, but this also ensures the prefix exists.
     assert s.startswith(prefix), f"{s} doesn't start with {prefix}"
@@ -335,13 +304,6 @@ def removed_path(path: str) -> Iterator[None]:
         remove_path(path, missing_ok=True)
 
 
-def is_same_ns(pid: int, nstype: str, pid2: int = None) -> bool:
-    return (
-        os.stat(f"/proc/{pid2 if pid2 is not None else 'self'}/ns/{nstype}").st_ino
-        == os.stat(f"/proc/{pid}/ns/{nstype}").st_ino
-    )
-
-
 _INSTALLED_PROGRAMS_CACHE: List[str] = []
 
 
@@ -353,52 +315,6 @@ def assert_program_installed(program: str):
         _INSTALLED_PROGRAMS_CACHE.append(program)
     else:
         raise ProgramMissingException(program)
-
-
-def run_in_ns(nstypes: List[str], callback: Callable[[], T], target_pid: int = 1) -> Optional[T]:
-    """
-    Runs a callback in a new thread, switching to a set of the namespaces of a target process before
-    doing so.
-
-    Needed initially for switching mount namespaces, because we can't setns(CLONE_NEWNS) in a multithreaded
-    program (unless we unshare(CLONE_NEWNS) before). so, we start a new thread, unshare() & setns() it,
-    run our callback and then stop the thread (so we don't keep unshared threads running around).
-    For other namespace types, we use this function to execute callbacks without changing the namespaces
-    for the core threads.
-
-    By default, run stuff in init NS. You can pass 'target_pid' to run in the namespace of that process.
-    """
-
-    # make sure "mnt" is last, once we change it our /proc is gone
-    nstypes = sorted(nstypes, key=lambda ns: 1 if ns == "mnt" else 0)
-
-    ret: Optional[T] = None
-
-    def _switch_and_run():
-        libc = ctypes.CDLL("libc.so.6")
-        for nstype in nstypes:
-            if not is_same_ns(target_pid, nstype):
-                flag = {
-                    "mnt": 0x00020000,  # CLONE_NEWNS
-                    "net": 0x40000000,  # CLONE_NEWNET
-                    "pid": 0x20000000,  # CLONE_NEWPID
-                    "uts": 0x04000000,  # CLONE_NEWUTS
-                }[nstype]
-                if libc.unshare(flag) != 0:
-                    raise ValueError(f"Failed to unshare({nstype})")
-
-                with open(f"/proc/{target_pid}/ns/{nstype}", "r") as nsf:
-                    if libc.setns(nsf.fileno(), flag) != 0:
-                        raise ValueError(f"Failed to setns({nstype}) (to pid {target_pid})")
-
-        nonlocal ret
-        ret = callback()
-
-    t = Thread(target=_switch_and_run)
-    t.start()
-    t.join()
-
-    return ret
 
 
 def grab_gprofiler_mutex() -> bool:
@@ -477,25 +393,6 @@ def reset_umask() -> None:
     os.umask(0o022)
 
 
-def is_running_in_init_pid() -> bool:
-    """
-    Check if we're running in the init PID namespace.
-
-    This check is implemented by checking if PID 2 is running, and if it's named "kthreadd"
-    which is the kernel thread from which kernel threads are forked. It's always PID 2 and
-    we should always see it in the init NS. If we don't have a PID 2 running, or if it's not named
-    kthreadd, then we're not in the init PID NS.
-    """
-    try:
-        p = psutil.Process(2)
-    except psutil.NoSuchProcess:
-        return False
-    else:
-        # technically, funny processes can name themselves "kthreadd", causing this check to pass in a non-init NS.
-        # but we don't need to handle such extreme cases, I think.
-        return p.name() == "kthreadd"
-
-
 def limit_frequency(limit: Optional[int], requested: int, msg_header: str, runtime_logger: logging.LoggerAdapter):
     if limit is not None and requested > limit:
         runtime_logger.warning(
@@ -539,21 +436,6 @@ def is_pyinstaller() -> bool:
 
 def get_staticx_dir() -> Optional[str]:
     return os.getenv("STATICX_BUNDLE_DIR")
-
-
-def get_mnt_ns_ancestor(process: Process) -> int:
-    """
-    Gets the topmost ancestor of "process" that runs in the same mount namespace of "process".
-    """
-    while True:
-        parent = process.parent()
-        if parent is None:  # topmost ancestor?
-            return process.pid
-
-        if not is_same_ns(process.pid, "mnt", parent.pid):
-            return process.pid
-
-        process = parent
 
 
 def is_process_running(process: psutil.Process):

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
 python_version = 3.6
 warn_unused_configs = True
-exclude = venv/bin/|deploy/dataflow/
+exclude = venv/bin/|deploy/dataflow/|granulate-utils
 
 [mypy-psutil.*]
 ignore_missing_imports = True

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -151,7 +151,8 @@ RUN if [ $(uname -m) = "aarch64" ]; then python3 -m pip install 'wheel==0.37.0' 
 RUN python3 -m pip install --upgrade pip
 
 COPY requirements.txt requirements.txt
-COPY granulate-utils granulate-utils
+COPY granulate-utils/setup.py granulate-utils/requirements.txt granulate-utils/README.md granulate-utils/
+COPY granulate-utils/granulate_utils granulate-utils/granulate_utils
 RUN python3 -m pip install -r requirements.txt
 
 COPY exe-requirements.txt exe-requirements.txt

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -151,6 +151,7 @@ RUN if [ $(uname -m) = "aarch64" ]; then python3 -m pip install 'wheel==0.37.0' 
 RUN python3 -m pip install --upgrade pip
 
 COPY requirements.txt requirements.txt
+COPY granulate-utils granulate-utils
 RUN python3 -m pip install -r requirements.txt
 
 COPY exe-requirements.txt exe-requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ docker==5.0.0
 six==1.16.0
 dataclasses==0.8; python_version < '3.7'
 packaging==21.2
-granulate_utils@git+https://github.com/Granulate/granulate-utils.git@9a672b209bd6e39bd5f0c7c2140912a727d4a4ab#egg=granulate_utils
+./granulate-utils/

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ docker==5.0.0
 six==1.16.0
 dataclasses==0.8; python_version < '3.7'
 packaging==21.2
-granulate_utils@git+https://github.com/Granulate/granulate-utils.git@eff29e9e67fdf284a6f8008186c67c2d9bb56145#egg=granulate_utils
+granulate_utils@git+https://github.com/Granulate/granulate-utils.git@9a672b209bd6e39bd5f0c7c2140912a727d4a4ab#egg=granulate_utils

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,21 @@
 #
 import re
 from pathlib import Path
-from typing import List
+from typing import Iterator
 
 import setuptools
 
 
-def read_requirements(path: str) -> List[str]:
+def read_requirements(path: str) -> Iterator[str]:
     with open(path) as f:
-        return [line for line in f.readlines() if not line.startswith("#")]
+        for line in f:
+            if line.startswith("#"):
+                continue
+            # install_requires doesn't like paths
+            if line.strip() == "./granulate-utils/":
+                yield "granulate-utils"
+                continue
+            yield line
 
 
 version = re.search(r'__version__\s*=\s*"(.*?)"', Path("gprofiler/__init__.py").read_text())
@@ -34,6 +41,6 @@ setuptools.setup(
     ],
     packages=setuptools.find_packages(),
     include_package_data=True,
-    install_requires=read_requirements("requirements.txt"),
+    install_requires=list(read_requirements("requirements.txt")),
     python_requires=">=3.6",
 )


### PR DESCRIPTION
* Move namespace utils to granulate_utils so they can be reused by other components besides gProfiler.
* Make granulate_utils a submodule
* Upgrade version of granulate_utils (after https://github.com/Granulate/granulate-utils/pull/8)