### PR TITLE
tests: Test gProfiler with low privileges

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,7 +198,18 @@ def application_docker_image(
 
 @fixture
 def application_docker_mount() -> bool:
+    """
+    Whether or not to mount the output directory (output_directory fixture) to the application containers.
+    """
     return False
+
+
+@fixture
+def application_docker_capabilities() -> List[str]:
+    """
+    List of capabilities to add to the application containers.
+    """
+    return []
 
 
 @fixture
@@ -208,6 +219,7 @@ def application_docker_container(
     application_docker_image: Image,
     output_directory: Path,
     application_docker_mount: bool,
+    application_docker_capabilities: List[str],
 ) -> Iterable[Container]:
     if not in_container:
         yield None
@@ -221,7 +233,7 @@ def application_docker_container(
             detach=True,
             user="5555:6666",
             volumes=volumes,
-            cap_add=["SYS_PTRACE"],
+            cap_add=application_docker_capabilities,
         )
         while container.status != "running":
             if container.status == "exited":

--- a/tests/containers/python/Dockerfile
+++ b/tests/containers/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python:3.6-slim
 
 WORKDIR /app
 ADD lister.py /app

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -80,6 +80,14 @@ def test_executable(
         ("ruby", "rbspy"),
     ],
 )
+@pytest.mark.parametrize(
+    "application_docker_capabilities",
+    [
+        [
+            "SYS_PTRACE",
+        ]
+    ],
+)
 @pytest.mark.parametrize("in_container", [True])
 def test_executale_not_privileged(
     gprofiler_exe: Path,

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -63,7 +63,7 @@ def test_executable(
             + profiler_flags
         )
         popen = Popen(command)
-        popen.wait()
+        assert popen.wait() == 0
 
     collapsed = parse_one_collapsed(Path(output_directory / "last_profile.col").read_text())
     assert_collapsed(collapsed)

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -19,12 +19,12 @@ from tests.utils import RUNTIME_PROFILERS, run_gprofiler_in_container
     "runtime,profiler_type",
     RUNTIME_PROFILERS,
 )
-def test_from_executable(
+def test_executable(
     gprofiler_exe: Path,
     application_pid: int,
     runtime_specific_args: List[str],
     assert_collapsed: Callable[[Mapping[str, int]], None],
-    exec_container_image: Image,
+    exec_container_image: Optional[Image],
     docker_client: DockerClient,
     output_directory: Path,
     profiler_flags: List[str],

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -78,6 +78,7 @@ def test_executable(
         ("java", "ap"),
         ("python", "py-spy"),
         ("ruby", "rbspy"),
+        ("php", "phpspy"),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -3,16 +3,18 @@
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
 import os
+import shutil
 from pathlib import Path
 from subprocess import Popen
-from typing import Callable, List, Mapping
+from typing import Callable, List, Mapping, Optional
 
 import pytest  # type: ignore
 from docker import DockerClient
+from docker.models.containers import Container
 from docker.models.images import Image
 
 from gprofiler.merge import parse_one_collapsed
-from tests.utils import RUNTIME_PROFILERS, run_gprofiler_in_container
+from tests.utils import RUNTIME_PROFILERS, _no_errors, run_gprofiler_in_container
 
 
 @pytest.mark.parametrize(
@@ -64,6 +66,56 @@ def test_executable(
         )
         popen = Popen(command)
         assert popen.wait() == 0
+
+    collapsed = parse_one_collapsed(Path(output_directory / "last_profile.col").read_text())
+    assert_collapsed(collapsed)
+
+
+@pytest.mark.parametrize("application_docker_mount", [True])  # adds output_directory mount to the application container
+@pytest.mark.parametrize(
+    "runtime,profiler_type",
+    [
+        ("java", "ap"),
+        ("python", "py-spy"),
+        ("ruby", "rbspy"),
+    ],
+)
+@pytest.mark.parametrize("in_container", [True])
+def test_executale_not_privileged(
+    gprofiler_exe: Path,
+    application_docker_container: Container,
+    runtime_specific_args: List[str],
+    assert_collapsed: Callable[[Mapping[str, int]], None],
+    output_directory: Path,
+    profiler_flags: List[str],
+    application_docker_mount: bool,
+) -> None:
+    """
+    Tests gProfiler with lower privileges: runs in a container, as root & with SYS_PTRACE,
+    but nothing more.
+    """
+    os.makedirs(str(output_directory), mode=0o755, exist_ok=True)
+
+    mount_gprofiler_exe = str(output_directory / "gprofiler")
+    if not os.path.exists(mount_gprofiler_exe):
+        shutil.copy(str(gprofiler_exe), mount_gprofiler_exe)
+
+    command = (
+        [
+            mount_gprofiler_exe,
+            "-v",
+            "--output-dir",
+            str(output_directory),
+            "--disable-pidns-check",  # not running in init PID
+            "--no-perf",  # no privileges to run perf
+        ]
+        + runtime_specific_args
+        + profiler_flags
+    )
+    exit_code, output = application_docker_container.exec_run(cmd=command, privileged=False, user="root:root")
+
+    _no_errors(output.decode())
+    assert exit_code == 0
 
     collapsed = parse_one_collapsed(Path(output_directory / "last_profile.col").read_text())
     assert_collapsed(collapsed)

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -90,7 +90,7 @@ def test_executable(
     ],
 )
 @pytest.mark.parametrize("in_container", [True])
-def test_executale_not_privileged(
+def test_executable_not_privileged(
     gprofiler_exe: Path,
     application_docker_container: Container,
     runtime_specific_args: List[str],


### PR DESCRIPTION
## Description
Add tests that run AP, py-spy & rbspy (and gProfiler itself) in a container without `--privileged`. This resembles Databricks, Fargate etc.