### PR TITLE
Python: Improve packages versions cache

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,6 +3,7 @@ flake8==3.9.2
 black==21.5b2
 mypy==0.901
 isort==5.8.0
+types-cachetools==4.2.6
 types-requests==0.1.9
 types-dataclasses==0.1.5
 types-psutil==5.8.0

--- a/gprofiler/metadata/py_module_version.py
+++ b/gprofiler/metadata/py_module_version.py
@@ -9,24 +9,62 @@ in pip 21.3.1, as mentioned in the functions' documentation.
 """
 import csv
 import email.parser
-import functools
 import os
 import pathlib
 import re
-from typing import Dict, Iterator, Optional, Tuple
+from typing import Dict, Iterator, Optional, Tuple, Type, Union
 
 # pkg_resources is a part of setuptools, but it has a standalone deprecated version. That's the version mypy
 # is looking for, but the stubs there are extremely deprecated
 import pkg_resources  # type: ignore
+from cachetools import Cache
+from cachetools import LRUCache as _LRUCache
+from cachetools import cached, keys
 from granulate_utils.linux.ns import get_mnt_ns_ancestor, resolve_host_path
 from psutil import AccessDenied, NoSuchProcess, Process
 
 from gprofiler.log import get_logger_adapter
 
+# For some reason mypy fails to infer the type of LRUCache when it's passed to @cached. This is the workaround:
+LRUCache: Type[Cache] = _LRUCache
+
 logger = get_logger_adapter(__name__)
 
 
 __all__ = ["get_modules_versions"]
+
+
+_permission_errors_logged = 0
+
+
+def _get_mnt_ns(process: Process) -> Optional[str]:
+    try:
+        return os.readlink(f"/proc/{process.pid}/ns/mnt")
+    except PermissionError:
+        global _permission_errors_logged
+        if _permission_errors_logged < 10:
+            logger.warning(f"Got PermissionError when tried to readlink {process!r}'s ns")
+            _permission_errors_logged += 1
+    except FileNotFoundError:
+        # The process is probably dead
+        pass
+    return None
+
+
+def _get_mnt_ns_id(process: Process) -> Union[str, Tuple[int, float]]:
+    """Get an identifier of the mount ns of a process for caching purposes.
+
+    The result of this function isn't necessarily one-to-one - ideally it
+    returns the contents of /proc/[pid]/mnt/ns, but if the function fails to
+    read this file it returns a tuple that identifies an ancestor process in
+    the namespace.
+    """
+    mnt_ns = _get_mnt_ns(process)
+    if mnt_ns is not None:
+        return mnt_ns
+
+    ancestor = get_mnt_ns_ancestor(process)
+    return (ancestor.pid, ancestor._create_time)
 
 
 def _get_packages_dir(file_path: str) -> Optional[str]:
@@ -150,7 +188,7 @@ def _get_libpython_path(process: Process) -> Optional[str]:
 _PY_VERSION_STRING_PATTERN = re.compile(rb"(?<=\D)(?:2\.7|3\.1?\d)\.\d\d?(?=\x00)")
 
 
-@functools.lru_cache(maxsize=128)
+@cached(LRUCache(maxsize=128), key=lambda process: keys.hashkey(_get_mnt_ns_id(process)))
 def _get_python_full_version(process: Process) -> Optional[str]:
     bin_file = _get_libpython_path(process) or f"/proc/{process.pid}/exe"
 
@@ -190,7 +228,7 @@ def _populate_standard_libs_version(result: Dict[str, Optional[Tuple[str, str]]]
         result[path] = ("standard-library", py_version)  # type: ignore
 
 
-@functools.lru_cache(maxsize=128)
+@cached(LRUCache(maxsize=128), key=lambda process, packages_path: keys.hashkey(_get_mnt_ns_id(process), packages_path))
 def _get_packages_files(process: Process, packages_path: str) -> Dict[str, Tuple[str, str]]:
     """Return a dict of filename: (package_name, package_version) for the packages in packages_path"""
     # Transform packages_path to be relative to /proc/[pid]/root/
@@ -230,10 +268,6 @@ def _populate_packages_versions(packages_versions: Dict[str, Optional[Tuple[str,
         # Not much that we can do, pkg_resources.find_distributions won't work properly
         return
 
-    # We use the process only for its /proc/[pid]/root, so it's more efficient for caching purposes to use the
-    # ns ancestor
-    ancestor = get_mnt_ns_ancestor(process)
-
     try:
         for module_path in packages_versions:
             if not module_path.startswith("/"):
@@ -243,7 +277,7 @@ def _populate_packages_versions(packages_versions: Dict[str, Optional[Tuple[str,
             if packages_path is None:
                 # This module is (probably) not part of a package
                 continue
-            path_to_package_info = _get_packages_files(ancestor, packages_path)
+            path_to_package_info = _get_packages_files(process, packages_path)
             package_info: Optional[Tuple[str, str]] = path_to_package_info.get(module_path)
             if package_info is not None:
                 packages_versions[module_path] = package_info

--- a/gprofiler/metadata/py_module_version.py
+++ b/gprofiler/metadata/py_module_version.py
@@ -188,7 +188,7 @@ def _get_libpython_path(process: Process) -> Optional[str]:
 _PY_VERSION_STRING_PATTERN = re.compile(rb"(?<=\D)(?:2\.7|3\.1?\d)\.\d\d?(?=\x00)")
 
 
-@cached(LRUCache(maxsize=128), key=lambda process: keys.hashkey(_get_mnt_ns_id(process)))
+@cached(LRUCache(maxsize=128), key=lambda process: keys.hashkey(_get_mnt_ns_id(process), process.cmdline()[0]))
 def _get_python_full_version(process: Process) -> Optional[str]:
     bin_file = _get_libpython_path(process) or f"/proc/{process.pid}/exe"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cachetools==4.2.4
 importlib-resources==5.1.0
 psutil==5.8.0
 requests==2.25.1


### PR DESCRIPTION
Cache Python packages versions by mount namespace.

## Description
Improve the cache of Python packages versions to be based on `/proc/[pid]/ns/mnt` instead of on ancestor process in the namespace.

Also, fix a potential bug by caching Python's version according mnt ns *and* `cmdline[0]` of the process to prevent collision in case several Python versions are executed in the same namespace.

## Related Issue
<!--- If there's an issue related, please link it here -->
<!--- If suggesting a new feature or a medium/big change, please discuss it in an issue first. -->
<!--- For small changes, it's okay to open a PR immediately. -->

## Motivation and Context
Getting ancestor process is much heavier than `readlink`ing `/proc/[pid]/ns/mnt`. Also, namespace-based cache is more accurate.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your changes are tested by the CI, you can just write that.-->

## Screenshots
[<!--- (if appropriate) -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
