### PR TITLE
java: Upgrade AP for a static libgcc build

### DIFF
--- a/scripts/async_profiler_build_shared.sh
+++ b/scripts/async_profiler_build_shared.sh
@@ -5,8 +5,8 @@
 #
 set -euo pipefail
 
-VERSION=v2.5g1
-GIT_REV="02cb785f7cc0024581a1802126f51ed94d5b0475"
+VERSION=v2.5g2
+GIT_REV="05797686d3187b067579829924961ab939793dd5"
 
 git clone --depth 1 -b "$VERSION" https://github.com/Granulate/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
 source "$1"


### PR DESCRIPTION
## Description
The new version is built statically with libgcc, which was required for Java
based on the image 'openjdk:14-alpine' as it doesn't have libgcc installed.
I can't think of a reason *not* to build statically always, hence enabling it
for all builds.

## How Has This Been Tested?
Tested profiling on Java from `openjdk:14-alpine`, hasn't worked before, does work now.
