### PR TITLE
java: Strip unrelated output prefix lines in "java -version"

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -583,9 +583,9 @@ class JavaProfiler(ProcessProfilerBase):
     def _is_jvm_version_supported(self, java_version_cmd_output: str) -> bool:
         try:
             jvm_version = parse_jvm_version(java_version_cmd_output)
-            logger.info(f"Checking support for java version {jvm_version}")
-        except Exception as e:
-            logger.exception(f"Failed to parse java -version output {java_version_cmd_output}: {e}")
+            logger.info("Checking support for java version", jvm_version=jvm_version)
+        except Exception:
+            logger.exception("Failed to parse java -version output", java_version_cmd_output=java_version_cmd_output)
             return False
 
         if jvm_version.version.major not in self.MINIMAL_SUPPORTED_VERSIONS:

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -11,6 +11,7 @@ import shutil
 import signal
 from collections import Counter
 from enum import Enum
+from itertools import dropwhile
 from pathlib import Path
 from threading import Event
 from typing import List, Optional, Set
@@ -387,6 +388,11 @@ def parse_jvm_version(version_string: str) -> JvmVersion:
     # We are taking the version from the first line, and the build number and vm name from the last line
 
     lines = version_string.splitlines()
+
+    # the version always starts with "openjdk version" or "java version". strip all lines
+    # before that.
+    lines = list(dropwhile(lambda l: not ("openjdk version" in l or "java version" in l), lines))
+
     # version is always in quotes
     _, version_str, _ = lines[0].split('"')
     build_str = lines[2].split("(build ")[1]


### PR DESCRIPTION
## Description
We see errors like:

	Java HotSpot(TM) 64-Bit Server VM warning: Insufficient space for shared memory file:
	   8703
	Try using the -Djava.io.tmpdir= option to select an alternate temp location.

Don't care about them, so I am stripping everything before the expected first line.

## How Has This Been Tested?
CI

* [x] Manually checked some HS, J9, Zing strings with the new parser - works fine.