### PR TITLE
ci: deploy-executable needs build-executable, not test-executable

### DIFF
--- a/.github/workflows/build-executable-test-deploy.yml
+++ b/.github/workflows/build-executable-test-deploy.yml
@@ -133,7 +133,7 @@ jobs:
   deploy-executable:
     if: startsWith(github.ref, 'refs/tags/')
     needs:
-      - test-executable  # depends on build-executable
+      - build-executable  # depends on build-executable
       - build-executable-aarch64
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/build-executable-test-deploy.yml
+++ b/.github/workflows/build-executable-test-deploy.yml
@@ -133,7 +133,7 @@ jobs:
   deploy-executable:
     if: startsWith(github.ref, 'refs/tags/')
     needs:
-      - build-executable  # depends on build-executable
+      - build-executable
       - build-executable-aarch64
     runs-on: ubuntu-20.04
 


### PR DESCRIPTION
So last release (1.2.9) I had to upload the files manually :/