### PR TITLE
java: Upgrade async-profiler to v2.6g1

### DIFF
--- a/scripts/async_profiler_build_shared.sh
+++ b/scripts/async_profiler_build_shared.sh
@@ -5,8 +5,8 @@
 #
 set -euo pipefail
 
-VERSION=v2.5g3
-GIT_REV="b835b2591c968c1170056b18a12fd03918a4360f"
+VERSION=v2.6g1
+GIT_REV="717d501ddb9da3b8a2cf30e800bc84cf110da150"
 
 git clone --depth 1 -b "$VERSION" https://github.com/Granulate/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
 source "$1"


### PR DESCRIPTION
## Description
Upgrade async-profiler to v2.6g1. This brings many fixes & stability improvements.

Additionally, since we're now based on https://github.com/jvm-profiling-tools/async-profiler/commit/9087bc57d80f622b8f4e0eabcf06dbf9cb54e815, we don't need the `mlock` games anymore, so I have removed them.

## How Has This Been Tested?
* CI
* [x] Tested CPU mode on my machine (without the `mlock`). It has passed in the CI before we added the `mlock`, but failed on my machine. Now it passes on my machine without the `mlock`.
