### PR TITLE
java: Paranoid profiling stop on suspicious events in kernel messages

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -493,8 +493,9 @@ class JavaProfiler(ProcessProfilerBase):
 
     @classmethod
     def _disable_profiling(cls):
-        logger.warning("Java profiling has been disabled, will avoid profiling any new java process")
-        cls._should_profile = False
+        if cls._should_profile:
+            logger.warning("Java profiling has been disabled, will avoid profiling any new java process")
+            cls._should_profile = False
 
     def _is_jvm_type_supported(self, java_version_cmd_output: str) -> bool:
         return all(exclusion not in java_version_cmd_output for exclusion in self.JDK_EXCLUSIONS)


### PR DESCRIPTION
## Description
We want the ability to be very strict on error detection. This is possibly too strict (segfaults in non-profiled processes are most likely not related to us...) but we'll start very strict and lower the bar as we go.
The "PID in message" check will help us identify if our regex on OOM/signals miss anything (or if there's any other type of bad message we should be looking at). I hope it won't catch too many false positives.

## How Has This Been Tested?
* Triggered an OOM with `docker run -it -m 6m python` and made sure Java profiling stops
* Triggered a segfault with `main(){*(int*)0=0;}` and made sure Java profiling stops
* Wrote a profiled PID to the kernel log (`echo 374075 | sudo tee /dev/kmsg`) and made sure Java profiling stops. It's funny that it works - the kernel does flag messages coming from usermode, we should check this flag and ignore such messages as we really care only about kernel messages.