### PR TITLE
python: Upgrade PyPerf & run the CI on Python 3.10

### DIFF
--- a/.github/workflows/build-container-and-test.yml
+++ b/.github/workflows/build-container-and-test.yml
@@ -6,7 +6,7 @@ jobs:
   lint:
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.1]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0]
 
     runs-on: ubuntu-latest
 
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false  # helps detecting flakiness / errors specific to one Python version
       matrix:
-        python-version: [3.6, 3.7, 3.8.8, 3.9.2, 3.10.1]
+        python-version: [3.6, 3.7, 3.8.8, 3.9.2, 3.10.0]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build-container-and-test.yml
+++ b/.github/workflows/build-container-and-test.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false  # helps detecting flakiness / errors specific to one Python version
       matrix:
-        python-version: [3.6, 3.7, 3.8.8, 3.9.2]
+        python-version: [3.6, 3.7, 3.8.8, 3.9.2, 3.10.1]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build-container-and-test.yml
+++ b/.github/workflows/build-container-and-test.yml
@@ -6,7 +6,7 @@ jobs:
   lint:
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.1]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build-container-and-test.yml
+++ b/.github/workflows/build-container-and-test.yml
@@ -6,7 +6,7 @@ jobs:
   lint:
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
 
     runs-on: ubuntu-latest
 

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -5,7 +5,7 @@
 #
 set -e
 
-git clone --depth 1 -b v1.2.0 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 3fd97d89efb79553a20e16653c2538b14674f6c6
+git clone --depth 1 -b v1.2.1 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 3f1d60180946852aa89e3644b786e4bf8934e7a9
 
 # (after clone, because we copy the licenses)
 # TODO support aarch64


### PR DESCRIPTION
## Description
* Support Python 3.10 offsets - so PyPerf can profile Python 3.10 apps :)
* Fix native stacks that were broken for certain kernel versions since PyPerf v1.2.0;
  should now work for all versions.
* Enable CI on Python 3.10

## Motivation and Context
Support PyPerf with Python 3.10, and fix native stacks so it works everywhere :)

## How Has This Been Tested?
PyPerf was tested on kernel versions such as `4.15.0-72-generic` that have previously failed to get native stacks. Now they succeed. Also see more in https://github.com/Granulate/bcc/pull/32.

And also, was tested by CI.