### PR TITLE
Bugfix/mypy set linux platform

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,4 +2,4 @@
 line_length = 120
 multi_line_output = 3
 include_trailing_comma = true
-skip = granulate-utils
+skip = granulate-utils,venv

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,6 +2,7 @@
 python_version = 3.6
 warn_unused_configs = True
 exclude = venv/bin/|deploy/dataflow/|granulate-utils
+platform = linux
 
 [mypy-psutil.*]
 ignore_missing_imports = True


### PR DESCRIPTION
## Description
Set MyPy platform to Linux (so when committing and running the git precommit hook on mac it won't fail). Also added `venv` dir to `isort` skip list.
