### PR TITLE
java: Filter signal codes only in proc_events callback (from all non-zero exit codes)

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -749,8 +749,7 @@ class JavaProfiler(ProcessProfilerBase):
                 # not a signal - don't report it.
                 return
 
-            if exit_code != 0:
-                logger.warning("async-profiled Java process exited with signal", pid=tid, signal=signo)
+            logger.warning("async-profiled Java process exited with signal", pid=tid, signal=signo)
 
     def _handle_kernel_messages(self, messages):
         for message in messages:

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -8,6 +8,7 @@ import json
 import os
 import re
 import shutil
+import signal
 from pathlib import Path
 from threading import Event
 from typing import List, Optional, Set
@@ -737,9 +738,19 @@ class JavaProfiler(ProcessProfilerBase):
         # Notice that we only check the exit code of the main thread here.
         # It's assumed that an error in any of the Java threads will be reflected in the exit code of the main thread.
         if tid in self._profiled_pids:
-            if exit_code != 0:
-                logger.warning("Async-profiled Java process exited with error code", pid=tid, exit_code=hex(exit_code))
             self._pids_to_remove.add(tid)
+
+            if os.WIFSIGNALED(exit_code):
+                signo = os.WTERMSIG(exit_code)
+            elif exit_code == 0x8F00:
+                # java exits with 143 upon SIGTERM
+                signo = signal.SIGTERM.value
+            else:
+                # not a signal - don't report it.
+                return
+
+            if exit_code != 0:
+                logger.warning("async-profiled Java process exited with signal", pid=tid, signal=signo)
 
     def _handle_kernel_messages(self, messages):
         for message in messages:


### PR DESCRIPTION
## Description
Log only upon signal exits - we don't care about the rest. We care specifically about SIGKILL, SIGTERM which are common sources of trouble.

* SIGKILL can't be caught, so it results in exit code `0x0009` which makes `WIFSIGNALED` return true and the signal code is 9.
* I checked SIGSEGV, SIGILL. They are caught by the JVM and cause generation of hs_err files; then the JVM exits with SIGABRT (`VMError::report_and_die` calls `os::die` which calls `abort`). So the signal code is 6.
* SIGTERM is the last question. The JVM handles it (seen in `strace -f`) and eventually does `exit_group(143)`. I have yet to find where it happens in JVM sources.

I have found this gem, tho:
```
    } else if (WIFSIGNALED(status)) {
       // The child exited because of a signal
       // The best value to return is 0x80 + signal number,
       // because that is what all Unix shells do, and because
       // it allows callers to distinguish between process exit and
       // process death by signal.
       return 0x80 + WTERMSIG(status);
    } else {
```

(in `os::fork_and_exec`, it's not the relevant code ofc, but it is a lead)

## Motivation and Context
Reduce noise by this log message. We only cared about signals in the first place, but delayed the work of actually figuring out how signals look like in the JVM.

## How Has This Been Tested?
Tested signaling a JVM with SIGKILL/SIGSEGV/SIGILL/SIGTERM