### PR TITLE
java: Show a "profiling skipped" stack when profiling is skipped for a process

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -631,7 +631,7 @@ class JavaProfiler(ProcessProfilerBase):
 
         return True
 
-    def _is_profiling_supported(self, process: Process) -> bool:
+    def _is_jvm_profiling_supported(self, process: Process) -> bool:
         process_basename = os.path.basename(process.exe())
         if JavaSafemodeOptions.JAVA_EXTENDED_VERSION_CHECKS in self._java_safemode:
             # TODO we can get the "java" binary by extracting the java home from the libjvm path,
@@ -688,8 +688,8 @@ class JavaProfiler(ProcessProfilerBase):
         if self._safemode_disable_reason is not None:
             return self._profiling_error_stack(f"disabled due to {self._safemode_disable_reason}")
 
-        if not self._is_profiling_supported(process):
-            return None
+        if not self._is_jvm_profiling_supported(process):
+            return self._profiling_error_stack("profiling this JVM is not supported")
 
         if self._check_async_profiler_loaded(process):
             return None

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -692,7 +692,7 @@ class JavaProfiler(ProcessProfilerBase):
             return self._profiling_error_stack("profiling this JVM is not supported")
 
         if self._check_async_profiler_loaded(process):
-            return None
+            return self._profiling_error_stack("async-profiler is already loaded")
 
         # track profiled PIDs only if proc_events are in use, otherwise there is no use in them.
         # TODO: it is possible to run in contexts where we're unable to use proc_events but are able to listen

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -31,7 +31,7 @@ from packaging.version import Version
 from psutil import Process
 
 from gprofiler.exceptions import CalledProcessError
-from gprofiler.gprofiler_types import StackToSampleCount
+from gprofiler.gprofiler_types import ProcessToStackSampleCounters, StackToSampleCount
 from gprofiler.kernel_messages import get_kernel_messages_provider
 from gprofiler.log import get_logger_adapter
 from gprofiler.merge import parse_one_collapsed
@@ -856,7 +856,7 @@ class JavaProfiler(ProcessProfilerBase):
         else:
             self._handle_kernel_messages(messages)
 
-    def snapshot(self):
+    def snapshot(self) -> ProcessToStackSampleCounters:
         try:
             return super().snapshot()
         finally:

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -12,7 +12,7 @@ import pytest
 from packaging.version import Version
 
 from gprofiler.profilers.java import JAVA_SAFEMODE_ALL, AsyncProfiledProcess, JavaProfiler, parse_jvm_version
-from tests.utils import assert_function_in_collapsed
+from tests.utils import assert_function_in_collapsed, snapshot_one_collaped
 
 
 # adds the "status" command to AsyncProfiledProcess from gProfiler.
@@ -62,9 +62,7 @@ def test_async_profiler_already_running(application_pid, assert_collapsed, tmp_p
             assert "Profiling is running for " in ap_proc.read_output()
 
         # then start again
-        result = profiler.snapshot()
-        assert len(result) == 1
-        collapsed = result[next(iter(result.keys()))]
+        collapsed = snapshot_one_collaped(profiler)
         assert "Found async-profiler already started" in caplog.text
         assert "Finished profiling process" in caplog.text
         assert_collapsed(collapsed)
@@ -91,11 +89,9 @@ def test_java_async_profiler_cpu_mode(
         java_safemode="",
         java_mode="ap",
     ) as profiler:
-        result = profiler.snapshot()
-        assert len(result) == 1
-        process_collapsed = result[next(iter(result.keys()))]
-        assert_collapsed(process_collapsed, check_comm=True)
-        assert_function_in_collapsed("do_syscall_64_[k]", process_collapsed, True)  # ensure kernels stacks exist
+        collapsed = snapshot_one_collaped(profiler)
+        assert_collapsed(collapsed, check_comm=True)
+        assert_function_in_collapsed("do_syscall_64_[k]", collapsed, True)  # ensure kernels stacks exist
 
 
 @pytest.mark.parametrize("in_container", [True])
@@ -121,11 +117,9 @@ def test_java_async_profiler_musl_and_cpu(
         java_safemode="",
         java_mode="ap",
     ) as profiler:
-        result = profiler.snapshot()
-        assert len(result) == 1
-        process_collapsed = result[next(iter(result.keys()))]
-        assert_collapsed(process_collapsed, check_comm=True)
-        assert_function_in_collapsed("do_syscall_64_[k]", process_collapsed, True)  # ensure kernels stacks exist
+        collapsed = snapshot_one_collaped(profiler)
+        assert_collapsed(collapsed, check_comm=True)
+        assert_function_in_collapsed("do_syscall_64_[k]", collapsed, True)  # ensure kernels stacks exist
 
 
 def test_java_safemode_parameters(tmp_path) -> None:
@@ -179,10 +173,8 @@ def test_java_safemode_version_check(
     ) as profiler:
         process = profiler._select_processes_to_profile()[0]
         jvm_version = parse_jvm_version(profiler._get_java_version(process))
-        result = profiler.snapshot()
-        assert len(result) == 1
-        process_collapsed = result[next(iter(result.keys()))]
-        assert process_collapsed == Counter({"java;[Profiling skipped: profiling this JVM is not supported]": 1})
+        collapsed = snapshot_one_collaped(profiler)
+        assert collapsed == Counter({"java;[Profiling skipped: profiling this JVM is not supported]": 1})
 
     assert next(filter(lambda r: r.message == "Unsupported JVM version", caplog.records)).gprofiler_adapter_extra[
         "jvm_version"
@@ -264,10 +256,8 @@ def test_disable_java_profiling(application_pid, tmp_path, monkeypatch, caplog):
     dummy_reason = "dummy reason"
     monkeypatch.setattr(profiler, "_safemode_disable_reason", dummy_reason)
     with profiler:
-        result = profiler.snapshot()
-        assert len(result) == 1
-        process_collapsed = result[next(iter(result.keys()))]
-        assert process_collapsed == Counter({f"java;[Profiling skipped: disabled due to {dummy_reason}]": 1})
+        collapsed = snapshot_one_collaped(profiler)
+        assert collapsed == Counter({f"java;[Profiling skipped: disabled due to {dummy_reason}]": 1})
 
     assert "Java profiling has been disabled, skipping profiling of all java process" in caplog.text
 
@@ -303,8 +293,6 @@ def test_already_loaded_async_profiler_profiling_failure(tmp_path, monkeypatch, 
     ) as profiler:
         process = profiler._select_processes_to_profile()[0]
         assert any("/tmp/fake_gprofiler_tmp" in mmap.path for mmap in process.memory_maps())
-        result = profiler.snapshot()
-        assert len(result) == 1
-        process_collapsed = result[next(iter(result.keys()))]
-        assert process_collapsed == Counter({"java;[Profiling skipped: async-profiler is already loaded]": 1})
+        collapsed = snapshot_one_collaped(profiler)
+        assert collapsed == Counter({"java;[Profiling skipped: async-profiler is already loaded]": 1})
         assert "Non-gProfiler async-profiler is already loaded to the target process" in caplog.text

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -4,6 +4,7 @@
 #
 import logging
 import signal
+from collections import Counter
 from pathlib import Path
 from threading import Event
 
@@ -178,7 +179,10 @@ def test_java_safemode_version_check(
     ) as profiler:
         process = profiler._select_processes_to_profile()[0]
         jvm_version = parse_jvm_version(profiler._get_java_version(process))
-        profiler.snapshot()
+        result = profiler.snapshot()
+        assert len(result) == 1
+        process_collapsed = result[next(iter(result.keys()))]
+        assert process_collapsed == Counter({"java;[Profiling skipped: profiling this JVM is not supported]": 1})
 
     assert next(filter(lambda r: r.message == "Unsupported JVM version", caplog.records)).gprofiler_adapter_extra[
         "jvm_version"
@@ -250,21 +254,25 @@ def test_hotspot_error_file(application_pid, tmp_path, monkeypatch, caplog):
     assert "libpthread.so" in caplog.text
     assert "memory_usage_in_bytes:" in caplog.text
     assert "Java profiling has been disabled, will avoid profiling any new java process" in caplog.text
-    assert not profiler._should_profile
+    assert profiler._safemode_disable_reason is not None
 
 
 def test_disable_java_profiling(application_pid, tmp_path, monkeypatch, caplog):
     caplog.set_level(logging.DEBUG)
 
     profiler = JavaProfiler(1, 5, Event(), str(tmp_path), False, False, "cpu", 0, False, "ap")
-    monkeypatch.setattr(profiler, "_should_profile", False)
+    dummy_reason = "dummy reason"
+    monkeypatch.setattr(profiler, "_safemode_disable_reason", dummy_reason)
     with profiler:
-        assert len(profiler.snapshot()) == 0
+        result = profiler.snapshot()
+        assert len(result) == 1
+        process_collapsed = result[next(iter(result.keys()))]
+        assert process_collapsed == Counter({f"java;[Profiling skipped: disabled due to {dummy_reason}]": 1})
 
     assert "Java profiling has been disabled, skipping profiling of all java process" in caplog.text
 
 
-def test_already_loaded_ap_profiling_failure(tmp_path, monkeypatch, caplog, application_pid) -> None:
+def test_already_loaded_async_profiler_profiling_failure(tmp_path, monkeypatch, caplog, application_pid) -> None:
     with monkeypatch.context() as m:
         m.setattr("gprofiler.profilers.java.TEMPORARY_STORAGE_PATH", "/tmp/fake_gprofiler_tmp")
         with JavaProfiler(
@@ -295,5 +303,8 @@ def test_already_loaded_ap_profiling_failure(tmp_path, monkeypatch, caplog, appl
     ) as profiler:
         process = profiler._select_processes_to_profile()[0]
         assert any("/tmp/fake_gprofiler_tmp" in mmap.path for mmap in process.memory_maps())
-        profiler.snapshot()
+        result = profiler.snapshot()
+        assert len(result) == 1
+        process_collapsed = result[next(iter(result.keys()))]
+        assert process_collapsed == Counter({"java;[Profiling skipped: async-profiler is already loaded]": 1})
         assert "Non-gProfiler async-profiler is already loaded to the target process" in caplog.text

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -199,7 +199,8 @@ def test_java_safemode_build_number_check(
         process = profiler._select_processes_to_profile()[0]
         jvm_version = parse_jvm_version(profiler._get_java_version(process))
         monkeypatch.setitem(JavaProfiler.MINIMAL_SUPPORTED_VERSIONS, 8, (jvm_version.version, 999))
-        profiler.snapshot()
+        collapsed = snapshot_one_collaped(profiler)
+        assert collapsed == Counter({"java;[Profiling skipped: profiling this JVM is not supported]": 1})
 
     assert next(filter(lambda r: r.message == "Unsupported JVM version", caplog.records)).gprofiler_adapter_extra[
         "jvm_version"

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -17,7 +17,12 @@ from gprofiler.profilers.php import PHPSpyProfiler
 from gprofiler.profilers.python import PySpyProfiler, PythonEbpfProfiler
 from gprofiler.profilers.ruby import RbSpyProfiler
 from tests import PHPSPY_DURATION
-from tests.utils import RUNTIME_PROFILERS, assert_function_in_collapsed, run_gprofiler_in_container
+from tests.utils import (
+    RUNTIME_PROFILERS,
+    assert_function_in_collapsed,
+    run_gprofiler_in_container,
+    snapshot_one_collaped,
+)
 
 
 @pytest.mark.parametrize("runtime", ["java"])
@@ -40,9 +45,7 @@ def test_java_from_host(
         java_mode="ap",
     ) as profiler:
         _ = assert_application_name  # Required for mypy unused argument warning
-        result = profiler.snapshot()
-        assert len(result) == 1
-        process_collapsed = result[next(iter(result.keys()))]
+        process_collapsed = snapshot_one_collaped(profiler)
         assert_collapsed(process_collapsed, check_comm=True)
 
 
@@ -56,7 +59,7 @@ def test_pyspy(
 ) -> None:
     _ = assert_application_name  # Required for mypy unused argument warning
     with PySpyProfiler(1000, 3, Event(), str(tmp_path), add_versions=True) as profiler:
-        process_collapsed = profiler.snapshot().get(application_pid)
+        process_collapsed = snapshot_one_collaped(profiler)
         assert_collapsed(process_collapsed, check_comm=True)
         assert_function_in_collapsed("PyYAML==6.0", process_collapsed)  # Ensure package info is presented
         # Ensure Python version is presented
@@ -85,7 +88,7 @@ def test_rbspy(
     gprofiler_docker_image: Image,
 ) -> None:
     with RbSpyProfiler(1000, 3, Event(), str(tmp_path), "rbspy") as profiler:
-        process_collapsed = profiler.snapshot().get(application_pid)
+        process_collapsed = snapshot_one_collaped(profiler)
         assert_collapsed(process_collapsed, check_comm=True)
 
 

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -59,7 +59,8 @@ def test_pyspy(
 ) -> None:
     _ = assert_application_name  # Required for mypy unused argument warning
     with PySpyProfiler(1000, 3, Event(), str(tmp_path), add_versions=True) as profiler:
-        process_collapsed = snapshot_one_collaped(profiler)
+        # not using snapshot_one_collaped because there are multiple Python processes running usually.
+        process_collapsed = profiler.snapshot().get(application_pid)
         assert_collapsed(process_collapsed, check_comm=True)
         assert_function_in_collapsed("PyYAML==6.0", process_collapsed)  # Ensure package info is presented
         # Ensure Python version is presented

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -106,4 +106,4 @@ def assert_function_in_collapsed(function_name: str, collapsed: Mapping[str, int
 def snapshot_one_collaped(profiler: ProfilerInterface) -> StackToSampleCount:
     result = profiler.snapshot()
     assert len(result) == 1
-    return result[next(iter(result.keys()))]
+    return next(iter(result.values()))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,6 +7,9 @@ from docker import DockerClient
 from docker.models.containers import Container
 from docker.models.images import Image
 
+from gprofiler.gprofiler_types import StackToSampleCount
+from gprofiler.profilers.profiler_base import ProfilerInterface
+
 RUNTIME_PROFILERS = [
     ("java", "ap"),
     ("python", "py-spy"),
@@ -98,3 +101,9 @@ def assert_function_in_collapsed(function_name: str, collapsed: Mapping[str, int
     assert any(
         (function_name in record) for record in collapsed.keys()
     ), f"function {function_name!r} missing in collapsed data!"
+
+
+def snapshot_one_collaped(profiler: ProfilerInterface) -> StackToSampleCount:
+    result = profiler.snapshot()
+    assert len(result) == 1
+    return result[next(iter(result.keys()))]


### PR DESCRIPTION
## Description
When profiling of a process is skipped by gProfiler for whatever reason, the following happens:
* In perf-less mode (`--perf-mode=none`) - we won't see its stacks and we won't know it existed.
* In standard mode, gProfiler will use the samples collected by `perf` (if any) when merging the stacks. So we'll see the native Java code, which is seldom interesting.

This PR amends the Java profiler to return a specialized stack per "skip" case (safemode, AP already loaded in a process, ...). This way, the user sees the cause of the error immediately, and doesn't have to skim through the logs in order to understand. Also, it makes the skip explicit ("gProfiler found this process and decided to skip", instead of "maybe gProfiler missed it..."). Explicitness is good.

## Motivation and Context
Make it easier to understand when & why gProfiler decides to skip Java profiling.

## How Has This Been Tested?
* [x] Profiling a process with AP loaded (from a different path) - results in `java;[Profiling skipped: async-profiler is already loaded]`.
* [x] Profiling a process with unsupported JVM version / type - results in `java;[Profiling skipped: profiling this JVM is not supported]`.
* [x] Profiling a process after safemode has disabled profiling completely - results in the profiling skipped stack, with the safemode reason in it. For example: `java;[Profiling skipped: disabled due to hserr]`

Automatic tests for all the above ^^