### PR TITLE
java: Add JDK 17 to supported versions

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -454,6 +454,7 @@ class JavaProfiler(ProcessProfilerBase):
         14: (Version("14"), 33),
         15: (Version("15.0.1"), 9),
         16: (Version("16"), 36),
+        17: (Version("17.0.1"), 12),
     }
 
     _new_perf_event_mlock_kb = 8192


### PR DESCRIPTION
## Description
The minimum version I've set is the one I have tested on.

```
bash-4.4# java -version
openjdk version "17.0.1" 2021-10-19
OpenJDK Runtime Environment (build 17.0.1+12-39)
OpenJDK 64-Bit Server VM (build 17.0.1+12-39, mixed mode, sharing)
bash-4.4# java Target
```

from (`openjdk:17`).

## Motivation and Context
Support new JDK versions.

## How Has This Been Tested?
Tested profiling a demo app in `openjdk:17` container.