### PR TITLE
app ids: Keep original frame

### DIFF
--- a/gprofiler/merge.py
+++ b/gprofiler/merge.py
@@ -251,7 +251,13 @@ def concatenate_profiles(
         prefix = (container_name + ";") if add_container_names else ""
         for stack, count in stacks.items():
             if identify_applications and application_name is not None:
-                stack = f'{application_name};{stack.split(";", maxsplit=1)[1]}'
+                application_name = f"appid: {application_name}"
+                # insert the app name between the first frame and all others
+                try:
+                    first_frame, others = stack.split(";", maxsplit=1)
+                    stack = f"{first_frame};{application_name};{others}"
+                except ValueError:
+                    stack = f"{stack};{application_name}"
 
             total_samples += count
             lines.append(f"{prefix}{stack} {count}")

--- a/gprofiler/metadata/application_identifiers.py
+++ b/gprofiler/metadata/application_identifiers.py
@@ -214,7 +214,11 @@ class _JavaJarApplicationIdentifier(_ApplicationIdentifier):
         if not any("libjvm.so" in m.path for m in process.memory_maps()):
             return None
 
-        return f"java: {_append_file_to_proc_wd(process, _get_cli_arg_by_name(process.cmdline(), '-jar'))}"
+        jar_arg = _get_cli_arg_by_name(process.cmdline(), "-jar")
+        if _NON_AVAILABLE_ARG is None:
+            return None
+
+        return f"java: {_append_file_to_proc_wd(process, jar_arg)}"
 
 
 # Please note that the order matter, because the FIRST matching identifier will be used.


### PR DESCRIPTION
## Description
1. Don't insert Java app id if no `-jar` arg is present (bugfix)
2. Keep the original first frame - insert the app id frame second.
