### PR TITLE
java: Disable profiling (safemode) on proc_events signals

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -63,6 +63,7 @@ class JavaSafemodeOptions(str, Enum):
     PROFILED_OOM = "profiled-oom"
     # a profiled process was signaled:
     # * fatally signaled and we saw it in the kernel log
+    # * we saw an exit code of signal in a proc_events event.
     PROFILED_SIGNALED = "profiled-signaled"
     # hs_err file was written for a profiled process
     HSERR = "hserr"
@@ -826,6 +827,13 @@ class JavaProfiler(ProcessProfilerBase):
 
             logger.warning("async-profiled Java process exited with signal", pid=tid, signal=signo)
 
+            # SIGABRT is what JVMs (at least HotSpot) exit with upon a VM error (e.g after writing the hs_err file).
+            # SIGKILL is the result of OOM.
+            # Other signals (such as SIGTERM which is common) are ignored until proven relevant
+            # to hard errors such as crashes. (SIGTERM, for example, is used as containers' stop signal)
+            if signo == signal.SIGABRT.value or signo == signal.SIGKILL.value:
+                self._disable_profiling(JavaSafemodeOptions.PROFILED_SIGNALED)
+
     def _handle_kernel_messages(self, messages):
         for message in messages:
             _, _, text = message
@@ -837,7 +845,7 @@ class JavaProfiler(ProcessProfilerBase):
 
             signal_entry = get_signal_entry(text)
             if signal_entry is not None and signal_entry.pid in self._profiled_pids:
-                logger.warning("Profiled Java process signaled", signal=json.dumps(signal_entry._asdict()))
+                logger.warning("Profiled Java process fatally signaled", signal=json.dumps(signal_entry._asdict()))
                 self._disable_profiling(JavaSafemodeOptions.PROFILED_SIGNALED)
                 continue
 

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -829,9 +829,11 @@ class JavaProfiler(ProcessProfilerBase):
 
             # SIGABRT is what JVMs (at least HotSpot) exit with upon a VM error (e.g after writing the hs_err file).
             # SIGKILL is the result of OOM.
+            # SIGSEGV is added because in some extreme cases, the signal handler (which usually ends up with SIGABRT)
+            # causes another SIGSEGV (possibly in some loop), and eventually Java really dies with SIGSEGV.
             # Other signals (such as SIGTERM which is common) are ignored until proven relevant
             # to hard errors such as crashes. (SIGTERM, for example, is used as containers' stop signal)
-            if signo == signal.SIGABRT.value or signo == signal.SIGKILL.value:
+            if signo in (signal.SIGABRT.value, signal.SIGKILL.value, signal.SIGSEGV.value):
                 self._disable_profiling(JavaSafemodeOptions.PROFILED_SIGNALED)
 
     def _handle_kernel_messages(self, messages):


### PR DESCRIPTION
Based on https://github.com/Granulate/gprofiler/pull/248

## Description
Use detected "signaled profiled processes" from proc_events to disable profiling when the safemode option is on.

## Motivation and Context
Improve our safemode; specifically, this helps in the cases where the hs_err file is not available / will not be available (e.g because the target process runs in a container that'll exit once the process exits; so we won't see the file as the container went down).

## How Has This Been Tested?
* [x] Send SIGSEGV to a Java process running as PID 1 of a container (so the container exits immediately and we don't see the hs_err file) - profiling should be disabled based on the proc_events detection
* [x] Same ^^ with SIGKILL

## Checklist:
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
