### PR TITLE
gProfiler 1.2.10 & upgrade Java's async-profiler

### DIFF
--- a/gprofiler/__init__.py
+++ b/gprofiler/__init__.py
@@ -2,4 +2,4 @@
 # Copyright (c) Granulate. All rights reserved.
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
-__version__ = "1.2.9"
+__version__ = "1.2.10"

--- a/scripts/async_profiler_build_shared.sh
+++ b/scripts/async_profiler_build_shared.sh
@@ -5,8 +5,8 @@
 #
 set -euo pipefail
 
-VERSION=v2.5g2
-GIT_REV="05797686d3187b067579829924961ab939793dd5"
+VERSION=v2.5g3
+GIT_REV="b835b2591c968c1170056b18a12fd03918a4360f"
 
 git clone --depth 1 -b "$VERSION" https://github.com/Granulate/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
 source "$1"


### PR DESCRIPTION
## Description
Hotfix for the mentioned bug.

## How Has This Been Tested?
CI

Tested by `strace`ing a Java application and running gProfiler alongside. In the trace I can find `EBADF`. On this branch, I don't see the `EBADF` anymore, and there's only one `close` call.