### PR TITLE
Use process_exe() everywhere

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -29,7 +29,7 @@ from granulate_utils.java import (
 from granulate_utils.linux import ns, proc_events
 from granulate_utils.linux.ns import get_proc_root_path, resolve_proc_root_links, run_in_ns
 from granulate_utils.linux.oom import get_oom_entry
-from granulate_utils.linux.process import is_process_running
+from granulate_utils.linux.process import is_process_running, process_exe
 from granulate_utils.linux.signals import get_signal_entry
 from packaging.version import Version
 from psutil import Process
@@ -669,7 +669,8 @@ class JavaProfiler(ProcessProfilerBase):
         return True
 
     def _is_jvm_profiling_supported(self, process: Process) -> bool:
-        process_basename = os.path.basename(process.exe())
+        exe = process_exe(process)
+        process_basename = os.path.basename(exe)
         if JavaSafemodeOptions.JAVA_EXTENDED_VERSION_CHECKS in self._java_safemode:
             # TODO we can get the "java" binary by extracting the java home from the libjvm path,
             # then check with that instead (if exe isn't java)
@@ -678,7 +679,7 @@ class JavaProfiler(ProcessProfilerBase):
                     "Non-java basenamed process, skipping... (disable "
                     f" --java-safemode={JavaSafemodeOptions.JAVA_EXTENDED_VERSION_CHECKS} to profile it anyway)",
                     pid=process.pid,
-                    exe=process.exe(),
+                    exe=exe,
                 )
                 return False
 

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -13,7 +13,7 @@ from subprocess import Popen
 from threading import Event
 from typing import Dict, List, Optional
 
-from granulate_utils.linux.process import is_process_running
+from granulate_utils.linux.process import is_process_running, process_exe
 from psutil import NoSuchProcess, Process
 
 from gprofiler.exceptions import (
@@ -174,7 +174,7 @@ class PySpyProfiler(ProcessProfilerBase):
                 # when invoked on pypy.
                 # I'm checking for "pypy" in the basename here. I'm not aware of libpypy being directly loaded
                 # into non-pypy processes, if we ever encounter that - we can check the maps instead
-                if os.path.basename(process.exe()).startswith("pypy"):
+                if os.path.basename(process_exe(process)).startswith("pypy"):
                     continue
 
                 filtered_procs.append(process)

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -29,6 +29,7 @@ from typing import Callable, Iterator, List, Optional, Tuple, Union
 import importlib_resources
 import psutil
 from granulate_utils.linux.ns import run_in_ns
+from granulate_utils.linux.process import process_exe
 from psutil import Process
 
 from gprofiler.exceptions import (
@@ -266,7 +267,7 @@ def pgrep_exe(match: str) -> List[Process]:
     procs = []
     for process in psutil.process_iter():
         try:
-            if pattern.match(process.exe()):
+            if pattern.match(process_exe(process)):
                 procs.append(process)
         except psutil.NoSuchProcess:  # process might have died meanwhile
             continue


### PR DESCRIPTION
## Description

See comment on process_exe() - it correctly raises ZombieProcess (which is a subclass
of NoSuchProcess) for zombie processes.
gProfiler should treat this error as processes going down.

These are all invocations of `Process.exe()` in gProfiler.

See https://github.com/giampaolo/psutil/pull/2062 which solves the issue in `psutil`.

## Motivation and Context
Currently we don't handle it as "process is down", so we get unrelated errors like `Non-java basenamed process, skipping... (disable --java-safemode to profile it anyway)` with `exe=""`, which happens because the process is a zombie, so I actually want it ignored.
