### PR TITLE
Profile spawning processes

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -832,8 +832,7 @@ class JavaProfiler(ProcessProfilerBase):
     def start(self) -> None:
         super().start()
         try:
-            # needs to run in init net NS - see netlink_kernel_create() call on init_net in cn_init().
-            run_in_ns(["net"], lambda: proc_events.register_exit_callback(self._proc_exit_callback), 1)
+            proc_events.register_exit_callback(self._proc_exit_callback)
         except Exception:
             logger.warning("Failed to enable proc_events listener for exited Java processes", exc_info=True)
         else:

--- a/gprofiler/profilers/profiler_base.py
+++ b/gprofiler/profilers/profiler_base.py
@@ -233,7 +233,6 @@ class SpawningProcessProfilerBase(ProcessProfilerBase):
                 with self._submit_lock:
                     if self._is_profiling_spawning:
                         # TODO ensure > 0 etc
-                        print("starting at interval", interval)
                         assert self._start_ts is not None and self._threads is not None
                         duration = self._duration - (time.monotonic() - self._start_ts)
                         self._futures[self._threads.submit(self._profile_process, process, int(duration))] = process.pid

--- a/gprofiler/profilers/profiler_base.py
+++ b/gprofiler/profilers/profiler_base.py
@@ -3,10 +3,15 @@
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
 
-import concurrent.futures
-from threading import Event
-from typing import List, Optional
+import sched
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures._base import Future
+from threading import Event, Lock, Thread
+from typing import Dict, List, Optional
 
+from granulate_utils.linux.proc_events import register_exec_callback, unregister_exec_callback
+from granulate_utils.linux.process import is_process_running
 from psutil import NoSuchProcess, Process
 
 from gprofiler.exceptions import StopEventSetException
@@ -92,33 +97,147 @@ class ProcessProfilerBase(ProfilerBase):
     def _select_processes_to_profile(self) -> List[Process]:
         raise NotImplementedError
 
-    def _profile_process(self, process: Process) -> Optional[StackToSampleCount]:
+    def _profile_process(self, process: Process, duration: int) -> Optional[StackToSampleCount]:
         raise NotImplementedError
+
+    def _notify_selected_processes(self, processes: List[Process]) -> None:
+        pass
+
+    def _wait_for_profiles(self, futures: Dict[Future, int]) -> ProcessToStackSampleCounters:
+        results = {}
+        for future in as_completed(futures):
+            try:
+                result = future.result()
+                if result is not None:
+                    results[futures[future]] = result
+            except StopEventSetException:
+                raise
+            except NoSuchProcess:
+                logger.debug(
+                    f"{self.__class__.__name__}: process went down during profiling {futures[future]}",
+                    exc_info=True,
+                )
+            except Exception:
+                logger.exception(f"{self.__class__.__name__}: failed to profile process {futures[future]}")
+
+        return results
 
     def snapshot(self) -> ProcessToStackSampleCounters:
         processes_to_profile = self._select_processes_to_profile()
+        self._notify_selected_processes(processes_to_profile)
+
         if not processes_to_profile:
             return {}
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=len(processes_to_profile)) as executor:
-            futures = {}
+        with ThreadPoolExecutor(max_workers=len(processes_to_profile)) as executor:
+            futures: Dict[Future, int] = {}
             for process in processes_to_profile:
-                futures[executor.submit(self._profile_process, process)] = process.pid
+                futures[executor.submit(self._profile_process, process, self._duration)] = process.pid
 
-            results = {}
-            for future in concurrent.futures.as_completed(futures):
-                try:
-                    result = future.result()
-                    if result is not None:
-                        results[futures[future]] = result
-                except StopEventSetException:
-                    raise
-                except NoSuchProcess:
-                    logger.debug(
-                        f"{self.__class__.__name__}: process went down during profiling {futures[future]}",
-                        exc_info=True,
-                    )
-                except Exception:
-                    logger.exception(f"{self.__class__.__name__}: failed to profile process {futures[future]}")
+            return self._wait_for_profiles(futures)
 
+
+class SpawningProcessProfilerBase(ProcessProfilerBase):
+    """
+    Enhances ProcessProfilerBase with tracking of newly spawned processes.
+    """
+
+    _SCHED_THREAD_INTERVAL = 0.1
+    _BACKOFF_INIT = 0.1
+    # so we wait up to 1.5 seconds
+    _BACKOFF_MAX = 0.8
+
+    def __init__(self, frequency: int, duration: int, stop_event: Optional[Event], storage_dir: str):
+        super().__init__(frequency, duration, stop_event, storage_dir)
+        self._submit_lock = Lock()
+        self._threads: Optional[ThreadPoolExecutor] = None
+        self._start_ts: Optional[float] = None
+        self._enabled_proc_events = False
+        self._futures: Dict[Future, int] = {}
+        self._sched = sched.scheduler()
+        self._sched_stop = False
+        self._sched_thread = Thread(target=self._sched_thread_run)
+
+    def _should_profile_process(self, pid: int) -> bool:
+        raise NotImplementedError
+
+    def _notify_selected_processes(self, processes: List[Process]) -> None:
+        # TODO ensure PIDs in _proc_exec_callback don't intersect with "processes"?
+        # now we start watching for new processes.
+        self._start_profiling_spawning()
+
+    @property
+    def _is_profiling_spawning(self) -> bool:
+        return self._threads is not None
+
+    def _start_profiling_spawning(self) -> None:
+        with self._submit_lock:
+            self._start_ts = time.monotonic()
+            self._threads = ThreadPoolExecutor()
+
+    def _stop_profiling_spawning(self) -> None:
+        with self._submit_lock:
+            self._start_ts = None
+            self._threads = None
+
+    def _proc_exec_callback(self, tid: int, pid: int) -> None:
+        self._sched.enter(self._BACKOFF_INIT, 0, self._check_process, (Process(pid), self._BACKOFF_INIT))
+
+    def start(self) -> None:
+        super().start()
+
+        self._sched_thread.start()
+
+        try:
+            register_exec_callback(self._proc_exec_callback)
+        except Exception:
+            logger.warning("Failed to enable proc_events listener for executed processes", exc_info=True)
+        else:
+            self._enabled_proc_events = True
+
+    def stop(self) -> None:
+        super().stop()
+
+        if self._enabled_proc_events:
+            unregister_exec_callback(self._proc_exec_callback)
+            self._enabled_proc_events = False
+
+        self._sched_stop = True
+        self._sched_thread.join()
+
+    def snapshot(self) -> ProcessToStackSampleCounters:
+        results = super().snapshot()
+
+        # wait for one duration, in case snapshot() found no processes
+        self._stop_event.wait(self._duration)
+
+        self._stop_profiling_spawning()
+        results_spawned = self._wait_for_profiles(self._futures)
+        self._futures = {}
+
+        # should not intersect
+        assert set(results).intersection(results_spawned) == set()
+        results.update(results_spawned)
         return results
+
+    def _sched_thread_run(self):
+        while not (self._stop_event.is_set() or self._sched_stop):
+            self._sched.run()
+            self._stop_event.wait(0.1)
+
+    def _check_process(self, process: Process, interval: float) -> None:
+        # TODO try-except and ignore NoSuchProcess
+        if is_process_running(process) and self._is_profiling_spawning:
+            if self._should_profile_process(process.pid):
+                # check again, with the lock this time
+                with self._submit_lock:
+                    if self._is_profiling_spawning:
+                        # TODO ensure > 0 etc
+                        print("starting at interval", interval)
+                        assert self._start_ts is not None and self._threads is not None
+                        duration = self._duration - (time.monotonic() - self._start_ts)
+                        self._futures[self._threads.submit(self._profile_process, process, int(duration))] = process.pid
+            else:
+                if interval < self._BACKOFF_MAX:
+                    new_interval = interval * 2
+                    self._sched.enter(new_interval, 0, self._check_process, (process, new_interval))

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -119,7 +119,7 @@ class PySpyProfiler(ProcessProfilerBase):
             "--full-filenames",
         ]
 
-    def _profile_process(self, process: Process) -> Optional[StackToSampleCount]:
+    def _profile_process(self, process: Process, duration: int) -> Optional[StackToSampleCount]:
         try:
             logger.info(
                 f"Profiling process {process.pid} with py-spy", cmdline=process.cmdline(), no_extra_to_server=True
@@ -133,7 +133,7 @@ class PySpyProfiler(ProcessProfilerBase):
                 run_process(
                     self._make_command(process.pid, local_output_path),
                     stop_event=self._stop_event,
-                    timeout=self._duration + self._EXTRA_TIMEOUT,
+                    timeout=duration + self._EXTRA_TIMEOUT,
                     kill_signal=signal.SIGKILL,
                 )
             except ProcessStoppedException:

--- a/gprofiler/profilers/ruby.py
+++ b/gprofiler/profilers/ruby.py
@@ -56,7 +56,7 @@ class RbSpyProfiler(ProcessProfilerBase):
             str(pid),
         ]
 
-    def _profile_process(self, process: Process) -> StackToSampleCount:
+    def _profile_process(self, process: Process, duration: int) -> StackToSampleCount:
         logger.info(
             f"Profiling process {process.pid} with rbspy", cmdline=" ".join(process.cmdline()), no_extra_to_server=True
         )
@@ -67,7 +67,7 @@ class RbSpyProfiler(ProcessProfilerBase):
                 run_process(
                     self._make_command(process.pid, local_output_path),
                     stop_event=self._stop_event,
-                    timeout=self._duration + self._EXTRA_TIMEOUT,
+                    timeout=duration + self._EXTRA_TIMEOUT,
                     kill_signal=signal.SIGKILL,
                 )
             except ProcessStoppedException:


### PR DESCRIPTION
Based on:
* https://github.com/Granulate/gprofiler/pull/280
* https://github.com/Granulate/gprofiler/pull/279

## Description
This PR aims to solve the "short processes" issue: gProfiler runs profiling sessions of 60 seconds (that's the default). Upon each session, the different profilers (`JavaProfiler`, `PySpyProfiler` etc) scan through all currently running processes and invoke their respective profilers for each relevant process.

This works nicely for processes running for long durations (and still, it has some disadvantages which I'll describe later). However, it fails miserably in environments where processes are spawning and exiting quickly. For example, for an app with average lifetime of 10 seconds, we'll only see profiling data from the respective profiler for less than 1/6 of the time! (because on average, we'll catch only one out of 6 processes, and that process might already be halfway through its 10 seconds...). The situation was even worse for Java before https://github.com/Granulate/gprofiler/pull/265, because we didn't read the output file if the process exited before the profiling session has ended. So by design - processes shorter than 60 seconds were not profiled... (py-spy & rb-spy do not suffer from this problem; PyPerf & phpspy, by design, do not suffer from it).

This PR is the first step towards the "final" design of gProfiler, as I see it. I'll explain what I did here, then explain the next steps.

The `SpawningProcessProfilerBase` class was added (name T.B.D). It extends `ProcessProfilerBase` which is the base class for process-based profilers - profilers invoked per process (AP, py-spy, rbspy).
This class extends the existing behavior of `ProcessProfilerBase` using `proc_events`. Here's how it works:
1. `SpawningProcessProfilerBase.snapshot()` is called
2. `ProcessProfilerBase.snapshot()` is called. Upon selecting the currently running processes to profile, it notifies its base classes with the selected processes. At this point, `SpawningProcessProfilerBase` starts listening for new execs via `proc_events` (had it been listening earlier, we could "double catch" processes). This section is racy; fixing it is not too hard, but it's irrelevant in the final solution, and the race is not very likely anyway. So I don't intend to do it now.
3. Upon new execs, we place the `psutil.Process` object of the new process into a queue. It will now be checked for "should we profile it" multiple times over 1.5 seconds (with some basic exponential backoff logic). The reason we need to check multiple times is that our "should profile" checks are based on parsing `/proc/pid/maps`. Once the exec completes, libraries are not yet loaded (it is `ld.so`'s job). Furthermore, in the case of Java, `libjvm.so` is not even an (in)direct dependency of `java` - it's loaded later by whatever. This may take a short while, also depending on the load on the machine... In the case of Python, we sometimes select processes to profile based on `site-packages` in their maps - that definitely doesn't show up in maps right after the exec.
4. Once a spawned process was deemed relevant for profiling, we submit it to `_profile_process` in a TPE, with the duration decreased by how much time has passed since this session started.
5. Upon `ProcessProfilerBase.snapshot()` return, we also stop listening for new execs, and terminate the TPE.
6. Results from `ProcessProfilerBase.snapshot()` are merged with the results from our TPE.

Issues with the current impl:
* If used for rbspy, py-spy and AP: we're cloning the scheduler thread 3 times, Not sure it's that bad.
* `SpawningProcessProfilerBase` contains lots of logic that should be split.

### Roadmap & end goal
The final idea of gProfiler is this:
* *all* profilers run continuously (like perf, PyPerf & phpspy are now).
* Process-based profilers (AP, py-spy, rbspy) can run indefinitely, and dump output upon signal / request / process exit. So upon each session, we just "ask" profilers to give their current state.
* gProfiler runs a single thread using `proc_events`, and decides for each PID if any of the profilers should get it (as an optimization - phpsy & PyPerf should be modified to accept PIDs this way, instead of scanning themselves - scanning has a cost on the system, and thus if we have multiple unrelated "scanners", they run at lower frequency compared to the effectiveness of `proc_events`.
  * for low-priv executions, where we can't use `proc_events`, gProfiler will continue scanning for processes, but at a much higher interval (e.g each 0.5 seconds)

Roadmap:
1. Implement an alternative to `proc_events` for low-priv.
2. Get rid of `_select_processes_to_profile` - that is, don't "select processes" upon each session start, just select processes based on `proc_events`, and start profiling until the current session end.
3. Add support for continuous profiling in AP, rbspy, py-spy. I think that AP might have it (just gotta use the `dump` action instead of `stop`), not sure about the others.
4. Run all profilers independently of the profiling sessions, and just call a "dump data from all currently running py-spys" method.

## How Has This Been Tested?
T.B.A

## Checklist:
* [ ] Decide on the final design & implement it
* [ ] Make sure it is enabled for rbspy & py-spy as well.
* [ ] Add at least one automatic test, so that it runs in CI.
* [ ] Document theory of operation (I plan to add that in README)
* [ ] Document my future plans (as noted shortly in this PR)