### PR TITLE
java: Expand --java-safemode into a set of options

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -544,7 +544,9 @@ class JavaProfiler(ProcessProfilerBase):
             )
 
         if java_safemode == JAVA_SAFEMODE_ALL:
-            assert self._ap_safemode == 127, "async-profiler safemode must be set to 127 in --java-safemode"
+            assert (
+                self._ap_safemode == 127
+            ), f"async-profiler safemode must be set to 127 in --java-safemode={JAVA_SAFEMODE_ALL} (or --java-safemode)"
 
     def _disable_profiling(self, cause: str):
         if self._should_profile and cause in self._java_safemode:
@@ -631,7 +633,8 @@ class JavaProfiler(ProcessProfilerBase):
             # then check with that instead (if exe isn't java)
             if process_basename != "java":
                 logger.warning(
-                    "Non-java basenamed process, skipping... (disable --java-safemode to profile it anyway)",
+                    "Non-java basenamed process, skipping... (disable "
+                    f" --java-safemode={JavaSafemodeOptions.JAVA_EXTENDED_VERSION_CHECKS} to profile it anyway)",
                     pid=process.pid,
                     exe=process.exe(),
                 )
@@ -645,7 +648,8 @@ class JavaProfiler(ProcessProfilerBase):
             if not self._is_jvm_version_supported(java_version_output):
                 logger.warning(
                     "Process running unsupported Java version, skipping..."
-                    " (disable --java-safemode to profile it anyway)",
+                    f" (disable --java-safemode={JavaSafemodeOptions.JAVA_EXTENDED_VERSION_CHECKS}"
+                    " to profile it anyway)",
                     pid=process.pid,
                     java_version_output=java_version_output,
                 )
@@ -667,7 +671,7 @@ class JavaProfiler(ProcessProfilerBase):
             if "libasyncProfiler.so" in mmap.path and not mmap.path.startswith(TEMPORARY_STORAGE_PATH):
                 logger.warning(
                     "Non-gProfiler async-profiler is already loaded to the target process."
-                    " Disable --java-safemode=ap-loaded-check to bypass this check.",
+                    f" Disable --java-safemode={JavaSafemodeOptions.AP_LOADED_CHECK} to bypass this check.",
                     pid=process.pid,
                     ap_path=mmap.path,
                 )

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -70,6 +70,11 @@ class JavaSafemodeOptions(str, Enum):
 
 
 JAVA_SAFEMODE_ALL_OPTIONS = [o.value for o in JavaSafemodeOptions]
+JAVA_SAFEMODE_DEFAULT_OPTIONS = [
+    JavaSafemodeOptions.PROFILED_OOM.value,
+    JavaSafemodeOptions.PROFILED_SIGNALED.value,
+    JavaSafemodeOptions.HSERR.value,
+]
 
 
 class JattachException(CalledProcessError):
@@ -457,8 +462,8 @@ def parse_jvm_version(version_string: str) -> JvmVersion:
             type=str,
             const=JAVA_SAFEMODE_ALL,
             nargs="?",
-            default="",
-            help="Sets the Java profiler to a safemode options",
+            default=",".join(JAVA_SAFEMODE_DEFAULT_OPTIONS),
+            help="Sets the Java profiler safemode options. Default is: %(default)s.",
         ),
     ],
 )

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -260,7 +260,7 @@ class AsyncProfiledProcess:
         for mmap in self.process.memory_maps():
             if "libasyncProfiler.so" in mmap.path and not mmap.path.startswith(TEMPORARY_STORAGE_PATH):
                 raise Exception(
-                    f"Non-gProfiler Async-profiler is already loaded to the target process: {mmap.path!r}. "
+                    f"Non-gProfiler async-profiler is already loaded to the target process: {mmap.path!r}. "
                     f"Disable --java-safemode to bypass"
                 )
 

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -63,7 +63,6 @@ class JavaSafemodeOptions(str, Enum):
     PROFILED_OOM = "profiled-oom"
     # a profiled process was signaled:
     # * fatally signaled and we saw it in the kernel log
-    # * we saw an exit code of signal in a proc_events event.
     PROFILED_SIGNALED = "profiled-signaled"
     # hs_err file was written for a profiled process
     HSERR = "hserr"

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -128,7 +128,12 @@ class AsyncProfiledProcess:
     OUTPUTS_MODE = 0o622  # readable by root, writable by all
 
     def __init__(
-        self, process: Process, storage_dir: str, buildids: bool, mode: str, ap_safemode: int, java_safemode: List[str]
+        self,
+        process: Process,
+        storage_dir: str,
+        buildids: bool,
+        mode: str,
+        ap_safemode: int,
     ):
         self.process = process
         # access the process' root via its topmost parent/ancestor which uses the same mount namespace.
@@ -173,7 +178,6 @@ class AsyncProfiledProcess:
         assert mode in ("cpu", "itimer"), f"unexpected mode: {mode}"
         self._mode = mode
         self._ap_safemode = ap_safemode
-        self._java_safemode = java_safemode
 
     def __enter__(self):
         os.makedirs(self._ap_dir_host, 0o755, exist_ok=True)
@@ -686,9 +690,7 @@ class JavaProfiler(ProcessProfilerBase):
             self._profiled_pids.add(process.pid)
 
         logger.info(f"Profiling process {process.pid} with async-profiler")
-        with AsyncProfiledProcess(
-            process, self._storage_dir, self._buildids, self._mode, self._ap_safemode, self._java_safemode
-        ) as ap_proc:
+        with AsyncProfiledProcess(process, self._storage_dir, self._buildids, self._mode, self._ap_safemode) as ap_proc:
             return self._profile_ap_process(ap_proc)
 
     def _profile_ap_process(self, ap_proc: AsyncProfiledProcess) -> Optional[StackToSampleCount]:

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -59,13 +59,24 @@ JAVA_SAFEMODE_ALL = "all"  # magic value for *all* options from JavaSafemodeOpti
 
 
 class JavaSafemodeOptions(str, Enum):
+    # a profiled process was OOM-killed and we saw it in the kernel log
     PROFILED_OOM = "profiled-oom"
+    # a profiled process was signaled:
+    # * fatally signaled and we saw it in the kernel log
+    # * we saw an exit code of signal in a proc_events event.
     PROFILED_SIGNALED = "profiled-signaled"
+    # hs_err file was written for a profiled process
     HSERR = "hserr"
+    # a process was OOM-killed and we saw it in the kernel log
     GENERAL_OOM = "general-oom"
+    # a process was fatally signaled and we saw it in the kernel log
     GENERAL_SIGNALED = "general-signaled"
+    # we saw the PID of a profiled process in the kernel logs
     PID_IN_MESSAGES = "pid-in-messages"
+    # employ extended version checks before deciding to profile
     JAVA_EXTENDED_VERSION_CHECK = "java-extended-version-check"
+    # refuse profiling if async-profiler is already loaded (and not by gProfiler)
+    # in the target process
     AP_LOADED_CHECK = "ap-loaded-check"
 
 

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -457,6 +457,7 @@ def parse_jvm_version(version_string: str) -> JvmVersion:
             type=str,
             const=JAVA_SAFEMODE_ALL,
             nargs="?",
+            default="",
             help="Sets the Java profiler to a safemode options",
         ),
     ],
@@ -512,7 +513,7 @@ class JavaProfiler(ProcessProfilerBase):
         if java_safemode == JAVA_SAFEMODE_ALL:
             self._java_safemode = JAVA_SAFEMODE_ALL_OPTIONS
         else:
-            self._java_safemode = java_safemode.split(",")
+            self._java_safemode = java_safemode.split(",") if java_safemode else []
 
         assert all(
             o in JAVA_SAFEMODE_ALL_OPTIONS for o in self._java_safemode

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -749,7 +749,7 @@ class JavaProfiler(ProcessProfilerBase):
 
     def _select_processes_to_profile(self) -> List[Process]:
         if not self._should_profile:
-            logger.debug("Java profiling has been disabled, skipping profiling of all java process")
+            logger.debug("Java profiling has been disabled, skipping profiling of all java processes")
             return []
         return pgrep_maps(r"^.+/libjvm\.so$")
 

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -73,7 +73,7 @@ class JavaSafemodeOptions(str, Enum):
     # we saw the PID of a profiled process in the kernel logs
     PID_IN_KERNEL_MESSAGES = "pid-in-kernel-messages"
     # employ extended version checks before deciding to profile
-    JAVA_EXTENDED_VERSION_CHECK = "java-extended-version-check"
+    JAVA_EXTENDED_VERSION_CHECKS = "java-extended-version-checks"
     # refuse profiling if async-profiler is already loaded (and not by gProfiler)
     # in the target process
     AP_LOADED_CHECK = "ap-loaded-check"
@@ -544,10 +544,11 @@ class JavaProfiler(ProcessProfilerBase):
         if self._java_safemode:
             logger.debug("Java safemode enabled", safemode=self._java_safemode)
 
-        if JavaSafemodeOptions.JAVA_EXTENDED_VERSION_CHECK in self._java_safemode:
-            assert (
-                self._simple_version_check
-            ), f"Java version checks are mandatory in --java-safemode={JavaSafemodeOptions.JAVA_EXTENDED_VERSION_CHECK}"
+        if JavaSafemodeOptions.JAVA_EXTENDED_VERSION_CHECKS in self._java_safemode:
+            assert self._simple_version_check, (
+                "Java version checks are mandatory in"
+                f" --java-safemode={JavaSafemodeOptions.JAVA_EXTENDED_VERSION_CHECKS}"
+            )
 
         if java_safemode == JAVA_SAFEMODE_ALL:
             assert self._ap_safemode == 127, "async-profiler safemode must be set to 127 in --java-safemode"
@@ -632,7 +633,7 @@ class JavaProfiler(ProcessProfilerBase):
 
     def _is_profiling_supported(self, process: Process) -> bool:
         process_basename = os.path.basename(process.exe())
-        if JavaSafemodeOptions.JAVA_EXTENDED_VERSION_CHECK in self._java_safemode:
+        if JavaSafemodeOptions.JAVA_EXTENDED_VERSION_CHECKS in self._java_safemode:
             # TODO we can get the "java" binary by extracting the java home from the libjvm path,
             # then check with that instead (if exe isn't java)
             if process_basename != "java":

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -58,7 +58,7 @@ logger = get_logger_adapter(__name__)
 JAVA_SAFEMODE_ALL = "all"  # magic value for *all* options from JavaSafemodeOptions
 
 
-class JavaSafemodeOptions(Enum):
+class JavaSafemodeOptions(str, Enum):
     PROFILED_OOM = "profiled-oom"
     PROFILED_SIGNALED = "profiled-signaled"
     HSERR = "hserr"
@@ -722,7 +722,7 @@ class JavaProfiler(ProcessProfilerBase):
             f"container info:\n{container_info}"
         )
 
-        self._disable_profiling(JavaSafemodeOptions.HSERR.value)
+        self._disable_profiling(JavaSafemodeOptions.HSERR)
 
     def _select_processes_to_profile(self) -> List[Process]:
         if not self._should_profile:
@@ -794,13 +794,13 @@ class JavaProfiler(ProcessProfilerBase):
             oom_entry = get_oom_entry(text)
             if oom_entry and oom_entry.pid in self._profiled_pids:
                 logger.warning("Profiled Java process OOM", oom=json.dumps(oom_entry._asdict()))
-                self._disable_profiling(JavaSafemodeOptions.PROFILED_OOM.value)
+                self._disable_profiling(JavaSafemodeOptions.PROFILED_OOM)
                 continue
 
             signal_entry = get_signal_entry(text)
             if signal_entry is not None and signal_entry.pid in self._profiled_pids:
                 logger.warning("Profiled Java process signaled", signal=json.dumps(signal_entry._asdict()))
-                self._disable_profiling(JavaSafemodeOptions.PROFILED_SIGNALED.value)
+                self._disable_profiling(JavaSafemodeOptions.PROFILED_SIGNALED)
                 continue
 
             # paranoia - in safemode, stop Java profiling upon any OOM / fatal-signal / occurrence of a profiled
@@ -809,15 +809,15 @@ class JavaProfiler(ProcessProfilerBase):
             # are very broad and will spam our log.
             if oom_entry is not None and JavaSafemodeOptions.GENERAL_OOM in self._java_safemode:
                 logger.warning("General OOM", oom=json.dumps(oom_entry._asdict()))
-                self._disable_profiling(JavaSafemodeOptions.GENERAL_OOM.value)
+                self._disable_profiling(JavaSafemodeOptions.GENERAL_OOM)
             elif signal_entry is not None and JavaSafemodeOptions.GENERAL_SIGNALED in self._java_safemode:
                 logger.warning("General signal", signal=json.dumps(signal_entry._asdict()))
-                self._disable_profiling(JavaSafemodeOptions.GENERAL_SIGNALED.value)
+                self._disable_profiling(JavaSafemodeOptions.GENERAL_SIGNALED)
             elif JavaSafemodeOptions.PID_IN_MESSAGES in self._java_safemode and any(
                 str(p) in text for p in self._profiled_pids
             ):
                 logger.warning("Profiled PID shows in kernel message line", line=text)
-                self._disable_profiling(JavaSafemodeOptions.PID_IN_MESSAGES.value)
+                self._disable_profiling(JavaSafemodeOptions.PID_IN_MESSAGES)
 
     def _handle_new_kernel_messages(self):
         try:

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -691,10 +691,7 @@ class JavaProfiler(ProcessProfilerBase):
 
         output = ap_proc.read_output()
         if output is None:
-            logger.warning(
-                f"Profiled process {ap_proc.process.pid} exited after stopping async-profiler"
-                " but before reading the output"
-            )
+            logger.warning(f"Profiled process {ap_proc.process.pid} exited before reading the output")
             return None
         else:
             logger.info(f"Finished profiling process {ap_proc.process.pid}")

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -555,7 +555,7 @@ class JavaProfiler(ProcessProfilerBase):
 
     def _disable_profiling(self, cause: str):
         if self._should_profile and cause in self._java_safemode:
-            logger.warning("Java profiling has been disabled, will avoid profiling any new java process", cause=cause)
+            logger.warning("Java profiling has been disabled, will avoid profiling any new java processes", cause=cause)
             self._should_profile = False
 
     def _is_jvm_type_supported(self, java_version_cmd_output: str) -> bool:

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -828,17 +828,13 @@ class JavaProfiler(ProcessProfilerBase):
 
             # paranoia - in safemode, stop Java profiling upon any OOM / fatal-signal / occurrence of a profiled
             # PID in a kernel message.
-            # these next ones are only checked if the respective safemode option is enabled, because they
-            # are very broad and will spam our log.
-            if oom_entry is not None and JavaSafemodeOptions.GENERAL_OOM in self._java_safemode:
+            if oom_entry is not None:
                 logger.warning("General OOM", oom=json.dumps(oom_entry._asdict()))
                 self._disable_profiling(JavaSafemodeOptions.GENERAL_OOM)
-            elif signal_entry is not None and JavaSafemodeOptions.GENERAL_SIGNALED in self._java_safemode:
+            elif signal_entry is not None:
                 logger.warning("General signal", signal=json.dumps(signal_entry._asdict()))
                 self._disable_profiling(JavaSafemodeOptions.GENERAL_SIGNALED)
-            elif JavaSafemodeOptions.PID_IN_KERNEL_MESSAGES in self._java_safemode and any(
-                str(p) in text for p in self._profiled_pids
-            ):
+            elif any(str(p) in text for p in self._profiled_pids):
                 logger.warning("Profiled PID shows in kernel message line", line=text)
                 self._disable_profiling(JavaSafemodeOptions.PID_IN_KERNEL_MESSAGES)
 

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -72,7 +72,7 @@ class JavaSafemodeOptions(str, Enum):
     # a process was fatally signaled and we saw it in the kernel log
     GENERAL_SIGNALED = "general-signaled"
     # we saw the PID of a profiled process in the kernel logs
-    PID_IN_MESSAGES = "pid-in-messages"
+    PID_IN_KERNEL_MESSAGES = "pid-in-kernel-messages"
     # employ extended version checks before deciding to profile
     JAVA_EXTENDED_VERSION_CHECK = "java-extended-version-check"
     # refuse profiling if async-profiler is already loaded (and not by gProfiler)
@@ -836,11 +836,11 @@ class JavaProfiler(ProcessProfilerBase):
             elif signal_entry is not None and JavaSafemodeOptions.GENERAL_SIGNALED in self._java_safemode:
                 logger.warning("General signal", signal=json.dumps(signal_entry._asdict()))
                 self._disable_profiling(JavaSafemodeOptions.GENERAL_SIGNALED)
-            elif JavaSafemodeOptions.PID_IN_MESSAGES in self._java_safemode and any(
+            elif JavaSafemodeOptions.PID_IN_KERNEL_MESSAGES in self._java_safemode and any(
                 str(p) in text for p in self._profiled_pids
             ):
                 logger.warning("Profiled PID shows in kernel message line", line=text)
-                self._disable_profiling(JavaSafemodeOptions.PID_IN_MESSAGES)
+                self._disable_profiling(JavaSafemodeOptions.PID_IN_KERNEL_MESSAGES)
 
     def _handle_new_kernel_messages(self):
         try:

--- a/gprofiler/profilers/registry.py
+++ b/gprofiler/profilers/registry.py
@@ -14,6 +14,8 @@ class ProfilerArgument:
         choices: Sequence[Any] = None,
         type: Union[Type, Callable[[str], Any]] = None,
         metavar: str = None,
+        const: Any = None,
+        nargs: str = None,
     ):
         self.name = name
         self.dest = dest
@@ -23,6 +25,8 @@ class ProfilerArgument:
         self.choices = choices
         self.type = type
         self.metavar = metavar
+        self.const = const
+        self.nargs = nargs
 
     def get_dict(self) -> Dict[str, Any]:
         return {key: value for key, value in self.__dict__.items() if value is not None}

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -296,4 +296,4 @@ def test_already_loaded_ap_profiling_failure(tmp_path, monkeypatch, caplog, appl
         process = profiler._select_processes_to_profile()[0]
         assert any("/tmp/fake_gprofiler_tmp" in mmap.path for mmap in process.memory_maps())
         profiler.snapshot()
-        assert "Non-gProfiler async-profiler is already loaded to the target process:" in caplog.text
+        assert "Non-gProfiler async-profiler is already loaded to the target process" in caplog.text

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -52,7 +52,12 @@ def test_async_profiler_already_running(application_pid, assert_collapsed, tmp_p
         assert any("libasyncProfiler.so" in m.path for m in process.memory_maps())
         # run "status"
         with AsyncProfiledProcessForTests(
-            process, profiler._storage_dir, False, mode="itimer", safemode=False, java_safemode=profiler._java_safemode
+            process,
+            profiler._storage_dir,
+            False,
+            mode="itimer",
+            ap_safemode=False,
+            java_safemode=profiler._java_safemode,
         ) as ap_proc:
             ap_proc.status_async_profiler()
             # printed the output file, see ACTION_STATUS case in async-profiler/profiler.cpp
@@ -139,7 +144,7 @@ def test_java_safemode_parameters(tmp_path) -> None:
             java_safemode=JAVA_SAFEMODE_ALL,
             java_mode="ap",
         )
-    assert "Async-profiler safemode must be set to 127 in --java-safemode" in str(excinfo.value)
+    assert "async-profiler safemode must be set to 127 in --java-safemode" in str(excinfo.value)
 
     with pytest.raises(AssertionError) as excinfo:
         JavaProfiler(
@@ -283,4 +288,4 @@ def test_already_loaded_ap_profiling_failure(tmp_path, monkeypatch, caplog, appl
         process = profiler._select_processes_to_profile()[0]
         assert any("/tmp/fake_gprofiler_tmp" in mmap.path for mmap in process.memory_maps())
         profiler.snapshot()
-        assert "Non-gProfiler Async-profiler is already loaded to the target process:" in caplog.text
+        assert "Non-gProfiler async-profiler is already loaded to the target process:" in caplog.text

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -226,10 +226,9 @@ def test_hotspot_error_file(application_pid, tmp_path, monkeypatch, caplog):
         return result
 
     monkeypatch.setattr(AsyncProfiledProcess, "start_async_profiler", sap_and_crash)
-    # To make sure it is reverted to True (the original value) after the test
-    monkeypatch.setattr(JavaProfiler, "_should_profile", True)
 
-    with JavaProfiler(1, 5, Event(), str(tmp_path), False, False, "cpu", 0, False, "ap") as profiler:
+    profiler = JavaProfiler(1, 5, Event(), str(tmp_path), False, False, "cpu", 0, False, "ap")
+    with profiler:
         profiler.snapshot()
 
     assert "Found Hotspot error log" in caplog.text
@@ -238,13 +237,15 @@ def test_hotspot_error_file(application_pid, tmp_path, monkeypatch, caplog):
     assert "libpthread.so" in caplog.text
     assert "memory_usage_in_bytes:" in caplog.text
     assert "Java profiling has been disabled, will avoid profiling any new java process" in caplog.text
-    assert not JavaProfiler._should_profile
+    assert not profiler._should_profile
 
 
 def test_disable_java_profiling(application_pid, tmp_path, monkeypatch, caplog):
-    monkeypatch.setattr(JavaProfiler, "_should_profile", False)
     caplog.set_level(logging.DEBUG)
-    with JavaProfiler(1, 5, Event(), str(tmp_path), False, False, "cpu", 0, False, "ap") as profiler:
+
+    profiler = JavaProfiler(1, 5, Event(), str(tmp_path), False, False, "cpu", 0, False, "ap")
+    monkeypatch.setattr(profiler, "_should_profile", False)
+    with profiler:
         assert len(profiler.snapshot()) == 0
 
     assert "Java profiling has been disabled, skipping profiling of all java process" in caplog.text

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -232,7 +232,18 @@ def test_hotspot_error_file(application_pid, tmp_path, monkeypatch, caplog):
 
     monkeypatch.setattr(AsyncProfiledProcess, "start_async_profiler", sap_and_crash)
 
-    profiler = JavaProfiler(1, 5, Event(), str(tmp_path), False, False, "cpu", 0, False, "ap")
+    profiler = JavaProfiler(
+        1,
+        5,
+        Event(),
+        str(tmp_path),
+        False,
+        True,
+        java_async_profiler_mode="cpu",
+        java_async_profiler_safemode=127,
+        java_safemode=JAVA_SAFEMODE_ALL,
+        java_mode="ap",
+    )
     with profiler:
         profiler.snapshot()
 

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -10,7 +10,7 @@ from threading import Event
 import pytest  # type: ignore
 from packaging.version import Version
 
-from gprofiler.profilers.java import AsyncProfiledProcess, JavaProfiler, parse_jvm_version
+from gprofiler.profilers.java import JAVA_SAFEMODE_ALL, AsyncProfiledProcess, JavaProfiler, parse_jvm_version
 from tests.utils import assert_function_in_collapsed
 
 
@@ -32,7 +32,18 @@ def test_async_profiler_already_running(application_pid, assert_collapsed, tmp_p
     Test we're able to restart async-profiler in case it's already running in the process and get results normally.
     """
     caplog.set_level(logging.INFO)
-    with JavaProfiler(11, 1, Event(), str(tmp_path), False, False, "cpu", 0, False, "ap") as profiler:
+    with JavaProfiler(
+        11,
+        1,
+        Event(),
+        str(tmp_path),
+        False,
+        False,
+        java_async_profiler_mode="cpu",
+        java_async_profiler_safemode=0,
+        java_safemode="",
+        java_mode="ap",
+    ) as profiler:
         process = profiler._select_processes_to_profile()[0]
         with AsyncProfiledProcess(
             process, profiler._storage_dir, False, profiler._mode, False, profiler._java_safemode
@@ -74,7 +85,7 @@ def test_java_async_profiler_cpu_mode(
         True,
         java_async_profiler_mode="cpu",
         java_async_profiler_safemode=0,
-        java_safemode=False,
+        java_safemode="",
         java_mode="ap",
     ) as profiler:
         result = profiler.snapshot()
@@ -104,7 +115,7 @@ def test_java_async_profiler_musl_and_cpu(
         True,
         java_async_profiler_mode="cpu",
         java_async_profiler_safemode=0,
-        java_safemode=False,
+        java_safemode="",
         java_mode="ap",
     ) as profiler:
         result = profiler.snapshot()
@@ -125,7 +136,7 @@ def test_java_safemode_parameters(tmp_path) -> None:
             True,
             java_async_profiler_mode="cpu",
             java_async_profiler_safemode=0,
-            java_safemode=True,
+            java_safemode=JAVA_SAFEMODE_ALL,
             java_mode="ap",
         )
     assert "Async-profiler safemode must be set to 127 in --java-safemode" in str(excinfo.value)
@@ -140,7 +151,7 @@ def test_java_safemode_parameters(tmp_path) -> None:
             False,
             java_async_profiler_mode="cpu",
             java_async_profiler_safemode=127,
-            java_safemode=True,
+            java_safemode=JAVA_SAFEMODE_ALL,
             java_mode="ap",
         )
     assert "Java version checks are mandatory in --java-safemode" in str(excinfo.value)
@@ -160,7 +171,7 @@ def test_java_safemode_version_check(
         True,
         java_async_profiler_mode="cpu",
         java_async_profiler_safemode=127,
-        java_safemode=True,
+        java_safemode=JAVA_SAFEMODE_ALL,
         java_mode="ap",
     ) as profiler:
         process = profiler._select_processes_to_profile()[0]
@@ -184,7 +195,7 @@ def test_java_safemode_build_number_check(
         True,
         java_async_profiler_mode="cpu",
         java_async_profiler_safemode=127,
-        java_safemode=True,
+        java_safemode=JAVA_SAFEMODE_ALL,
         java_mode="ap",
     ) as profiler:
         process = profiler._select_processes_to_profile()[0]
@@ -251,7 +262,7 @@ def test_already_loaded_ap_profiling_failure(tmp_path, monkeypatch, caplog, appl
             True,
             java_async_profiler_mode="cpu",
             java_async_profiler_safemode=127,
-            java_safemode=True,
+            java_safemode=JAVA_SAFEMODE_ALL,
             java_mode="ap",
         ) as profiler:
             profiler.snapshot()
@@ -265,7 +276,7 @@ def test_already_loaded_ap_profiling_failure(tmp_path, monkeypatch, caplog, appl
         True,
         java_async_profiler_mode="cpu",
         java_async_profiler_safemode=127,
-        java_safemode=True,
+        java_safemode=JAVA_SAFEMODE_ALL,
         java_mode="ap",
     ) as profiler:
         process = profiler._select_processes_to_profile()[0]

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -45,9 +45,7 @@ def test_async_profiler_already_running(application_pid, assert_collapsed, tmp_p
         java_mode="ap",
     ) as profiler:
         process = profiler._select_processes_to_profile()[0]
-        with AsyncProfiledProcess(
-            process, profiler._storage_dir, False, profiler._mode, False, profiler._java_safemode
-        ) as ap_proc:
+        with AsyncProfiledProcess(process, profiler._storage_dir, False, profiler._mode, False) as ap_proc:
             assert ap_proc.start_async_profiler(11)
         assert any("libasyncProfiler.so" in m.path for m in process.memory_maps())
         # run "status"
@@ -57,7 +55,6 @@ def test_async_profiler_already_running(application_pid, assert_collapsed, tmp_p
             False,
             mode="itimer",
             ap_safemode=False,
-            java_safemode=profiler._java_safemode,
         ) as ap_proc:
             ap_proc.status_async_profiler()
             # printed the output file, see ACTION_STATUS case in async-profiler/profiler.cpp

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -35,7 +35,7 @@ def test_java_from_host(
         True,
         java_async_profiler_mode="itimer",
         java_async_profiler_safemode=0,
-        java_safemode=False,
+        java_safemode="",
         java_mode="ap",
     ) as profiler:
         result = profiler.snapshot()


### PR DESCRIPTION
## Description
Now, passing plain --java-safemode implies all options.
Alternatively, one can pass --java-safemode=a,b,c to enable only a, b, c.

## Motivation and Context
Finer control on which features are enabled.

Note that, for most features that revolve around disabling the profiler - they are enabled anyway but do not cause disabling of the Java profiler if the flag is not enabled.

## How Has This Been Tested?
Test disabling each appropriate flag, and test it again with `--java-safemode=all`.
* [x] General OOM stops in `all`
* [x] General OOM DOES NOT stop if not given
* [x] General signaled stops in `all`
* [x] General signaled DOES NOT stop if not given
* [x] Profiled OOM stops by default
* [x] Profiled OOM stops in `all`
* [x] Profiled OOM DOES NOT stop if not given in safemode
* [ ] ~~Profiled signaled stops by default~~ not relevant for Java as it catches SIGSEGV (which is what gets logged and we grep for in the kernel log), will be tested with https://github.com/Granulate/gprofiler/pull/254 which adds proc_events support.
* [ ] ~~Profiled signaled stops in `all`~~ same ^^
* [ ] ~~Profiled signaled DOES NOT stop not given in safemode~~ same ^^
* [x] HS err stops by default
* [x] HS err stops in `all`
* [x] HS err DOES NOT stop if not given in safemode
* [x] PID in kernel messages stops in `all`
* [x] PID in kernel messages DOES NOT stop if not given

Additionally, those 2 are unrelated to disabling the Java profiler:
* [x] We do not profile if another libap is loaded in `all`
* [x] We do profile if another libap is loaded and `ap-loaded-check` is not given
* [x] Extensive Java version checks are enabled in `all`
* [x] Extensive Java version checks are disabled if `java-version-check` is not given.