### PR TITLE
java: Use AP timeouts & read output file upon process exit

### DIFF
--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -17,6 +17,7 @@ from typing import Iterable, Optional
 
 import configargparse
 from granulate_utils.linux.ns import is_running_in_init_pid
+from granulate_utils.linux.process import is_process_running
 from psutil import NoSuchProcess, Process
 from requests import RequestException, Timeout
 
@@ -42,7 +43,6 @@ from gprofiler.utils import (
     atomically_symlink,
     get_iso8601_format_time,
     grab_gprofiler_mutex,
-    is_process_running,
     is_root,
     reset_umask,
     resource_path,

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -86,6 +86,8 @@ JAVA_SAFEMODE_DEFAULT_OPTIONS = [
     JavaSafemodeOptions.HSERR.value,
 ]
 
+JAVA_ASYNC_PROFILER_DEFAULT_SAFEMODE = 0  # all off
+
 
 class JattachException(CalledProcessError):
     def __init__(self, returncode, cmd, stdout, stderr, target_pid: int, ap_log: str):
@@ -461,7 +463,7 @@ def parse_jvm_version(version_string: str) -> JvmVersion:
             "--java-async-profiler-safemode",
             dest="java_async_profiler_safemode",
             type=int,
-            default=0,
+            default=JAVA_ASYNC_PROFILER_DEFAULT_SAFEMODE,
             choices=range(0, 128),
             metavar="[0-127]",
             help="Controls the 'safemode' parameter passed to async-profiler. This is parameter denotes multiple"

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -302,11 +302,11 @@ class AsyncProfiledProcess:
         return f",{self._ap_args}" if self._ap_args else ""
 
     def _get_ap_output_args(self) -> str:
-        return f"file={self._output_path_process},{self.OUTPUT_FORMAT},{self.FORMAT_PARAMS}"
+        return f",file={self._output_path_process},{self.OUTPUT_FORMAT},{self.FORMAT_PARAMS}"
 
     def _get_start_cmd(self, interval: int, ap_timeout: int) -> List[str]:
         return self._get_base_cmd() + [
-            f"start,event={self._mode},"
+            f"start,event={self._mode}"
             f"{self._get_ap_output_args()},interval={interval},"
             f"log={self._log_path_process}{',buildids' if self._buildids else ''}"
             f"{',fdtransfer' if self._mode == 'cpu' else ''}"

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -29,6 +29,7 @@ from granulate_utils.java import (
 from granulate_utils.linux import ns, proc_events
 from granulate_utils.linux.ns import get_proc_root_path, resolve_proc_root_links, run_in_ns
 from granulate_utils.linux.oom import get_oom_entry
+from granulate_utils.linux.process import is_process_running
 from granulate_utils.linux.signals import get_signal_entry
 from packaging.version import Version
 from psutil import Process
@@ -42,7 +43,6 @@ from gprofiler.profilers.profiler_base import ProcessProfilerBase
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
 from gprofiler.utils import (
     TEMPORARY_STORAGE_PATH,
-    is_process_running,
     pgrep_maps,
     process_comm,
     remove_path,

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -584,11 +584,6 @@ class JavaProfiler(ProcessProfilerBase):
                 f" --java-safemode={JavaSafemodeOptions.JAVA_EXTENDED_VERSION_CHECKS}"
             )
 
-        if java_safemode == JAVA_SAFEMODE_ALL:
-            assert (
-                self._ap_safemode == 127
-            ), f"async-profiler safemode must be set to 127 in --java-safemode={JAVA_SAFEMODE_ALL} (or --java-safemode)"
-
     def _disable_profiling(self, cause: str):
         if self._safemode_disable_reason is None and cause in self._java_safemode:
             logger.warning("Java profiling has been disabled, will avoid profiling any new java processes", cause=cause)

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -306,7 +306,7 @@ class AsyncProfiledProcess:
 
     def _get_start_cmd(self, interval: int, ap_timeout: int) -> List[str]:
         return self._get_base_cmd() + [
-            f"start,event={self._mode},file={self._output_path_process},"
+            f"start,event={self._mode},"
             f"{self._get_ap_output_args()},interval={interval},"
             f"log={self._log_path_process}{',buildids' if self._buildids else ''}"
             f"{',fdtransfer' if self._mode == 'cpu' else ''}"

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -13,6 +13,7 @@ from subprocess import Popen
 from threading import Event
 from typing import Dict, List, Optional
 
+from granulate_utils.linux.process import is_process_running
 from psutil import NoSuchProcess, Process
 
 from gprofiler.exceptions import (
@@ -29,7 +30,6 @@ from gprofiler.metadata.system_metadata import get_arch
 from gprofiler.profilers.profiler_base import ProcessProfilerBase, ProfilerBase, ProfilerInterface
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
 from gprofiler.utils import (
-    is_process_running,
     pgrep_maps,
     poll_process,
     process_comm,

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -486,10 +486,6 @@ def get_staticx_dir() -> Optional[str]:
     return os.getenv("STATICX_BUNDLE_DIR")
 
 
-def is_process_running(process: psutil.Process):
-    return process.is_running() and not process.status() == "zombie"
-
-
 def get_kernel_release() -> Tuple[int, int]:
     """Return Linux kernel version as (major, minor) tuple."""
     major_str, minor_str = os.uname().release.split(".", maxsplit=2)[:2]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -284,7 +284,7 @@ def runtime_specific_args(runtime: str) -> List[str]:
 
 
 @fixture
-def assert_collapsed(runtime: str) -> Callable[[Mapping[str, int], bool], None]:
+def assert_collapsed(runtime: str) -> Callable[[Mapping[str, int]], None]:
     function_name = {
         "java": "Fibonacci.main",
         "python": "burner",

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -15,7 +15,7 @@ import pytest
 from packaging.version import Version
 
 from gprofiler.profilers.java import AsyncProfiledProcess, JavaProfiler, frequency_to_ap_interval, parse_jvm_version
-from tests.utils import assert_function_in_collapsed, snapshot_one_collaped, make_java_profiler
+from tests.utils import assert_function_in_collapsed, make_java_profiler, snapshot_one_collaped
 
 
 # adds the "status" command to AsyncProfiledProcess from gProfiler.
@@ -78,7 +78,7 @@ def test_java_async_profiler_cpu_mode(
     Run Java in a container and enable async-profiler in CPU mode, make sure we get kernel stacks.
     """
     with make_java_profiler(str(tmp_path), frequency=999) as profiler:
-        collapsed = snapshot_one_collaped(profiler)
+        process_collapsed = snapshot_one_collaped(profiler)
         assert_collapsed(process_collapsed, check_comm=True)
         assert_function_in_collapsed("do_syscall_64_[k]", process_collapsed, True)  # ensure kernels stacks exist
 
@@ -95,7 +95,7 @@ def test_java_async_profiler_musl_and_cpu(
     works and that we get kernel stacks.
     """
     with make_java_profiler(str(tmp_path), frequency=999) as profiler:
-        collapsed = snapshot_one_collaped(profiler)
+        process_collapsed = snapshot_one_collaped(profiler)
         assert_collapsed(process_collapsed, check_comm=True)
         assert_function_in_collapsed("do_syscall_64_[k]", process_collapsed, True)  # ensure kernels stacks exist
 

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -228,10 +228,7 @@ def test_async_profiler_output_written_upon_jvm_exit(tmp_path, application_pid, 
 
 # test only once
 @pytest.mark.parametrize("in_container", [False])
-def test_async_profiler_timeout_stop(tmp_path, application_pid, assert_collapsed, caplog) -> None:
-    """
-    Make sure that async-profiler stops after the given output.
-    """
+def test_async_profiler_stops_after_given_timeout(tmp_path, application_pid, assert_collapsed, caplog) -> None:
     caplog.set_level(logging.DEBUG)
 
     process = psutil.Process(application_pid)

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -43,7 +43,7 @@ def test_async_profiler_already_running(application_pid, assert_collapsed, tmp_p
             process=process,
             storage_dir=profiler._storage_dir,
             stop_event=profiler._stop_event,
-            buildis=False,
+            buildids=False,
             mode=profiler._mode,
             ap_safemode=0,
             ap_args="",

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -163,7 +163,7 @@ def test_hotspot_error_file(application_pid, tmp_path, monkeypatch, caplog):
 
     monkeypatch.setattr(AsyncProfiledProcess, "start_async_profiler", sap_and_crash)
 
-    profiler = make_java_profiler(storage_dir=str(tmp_path))
+    profiler = make_java_profiler(storage_dir=str(tmp_path), duration=5)
     with profiler:
         profiler.snapshot()
 

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -105,10 +105,6 @@ def test_java_async_profiler_musl_and_cpu(
 
 def test_java_safemode_parameters(tmp_path) -> None:
     with pytest.raises(AssertionError) as excinfo:
-        make_java_profiler(storage_dir=str(tmp_path), java_async_profiler_safemode=0)
-    assert "async-profiler safemode must be set to 127 in --java-safemode" in str(excinfo.value)
-
-    with pytest.raises(AssertionError) as excinfo:
         make_java_profiler(storage_dir=str(tmp_path), java_version_check=False)
     assert "Java version checks are mandatory in --java-safemode" in str(excinfo.value)
 

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -159,7 +159,8 @@ def test_hotspot_error_file(application_pid, tmp_path, monkeypatch, caplog):
 
     monkeypatch.setattr(AsyncProfiledProcess, "start_async_profiler", sap_and_crash)
 
-    profiler = make_java_profiler(storage_dir=str(tmp_path), duration=5)
+    # increased duration - give the JVM some time to write the hs_err file.
+    profiler = make_java_profiler(storage_dir=str(tmp_path), duration=10)
     with profiler:
         profiler.snapshot()
 

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -82,8 +82,8 @@ def test_java_async_profiler_cpu_mode(
     """
     with make_java_profiler(storage_dir=str(tmp_path), frequency=999) as profiler:
         process_collapsed = snapshot_one_collaped(profiler)
-        assert_collapsed(process_collapsed, check_comm=True)
-        assert_function_in_collapsed("do_syscall_64_[k]", process_collapsed, True)  # ensure kernels stacks exist
+        assert_collapsed(process_collapsed)
+        assert_function_in_collapsed("do_syscall_64_[k]", process_collapsed)  # ensure kernels stacks exist
 
 
 @pytest.mark.parametrize("in_container", [True])
@@ -99,8 +99,8 @@ def test_java_async_profiler_musl_and_cpu(
     """
     with make_java_profiler(storage_dir=str(tmp_path), frequency=999) as profiler:
         process_collapsed = snapshot_one_collaped(profiler)
-        assert_collapsed(process_collapsed, check_comm=True)
-        assert_function_in_collapsed("do_syscall_64_[k]", process_collapsed, True)  # ensure kernels stacks exist
+        assert_collapsed(process_collapsed)
+        assert_function_in_collapsed("do_syscall_64_[k]", process_collapsed)  # ensure kernels stacks exist
 
 
 def test_java_safemode_parameters(tmp_path) -> None:
@@ -221,7 +221,7 @@ def test_async_profiler_output_written_upon_jvm_exit(tmp_path, application_pid, 
         threading.Thread(target=delayed_kill).start()
 
         process_collapsed = snapshot_one_collaped(profiler)
-        assert_collapsed(process_collapsed, check_comm=True)
+        assert_collapsed(process_collapsed)
 
         assert f"Profiled process {application_pid} exited before stopping async-profiler" in caplog.text
 

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -47,7 +47,7 @@ def test_java_from_host(
     ) as profiler:
         _ = assert_application_name  # Required for mypy unused argument warning
         process_collapsed = snapshot_one_collaped(profiler)
-        assert_collapsed(process_collapsed, check_comm=True)
+        assert_collapsed(process_collapsed)
 
 
 @pytest.mark.parametrize("runtime", ["python"])
@@ -62,7 +62,7 @@ def test_pyspy(
     with PySpyProfiler(1000, 3, Event(), str(tmp_path), add_versions=True) as profiler:
         # not using snapshot_one_collaped because there are multiple Python processes running usually.
         process_collapsed = profiler.snapshot().get(application_pid)
-        assert_collapsed(process_collapsed, check_comm=True)
+        assert_collapsed(process_collapsed)
         assert_function_in_collapsed("PyYAML==6.0", process_collapsed)  # Ensure package info is presented
         # Ensure Python version is presented
         assert python_version is not None, "Failed to find python version"
@@ -79,7 +79,7 @@ def test_phpspy(
         1000, PHPSPY_DURATION, Event(), str(tmp_path), php_process_filter="php", php_mode="phpspy"
     ) as profiler:
         process_collapsed = profiler.snapshot().get(application_pid)
-        assert_collapsed(process_collapsed, check_comm=True)
+        assert_collapsed(process_collapsed)
 
 
 @pytest.mark.parametrize("runtime", ["ruby"])
@@ -91,7 +91,7 @@ def test_rbspy(
 ) -> None:
     with RbSpyProfiler(1000, 3, Event(), str(tmp_path), "rbspy") as profiler:
         process_collapsed = snapshot_one_collaped(profiler)
-        assert_collapsed(process_collapsed, check_comm=True)
+        assert_collapsed(process_collapsed)
 
 
 @pytest.mark.parametrize("runtime", ["nodejs"])
@@ -105,7 +105,7 @@ def test_nodejs(
         1000, 6, Event(), str(tmp_path), perf_mode="fp", perf_inject=True, perf_dwarf_stack_size=0
     ) as profiler:
         process_collapsed = profiler.snapshot().get(application_pid)
-        assert_collapsed(process_collapsed, check_comm=True)
+        assert_collapsed(process_collapsed)
 
 
 @pytest.mark.parametrize("runtime", ["python"])
@@ -122,10 +122,10 @@ def test_python_ebpf(
     with PythonEbpfProfiler(1000, 5, Event(), str(tmp_path), add_versions=True) as profiler:
         collapsed = profiler.snapshot()
         process_collapsed = collapsed.get(application_pid)
-        assert_collapsed(process_collapsed, check_comm=True)
-        assert_function_in_collapsed("do_syscall_64_[k]", process_collapsed, True)  # ensure kernels stacks exist
+        assert_collapsed(process_collapsed)
+        assert_function_in_collapsed("do_syscall_64_[k]", process_collapsed)  # ensure kernels stacks exist
         assert_function_in_collapsed(
-            "_PyEval_EvalFrameDefault_[pn]", process_collapsed, True
+            "_PyEval_EvalFrameDefault_[pn]", process_collapsed
         )  # ensure native user stacks exist
         assert_function_in_collapsed("PyYAML==6.0", process_collapsed)  # ensure package info is presented
         # ensure Python version is presented

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,12 +8,9 @@ from docker import DockerClient
 from docker.models.containers import Container
 from docker.models.images import Image
 
-<<<<<<< HEAD
 from gprofiler.gprofiler_types import StackToSampleCount
-from gprofiler.profilers.profiler_base import ProfilerInterface
-=======
 from gprofiler.profilers.java import JAVA_ASYNC_PROFILER_DEFAULT_SAFEMODE, JAVA_SAFEMODE_ALL, JavaProfiler
->>>>>>> d80722c... tests: java: Add make_java_profiler() helper
+from gprofiler.profilers.profiler_base import ProfilerInterface
 
 RUNTIME_PROFILERS = [
     ("java", "ap"),
@@ -112,6 +109,7 @@ def snapshot_one_collaped(profiler: ProfilerInterface) -> StackToSampleCount:
     result = profiler.snapshot()
     assert len(result) == 1
     return next(iter(result.values()))
+
 
 def make_java_profiler(
     storage_dir: str,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -98,7 +98,7 @@ def chmod_path_parts(path: Path, add_mode: int) -> None:
         os.chmod(subpath, os.stat(subpath).st_mode | add_mode)
 
 
-def assert_function_in_collapsed(function_name: str, collapsed: Mapping[str, int], check_comm: bool = False) -> None:
+def assert_function_in_collapsed(function_name: str, collapsed: Mapping[str, int]) -> None:
     print(f"collapsed: {collapsed}")
     assert any(
         (function_name in record) for record in collapsed.keys()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -114,8 +114,8 @@ def snapshot_one_collaped(profiler: ProfilerInterface) -> StackToSampleCount:
 def make_java_profiler(
     frequency: int = 11,
     duration: int = 1,
-    storage_dir: str = None,
     stop_event: Event = Event(),
+    storage_dir: str = None,
     java_async_profiler_buildids: bool = False,
     java_version_check: bool = True,
     java_async_profiler_mode: str = "cpu",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -112,9 +112,9 @@ def snapshot_one_collaped(profiler: ProfilerInterface) -> StackToSampleCount:
 
 
 def make_java_profiler(
-    storage_dir: str,
     frequency: int = 11,
     duration: int = 1,
+    storage_dir: str = None,
     stop_event: Event = Event(),
     java_async_profiler_buildids: bool = False,
     java_version_check: bool = True,
@@ -124,6 +124,7 @@ def make_java_profiler(
     java_safemode: str = JAVA_SAFEMODE_ALL,
     java_mode: str = "ap",
 ) -> JavaProfiler:
+    assert storage_dir is not None
     return JavaProfiler(
         frequency=frequency,
         duration=duration,
@@ -131,9 +132,9 @@ def make_java_profiler(
         storage_dir=storage_dir,
         java_async_profiler_buildids=java_async_profiler_buildids,
         java_version_check=java_version_check,
-        java_async_profiler_mode="cpu",
-        java_async_profiler_safemode=0,
-        java_async_profiler_args="",
-        java_safemode="",
-        java_mode="ap",
+        java_async_profiler_mode=java_async_profiler_mode,
+        java_async_profiler_safemode=java_async_profiler_safemode,
+        java_async_profiler_args=java_async_profiler_args,
+        java_safemode=java_safemode,
+        java_mode=java_mode,
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,14 +1,19 @@
 import os
 import subprocess
 from pathlib import Path
+from threading import Event
 from typing import Dict, List, Mapping, Optional, Tuple
 
 from docker import DockerClient
 from docker.models.containers import Container
 from docker.models.images import Image
 
+<<<<<<< HEAD
 from gprofiler.gprofiler_types import StackToSampleCount
 from gprofiler.profilers.profiler_base import ProfilerInterface
+=======
+from gprofiler.profilers.java import JAVA_ASYNC_PROFILER_DEFAULT_SAFEMODE, JAVA_SAFEMODE_ALL, JavaProfiler
+>>>>>>> d80722c... tests: java: Add make_java_profiler() helper
 
 RUNTIME_PROFILERS = [
     ("java", "ap"),
@@ -107,3 +112,30 @@ def snapshot_one_collaped(profiler: ProfilerInterface) -> StackToSampleCount:
     result = profiler.snapshot()
     assert len(result) == 1
     return next(iter(result.values()))
+
+def make_java_profiler(
+    storage_dir: str,
+    frequency: int = 11,
+    duration: int = 1,
+    stop_event: Event = Event(),
+    java_async_profiler_buildids: bool = False,
+    java_version_check: bool = True,
+    java_async_profiler_mode: str = "cpu",
+    java_async_profiler_safemode: int = JAVA_ASYNC_PROFILER_DEFAULT_SAFEMODE,
+    java_async_profiler_args: str = "",
+    java_safemode: str = JAVA_SAFEMODE_ALL,
+    java_mode: str = "ap",
+) -> JavaProfiler:
+    return JavaProfiler(
+        frequency=frequency,
+        duration=duration,
+        stop_event=stop_event,
+        storage_dir=storage_dir,
+        java_async_profiler_buildids=java_async_profiler_buildids,
+        java_version_check=java_version_check,
+        java_async_profiler_mode="cpu",
+        java_async_profiler_safemode=0,
+        java_async_profiler_args="",
+        java_safemode="",
+        java_mode="ap",
+    )


### PR DESCRIPTION
Based on:
* https://github.com/Granulate/gprofiler/pull/264
* https://github.com/Granulate/gprofiler/pull/263
* https://github.com/Granulate/gprofiler/pull/262

## Description
This PR includes 2 changes :sweat_smile: it was convenient to write them together.
* We now pass the `timeout` parameter, added to [AP v2.6](https://github.com/jvm-profiling-tools/async-profiler/releases/tag/v2.6). This ensures we prevent AP from running forever, if we don't stop it for whatever reason.
* We try to read the AP output file even if the profiled process has exited during profiling. This helps when profiling short processes - as the last "duration" of profiling may be lost, if the process exits e.g 50 seconds into the 60 seconds profiling session.

## Motivation and Context
* AP timeouts - improves robustness; we will automatically stop Java profiling if gProfiler goes down. This completes what we started in https://github.com/Granulate/gprofiler/pull/247.
* Reading output file upon process exit - we'll still have the what profiling data was already collected for the process; useful if processes are short.

## How Has This Been Tested?
Added 2 tests :) So CI.
* [x] Specifically for the AP timeout, I also ran old gProfiler, `pkill -9` it, then ran it again and saw the log "Found started AP". Then tried with this branch - no "Found started AP" message.

