### PR TITLE
Return profiling error stack in all error/skip cases of _profile_process

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -9,7 +9,6 @@ import os
 import re
 import shutil
 import signal
-from collections import Counter
 from enum import Enum
 from itertools import dropwhile
 from pathlib import Path
@@ -614,13 +613,6 @@ class JavaProfiler(ProcessProfilerBase):
         if self._safemode_disable_reason is None and cause in self._java_safemode:
             logger.warning("Java profiling has been disabled, will avoid profiling any new java processes", cause=cause)
             self._safemode_disable_reason = cause
-
-    @staticmethod
-    def _profiling_error_stack(what: str, reason: str, comm: str) -> StackToSampleCount:
-        # return 1 sample, it will be scaled later in merge_profiles().
-        # if --perf-mode=none mode is used, it will not, but we don't have anything logical to
-        # do here in that case :/
-        return Counter({f"{comm};[Profiling {what}: {reason}]": 1})
 
     def _profiling_skipped_stack(self, reason: str, comm: str) -> StackToSampleCount:
         return self._profiling_error_stack("skipped", reason, comm)

--- a/gprofiler/profilers/profiler_base.py
+++ b/gprofiler/profilers/profiler_base.py
@@ -144,7 +144,7 @@ class ProcessProfilerBase(ProfilerBase):
                     result = self._profiling_error_stack("error", "process went down during profiling", comm)
                 except Exception as e:
                     logger.exception(f"{self.__class__.__name__}: failed to profile process {pid} ({comm})")
-                    result = self._profiling_error_stack("error", str(e), comm)
+                    result = self._profiling_error_stack("error", f"exception {type(e).__name__}", comm)
 
                 results[pid] = result
 

--- a/gprofiler/profilers/profiler_base.py
+++ b/gprofiler/profilers/profiler_base.py
@@ -92,7 +92,7 @@ class ProcessProfilerBase(ProfilerBase):
     def _select_processes_to_profile(self) -> List[Process]:
         raise NotImplementedError
 
-    def _profile_process(self, process: Process) -> Optional[StackToSampleCount]:
+    def _profile_process(self, process: Process) -> StackToSampleCount:
         raise NotImplementedError
 
     def snapshot(self) -> ProcessToStackSampleCounters:

--- a/gprofiler/profilers/profiler_base.py
+++ b/gprofiler/profilers/profiler_base.py
@@ -4,6 +4,7 @@
 #
 
 import concurrent.futures
+from collections import Counter
 from threading import Event
 from types import TracebackType
 from typing import List, Optional, Type, TypeVar
@@ -103,6 +104,13 @@ class ProcessProfilerBase(ProfilerBase):
 
     def _profile_process(self, process: Process) -> StackToSampleCount:
         raise NotImplementedError
+
+    @staticmethod
+    def _profiling_error_stack(what: str, reason: str, comm: str) -> StackToSampleCount:
+        # return 1 sample, it will be scaled later in merge_profiles().
+        # if --perf-mode=none mode is used, it will not, but we don't have anything logical to
+        # do here in that case :/
+        return Counter({f"{comm};[Profiling {what}: {reason}]": 1})
 
     def snapshot(self) -> ProcessToStackSampleCounters:
         processes_to_profile = self._select_processes_to_profile()

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -119,13 +119,8 @@ class PySpyProfiler(ProcessProfilerBase):
             "--full-filenames",
         ]
 
-    def _profile_process(self, process: Process) -> Optional[StackToSampleCount]:
-        try:
-            logger.info(
-                f"Profiling process {process.pid} with py-spy", cmdline=process.cmdline(), no_extra_to_server=True
-            )
-        except NoSuchProcess:
-            return None
+    def _profile_process(self, process: Process) -> StackToSampleCount:
+        logger.info(f"Profiling process {process.pid} with py-spy", cmdline=process.cmdline(), no_extra_to_server=True)
 
         local_output_path = os.path.join(self._storage_dir, f"pyspy.{random_prefix()}.{process.pid}.col")
         with removed_path(local_output_path):

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -119,11 +119,6 @@ class PySpyProfiler(ProcessProfilerBase):
             "--full-filenames",
         ]
 
-    @staticmethod
-    def _profiling_error_stack(reason: str, comm: str) -> StackToSampleCount:
-        # like _profiling_skipped_stack of java.py
-        return Counter({f"{comm};[Profiling error: {reason}]": 1})
-
     def _profile_process(self, process: Process) -> StackToSampleCount:
         logger.info(f"Profiling process {process.pid} with py-spy", cmdline=process.cmdline(), no_extra_to_server=True)
         comm = process_comm(process)
@@ -148,7 +143,7 @@ class PySpyProfiler(ProcessProfilerBase):
                     and not is_process_running(process)
                 ):
                     logger.debug(f"Profiled process {process.pid} exited before py-spy could start")
-                    return self._profiling_error_stack(comm, "process exited before py-spy started")
+                    return self._profiling_error_stack("error", comm, "process exited before py-spy started")
                 raise
 
             logger.info(f"Finished profiling process {process.pid} with py-spy")

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -119,8 +119,14 @@ class PySpyProfiler(ProcessProfilerBase):
             "--full-filenames",
         ]
 
+    @staticmethod
+    def _profiling_error_stack(reason: str, comm: str) -> StackToSampleCount:
+        # like _profiling_skipped_stack of java.py
+        return Counter({f"{comm};[Profiling error: {reason}]": 1})
+
     def _profile_process(self, process: Process) -> StackToSampleCount:
         logger.info(f"Profiling process {process.pid} with py-spy", cmdline=process.cmdline(), no_extra_to_server=True)
+        comm = process_comm(process)
 
         local_output_path = os.path.join(self._storage_dir, f"pyspy.{random_prefix()}.{process.pid}.col")
         with removed_path(local_output_path):
@@ -142,11 +148,11 @@ class PySpyProfiler(ProcessProfilerBase):
                     and not is_process_running(process)
                 ):
                     logger.debug(f"Profiled process {process.pid} exited before py-spy could start")
-                    return None
+                    return self._profiling_error_stack(comm, "process exited before py-spy started")
                 raise
 
             logger.info(f"Finished profiling process {process.pid} with py-spy")
-            parsed = parse_one_collapsed_file(Path(local_output_path), process_comm(process))
+            parsed = parse_one_collapsed_file(Path(local_output_path), comm)
             if self.add_versions:
                 parsed = _add_versions_to_process_stacks(process, parsed)
             return parsed


### PR DESCRIPTION
## Description
As discussed in https://github.com/Granulate/gprofiler/pull/263#discussion_r785871160. The cases fixed here are much less common, but let's have them covered as well, and I changed the interface.

~~We still don't handle exceptions raised in `_profile_process`. I'll think how we want them handled - perhaps, automatically converted to an error stack by `ProcessProfilerBase.snapshot`?~~

## How Has This Been Tested?
* CI
* [x] Java process in a container going down - results in the expected stack.