### PR TITLE
Python: Make packages info representation more distinguishable

### DIFF
--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -52,7 +52,7 @@ def _add_versions_to_process_stacks(process: Process, stacks: StackToSampleCount
             package_info = packages_versions.get(module_name_match.group("filename"))
             if package_info is not None:
                 package_name, package_version = package_info
-                return "({} ({}-{}))".format(module_name_match.group("module_info"), package_name, package_version)
+                return "({} [{}=={}])".format(module_name_match.group("module_info"), package_name, package_version)
             return module_name_match.group()
 
         new_stack = _module_name_in_stack.sub(_replace_module_name, stack)

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -54,10 +54,10 @@ def test_pyspy(
     with PySpyProfiler(1000, 3, Event(), str(tmp_path), add_versions=True) as profiler:
         process_collapsed = profiler.snapshot().get(application_pid)
         assert_collapsed(process_collapsed, check_comm=True)
-        assert_function_in_collapsed("PyYAML-6.0", process_collapsed)  # Ensure package info is presented
+        assert_function_in_collapsed("PyYAML==6.0", process_collapsed)  # Ensure package info is presented
         # Ensure Python version is presented
         assert python_version is not None, "Failed to find python version"
-        assert_function_in_collapsed(f"standard-library-{python_version}", process_collapsed)
+        assert_function_in_collapsed(f"standard-library=={python_version}", process_collapsed)
 
 
 @pytest.mark.parametrize("runtime", ["php"])
@@ -116,10 +116,10 @@ def test_python_ebpf(
         assert_function_in_collapsed(
             "_PyEval_EvalFrameDefault_[pn]", process_collapsed, True
         )  # ensure native user stacks exist
-        assert_function_in_collapsed("PyYAML-6.0", process_collapsed)  # ensure package info is presented
+        assert_function_in_collapsed("PyYAML==6.0", process_collapsed)  # ensure package info is presented
         # ensure Python version is presented
         assert python_version is not None, "Failed to find python version"
-        assert_function_in_collapsed(f"standard-library-{python_version}", process_collapsed)
+        assert_function_in_collapsed(f"standard-library=={python_version}", process_collapsed)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Surround module info in stacks with `[]` instead of `()` and separate the package name from the package version with `==` instead of `-`.

For example, this symbol:
`scapy.utils.PcapReader.read_packet (/usr/lib/python3.6/site-packages/scapy/utils.py:1347 (scapy-2.4.5))_[p]`
Will be now presented like this:
`scapy.utils.PcapReader.read_packet (/usr/lib/python3.6/site-packages/scapy/utils.py:1347 [scapy==2.4.5])_[p]`


## Motivation and Context
* Regular parenthesis are already used to separate the metadata section of the symbol, so using another kind of parenthesis for the package info is more noticeable and easier to read.
* The character `"-"` can be part of a package name or version, so it's better to use characters that can't appear in either of them.

## How Has This Been Tested?


## Screenshots
<!--- (if appropriate) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [x] I have added tests for new logic.
