### PR TITLE
Prevent registering of profiler arguments with a wrong dest name

### DIFF
--- a/gprofiler/profilers/registry.py
+++ b/gprofiler/profilers/registry.py
@@ -72,6 +72,9 @@ def register_profiler(
 
     def profiler_decorator(profiler_class):
         assert profiler_name not in profilers_config, f"{profiler_name} is already registered!"
+        assert all(
+            arg.dest.startswith(profiler_name.lower()) for arg in profiler_arguments or []
+        ), f"{profiler_name}: Profiler args dest must be prefixed with the profiler name"
         profilers_config[profiler_name] = ProfilerConfig(
             profiler_mode_argument_help,
             disablement_help,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In order to be passed to the relevant profiler, the `dest` of profiler-specific arguments must be prefixed with the profiler's name. This PR `assert`s they're named correctly.

## Motivation and Context
I tried to add an argument without knowing this and spent some good amount of time debugging that could've been saved with this `assert`.

## How Has This Been Tested?
Just ran gProfiler and saw that this `assert` isn't triggered, and then ran it again with a wrong arg `dest`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
