### PR TITLE
python: pyperf: Bump bpf_get_stack_offset version to v0.0.3

### DIFF
--- a/scripts/bcc_helpers_build.sh
+++ b/scripts/bcc_helpers_build.sh
@@ -24,6 +24,6 @@ cd / && git clone -b v0.0.2 --depth=1 --recurse-submodules https://github.com/Jo
 cd /bpf_get_fs_offset && git reset --hard 8326d39cf44845d4b643ed4267994afca8ccecb3
 cd /bpf_get_fs_offset && make $LIBBPF_MAKE_FLAGS
 
-cd / && git clone -b v0.0.2 --depth=1 --recurse-submodules https://github.com/Jongy/bpf_get_stack_offset.git
-cd /bpf_get_stack_offset && git reset --hard bd0d4d9a0c4351710d116016e321045496a9eedc
+cd / && git clone -b v0.0.3 --depth=1 --recurse-submodules https://github.com/Jongy/bpf_get_stack_offset.git
+cd /bpf_get_stack_offset && git reset --hard 54b70ee65708cc8d3d7817277e82376d95205356
 cd /bpf_get_stack_offset && make $LIBBPF_MAKE_FLAGS


### PR DESCRIPTION
## Description
v0.0.3 avoids BPF accesses to non-canonical addresses, which may trigger a `WARN_ONCE` that we prefer to avoid :)

See the fix in https://github.com/Jongy/bpf_get_stack_offset/commit/54b70ee65708cc8d3d7817277e82376d95205356.

## Motivation and Context
Avoid triggering kernel warnings during gProfiler's run.

## How Has This Been Tested?
CI.

I have tested the fixed `get_stack_offset` program on a 5.4 kernel which triggers the `WARN_ONCE` on v0.0.2; and v0.0.3 no longer triggers it.

I have also tested v0.0.3 on 4.15.0-72-generic, which is old enough to have the limit of 4096 instructions. The program still runs (that is, the instructions I added in the loop do not cause us to exceed the limit.

## Checklist:
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
