### PR TITLE
merge: Scale process counts using random instead of just rounding

### DIFF
--- a/gprofiler/merge.py
+++ b/gprofiler/merge.py
@@ -8,7 +8,7 @@ import random
 import re
 from collections import Counter, defaultdict
 from pathlib import Path
-from typing import Dict, Iterable, Optional, Tuple
+from typing import Iterable, Optional, Tuple
 
 from gprofiler.docker_client import DockerClient
 from gprofiler.gprofiler_types import ProcessToStackSampleCounters, StackToSampleCount
@@ -158,7 +158,7 @@ def scale_sample_counts(stacks: StackToSampleCount, ratio: float) -> StackToSamp
     if ratio == 1:
         return stacks
 
-    scaled_stacks = StackToSampleCount()
+    scaled_stacks: StackToSampleCount = StackToSampleCount()
     for stack, count in stacks.items():
         new_count = count * ratio
         # If we were to round all of the sample counts it could skew the results. By using a random factor,

--- a/gprofiler/merge.py
+++ b/gprofiler/merge.py
@@ -164,7 +164,7 @@ def scale_sample_counts(stacks: StackToSampleCount, ratio: float) -> StackToSamp
         # If we were to round all of the sample counts it could skew the results. By using a random factor,
         # we mostly solve this by randomly rounding up / down stacks.
         # The higher the fractional part of the new count, the more likely it is to be rounded up instead of down
-        scaled_value = math.ceil(new_count) if new_count - int(new_count) <= random.random() else math.floor(new_count)
+        scaled_value = math.ceil(new_count) if random.random() <= math.modf(new_count)[0] else math.floor(new_count)
         # TODO: For more accurate truncation, check if there's a common frame for the truncated stacks and combine them
         if scaled_value != 0:
             scaled_stacks[stack] = scaled_value

--- a/gprofiler/merge.py
+++ b/gprofiler/merge.py
@@ -165,6 +165,7 @@ def scale_sample_counts(stacks: StackToSampleCount, ratio: float) -> StackToSamp
         # we mostly solve this by randomly rounding up / down stacks.
         # The higher the fractional part of the new count, the more likely it is to be rounded up instead of down
         scaled_value = math.ceil(new_count) if new_count - int(new_count) <= random.random() else math.floor(new_count)
+        # TODO: For more accurate truncation, check if there's a common frame for the truncated stacks and combine them
         if scaled_value != 0:
             scaled_stacks[stack] = scaled_value
     return scaled_stacks


### PR DESCRIPTION
## Description
Re-using the same logic from dwarf scaling to process scaling - instead of rounding the samples to nearest integer we call `random` and `ceil` if the non-integer part is lower than the result, so over time the sample counts are more correct.
In addition - for cases where the result is 0, we remove the whole stack from the results. The behavior for dwarf scaling was to just leave the old value which is bogus, and for perf it was to leave the stack with a zero count which spams the backend and enlarges the output files.

## Related Issue
None

## Motivation and Context

## How Has This Been Tested?
CI will test it