### PR TITLE
python: pyperf: Remove output files before starting

### DIFF
--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -257,6 +257,9 @@ class PythonEbpfProfiler(ProfilerBase):
         if self.user_stacks_pages is not None:
             cmd.extend(["--user-stacks-pages", str(self.user_stacks_pages)])
 
+        for f in glob.glob(f"{str(self.output_path)}.*"):
+            os.unlink(f)
+
         process = start_process(cmd, via_staticx=True)
         # wait until the transient data file appears - because once returning from here, PyPerf may
         # be polled via snapshot() and we need it to finish installing its signal handler.


### PR DESCRIPTION
## Description
Leftovers (from previous runs / from test()) may later be caught by our _dump().

I encountered it while running gProfiler and the output graph would have 1 sample of PyPerf... Which is the sample from the `test()` call.

## How Has This Been Tested?
After this fix, running gProfiler (`--no-perf` and just a Python app being profiled by PyPerf) correctly works and gives the expected number of samples; hence, using the real output file.