### PR TITLE
mypy: Enable mypy strict mode

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,3 +7,4 @@ types-requests==0.1.9
 types-dataclasses==0.1.5
 types-psutil==5.8.19
 types-PyYAML==6.0.3
+types-pkg-resources==0.1.3

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,4 +5,5 @@ mypy==0.901
 isort==5.8.0
 types-requests==0.1.9
 types-dataclasses==0.1.5
-types-psutil==5.8.0
+types-psutil==5.8.19
+types-PyYAML==6.0.3

--- a/gprofiler/client.py
+++ b/gprofiler/client.py
@@ -6,7 +6,7 @@ import datetime
 import gzip
 import json
 from io import BytesIO
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Any
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Any, cast
 
 import requests
 from requests import Session
@@ -63,7 +63,7 @@ class APIClient:
         self,
         method: str,
         path: str,
-        data: Optional[Dict],
+        data: Any,
         files: Dict = None,
         timeout: float = DEFAULT_REQUEST_TIMEOUT,
         api_version: str = None,
@@ -101,21 +101,21 @@ class APIClient:
                 raise APIError(resp.text)
         else:
             resp.raise_for_status()
-        return resp.json()
+        return cast(dict, resp.json())
 
-    def get(self, path: str, data: Optional[Dict] = None, **kwargs: Any) -> Dict:
+    def get(self, path: str, data: Any = None, **kwargs: Any) -> Dict:
         return self._send_request("GET", path, data, **kwargs)
 
-    def post(self, path: str, data: Optional[Dict] = None, **kwargs: Any) -> Dict:
+    def post(self, path: str, data: Any = None, **kwargs: Any) -> Dict:
         return self._send_request("POST", path, data, **kwargs)
 
-    def put(self, path: str, data: Optional[Dict] = None, **kwargs: Any) -> Dict:
+    def put(self, path: str, data: Any = None, **kwargs: Any) -> Dict:
         return self._send_request("PUT", path, data, **kwargs)
 
-    def patch(self, path: str, data: Optional[Dict] = None, **kwargs: Any) -> Dict:
+    def patch(self, path: str, data: Any = None, **kwargs: Any) -> Dict:
         return self._send_request("PATCH", path, data, **kwargs)
 
-    def delete(self, path: str, data: Optional[Dict] = None, **kwargs: Any) -> Dict:
+    def delete(self, path: str, data: Any = None, **kwargs: Any) -> Dict:
         return self._send_request("DELETE", path, data, **kwargs)
 
     def get_health(self) -> Dict:

--- a/gprofiler/client.py
+++ b/gprofiler/client.py
@@ -6,7 +6,7 @@ import datetime
 import gzip
 import json
 from io import BytesIO
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Any, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
 
 import requests
 from requests import Session

--- a/gprofiler/client.py
+++ b/gprofiler/client.py
@@ -6,7 +6,7 @@ import datetime
 import gzip
 import json
 from io import BytesIO
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast, IO
 
 import requests
 from requests import Session
@@ -82,7 +82,7 @@ class APIClient:
             buffer = BytesIO()
             with gzip.open(buffer, mode="wt", encoding="utf-8") as gzip_file:
                 try:
-                    json.dump(data, gzip_file, ensure_ascii=False)  # type: ignore
+                    json.dump(data, cast(IO[str], gzip_file), ensure_ascii=False)
                 except TypeError:
                     # This should only happen while in development, and is used to get a more indicative error.
                     bad_json = str(data)

--- a/gprofiler/client.py
+++ b/gprofiler/client.py
@@ -40,7 +40,7 @@ class APIClient:
         self._init_session()
         logger.info(f"The connection to the server was successfully established (service {service!r})")
 
-    def _init_session(self):
+    def _init_session(self) -> None:
         self._session: Session = requests.Session()
         self._session.headers.update({"GPROFILER-API-KEY": self._key, "GPROFILER-SERVICE-NAME": self._service})
 

--- a/gprofiler/client.py
+++ b/gprofiler/client.py
@@ -6,7 +6,7 @@ import datetime
 import gzip
 import json
 from io import BytesIO
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast, IO
+from typing import IO, TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
 
 import requests
 from requests import Session

--- a/gprofiler/client.py
+++ b/gprofiler/client.py
@@ -6,7 +6,7 @@ import datetime
 import gzip
 import json
 from io import BytesIO
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Any
 
 import requests
 from requests import Session
@@ -103,22 +103,22 @@ class APIClient:
             resp.raise_for_status()
         return resp.json()
 
-    def get(self, path: str, data=None, **kwargs) -> Dict:
+    def get(self, path: str, data: Optional[Dict] = None, **kwargs: Any) -> Dict:
         return self._send_request("GET", path, data, **kwargs)
 
-    def post(self, path: str, data=None, **kwargs) -> Dict:
+    def post(self, path: str, data: Optional[Dict] = None, **kwargs: Any) -> Dict:
         return self._send_request("POST", path, data, **kwargs)
 
-    def put(self, path: str, data=None, **kwargs) -> Dict:
+    def put(self, path: str, data: Optional[Dict] = None, **kwargs: Any) -> Dict:
         return self._send_request("PUT", path, data, **kwargs)
 
-    def patch(self, path: str, data=None, **kwargs) -> Dict:
+    def patch(self, path: str, data: Optional[Dict] = None, **kwargs: Any) -> Dict:
         return self._send_request("PATCH", path, data, **kwargs)
 
-    def delete(self, path: str, data=None, **kwargs) -> Dict:
+    def delete(self, path: str, data: Optional[Dict] = None, **kwargs: Any) -> Dict:
         return self._send_request("DELETE", path, data, **kwargs)
 
-    def get_health(self):
+    def get_health(self) -> Dict:
         return self.get("health_check")
 
     def submit_profile(

--- a/gprofiler/docker_client.py
+++ b/gprofiler/docker_client.py
@@ -15,7 +15,7 @@ logger = get_logger_adapter(__name__)
 
 
 class DockerClient:
-    def __init__(self):
+    def __init__(self) -> None:
         try:
             self._client = docker.from_env()
         except Exception:

--- a/gprofiler/docker_client.py
+++ b/gprofiler/docker_client.py
@@ -32,7 +32,7 @@ class DockerClient:
         self._current_container_names: Set[str] = set()
         self._container_id_to_name_cache: Dict[str, Optional[str]] = {}
 
-    def reset_cache(self):
+    def reset_cache(self) -> None:
         self._pid_to_container_name_cache.clear()
         self._current_container_names.clear()
 
@@ -62,7 +62,7 @@ class DockerClient:
             logger.warning(f"Could not get a container name for PID {pid}", exc_info=True)
             return None
 
-    def _get_container_name(self, container_id) -> Optional[str]:
+    def _get_container_name(self, container_id: str) -> Optional[str]:
         if container_id in self._container_id_to_name_cache:
             container_name = self._container_id_to_name_cache[container_id]
             if container_name is not None:
@@ -79,7 +79,7 @@ class DockerClient:
             self._current_container_names.add(container_name)
         return container_name
 
-    def _refresh_container_names_cache(self):
+    def _refresh_container_names_cache(self) -> None:
         # We re-fetch all of the currently running containers, so in order to keep the cache small we clear it
         self._container_id_to_name_cache.clear()
         running_containers = self._client.containers.list()
@@ -101,6 +101,6 @@ class DockerClient:
         for line in cgroup.split():
             found = CONTAINER_ID_PATTERN.findall(line)
             if found:
-                return found[-1]
+                return found[-1]  # type: ignore
 
         return None

--- a/gprofiler/docker_client.py
+++ b/gprofiler/docker_client.py
@@ -3,7 +3,7 @@
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
 import re
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional, Set, cast
 
 import docker
 
@@ -101,6 +101,6 @@ class DockerClient:
         for line in cgroup.split():
             found = CONTAINER_ID_PATTERN.findall(line)
             if found:
-                return found[-1]  # type: ignore
+                return cast(str, found[-1])
 
         return None

--- a/gprofiler/exceptions.py
+++ b/gprofiler/exceptions.py
@@ -29,7 +29,7 @@ class CalledProcessError(subprocess.CalledProcessError):
 
 class CalledProcessTimeoutError(CalledProcessError):
     def __init__(
-        self, timeout: float, returncode: int, cmd: Union[str, List[str]], output: Any = None, stderr: Any = None
+        self, timeout: float, returncode: int, cmd: Union[str, List[str]], output: Any = str, stderr: Any = str
     ):
         super().__init__(returncode, cmd, output, stderr)
         self.timeout = timeout

--- a/gprofiler/exceptions.py
+++ b/gprofiler/exceptions.py
@@ -4,7 +4,7 @@
 #
 import signal
 import subprocess
-from typing import List, Union, Any
+from typing import Any, List, Union
 
 
 class StopEventSetException(Exception):

--- a/gprofiler/exceptions.py
+++ b/gprofiler/exceptions.py
@@ -4,7 +4,7 @@
 #
 import signal
 import subprocess
-from typing import List, Union
+from typing import List, Union, Any
 
 
 class StopEventSetException(Exception):
@@ -28,11 +28,12 @@ class CalledProcessError(subprocess.CalledProcessError):
 
 
 class CalledProcessTimeoutError(CalledProcessError):
-    def __init__(self, timeout: float, returncode: int, cmd: Union[str, List[str]], output=None, stderr=None):
+    def __init__(self, timeout: float, returncode: int, cmd: Union[str, List[str]], output: Any = None,
+                 stderr: Any = None):
         super().__init__(returncode, cmd, output, stderr)
         self.timeout = timeout
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"Timed out after {self.timeout} seconds\n" + super().__str__()
 
 

--- a/gprofiler/exceptions.py
+++ b/gprofiler/exceptions.py
@@ -28,8 +28,9 @@ class CalledProcessError(subprocess.CalledProcessError):
 
 
 class CalledProcessTimeoutError(CalledProcessError):
-    def __init__(self, timeout: float, returncode: int, cmd: Union[str, List[str]], output: Any = None,
-                 stderr: Any = None):
+    def __init__(
+        self, timeout: float, returncode: int, cmd: Union[str, List[str]], output: Any = None, stderr: Any = None
+    ):
         super().__init__(returncode, cmd, output, stderr)
         self.timeout = timeout
 

--- a/gprofiler/exceptions.py
+++ b/gprofiler/exceptions.py
@@ -15,7 +15,7 @@ class ProcessStoppedException(Exception):
 
 
 class CalledProcessError(subprocess.CalledProcessError):
-    def __str__(self):
+    def __str__(self) -> str:
         if self.returncode and self.returncode < 0:
             try:
                 base = f"Command '{self.cmd}' died with {signal.Signals(-self.returncode)!r}."
@@ -36,7 +36,7 @@ class APIError(Exception):
         self.message = message
         self.full_data = full_data
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.message
 
 

--- a/gprofiler/gprofiler_types.py
+++ b/gprofiler/gprofiler_types.py
@@ -13,15 +13,15 @@ ProcessToStackSampleCounters = MutableMapping[int, StackToSampleCount]
 UserArgs = Dict[str, Tuple[int, bool, str]]
 
 
-def positive_integer(value) -> int:
-    value = int(value)
+def positive_integer(value_str: str) -> int:
+    value = int(value_str)
     if value <= 0:
         raise configargparse.ArgumentTypeError("invalid positive integer value: {!r}".format(value))
     return value
 
 
-def nonnegative_integer(value) -> int:
-    value = int(value)
+def nonnegative_integer(value_str: str) -> int:
+    value = int(value_str)
     if value < 0:
         raise configargparse.ArgumentTypeError("invalid non-negative integer value: {!r}".format(value))
     return value

--- a/gprofiler/gprofiler_types.py
+++ b/gprofiler/gprofiler_types.py
@@ -4,7 +4,7 @@
 #
 
 from collections import Counter
-from typing import Dict, MutableMapping, Tuple, Union, Optional
+from typing import Dict, MutableMapping, Optional, Tuple, Union
 
 import configargparse
 

--- a/gprofiler/gprofiler_types.py
+++ b/gprofiler/gprofiler_types.py
@@ -4,7 +4,7 @@
 #
 
 from collections import Counter
-from typing import Dict, MutableMapping, Optional, Tuple, Union
+from typing import Dict, MutableMapping, Optional, Union
 
 import configargparse
 

--- a/gprofiler/gprofiler_types.py
+++ b/gprofiler/gprofiler_types.py
@@ -4,13 +4,13 @@
 #
 
 from collections import Counter
-from typing import Dict, MutableMapping, Tuple
+from typing import Dict, MutableMapping, Tuple, Union, Optional
 
 import configargparse
 
 StackToSampleCount = Counter
 ProcessToStackSampleCounters = MutableMapping[int, StackToSampleCount]
-UserArgs = Dict[str, Tuple[int, bool, str]]
+UserArgs = Dict[str, Optional[Union[int, bool, str]]]
 
 
 def positive_integer(value_str: str) -> int:

--- a/gprofiler/kernel_messages.py
+++ b/gprofiler/kernel_messages.py
@@ -2,8 +2,11 @@
 # Copyright (c) Granulate. All rights reserved.
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
-from granulate_utils.linux.kernel_messages import DefaultKernelMessagesProvider, EmptyKernelMessagesProvider, \
-    KernelMessagesProvider
+from granulate_utils.linux.kernel_messages import (
+    DefaultKernelMessagesProvider,
+    EmptyKernelMessagesProvider,
+    KernelMessagesProvider,
+)
 
 from gprofiler.log import get_logger_adapter
 

--- a/gprofiler/kernel_messages.py
+++ b/gprofiler/kernel_messages.py
@@ -2,7 +2,8 @@
 # Copyright (c) Granulate. All rights reserved.
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
-from granulate_utils.linux.kernel_messages import DefaultKernelMessagesProvider, EmptyKernelMessagesProvider
+from granulate_utils.linux.kernel_messages import DefaultKernelMessagesProvider, EmptyKernelMessagesProvider, \
+    KernelMessagesProvider
 
 from gprofiler.log import get_logger_adapter
 
@@ -17,7 +18,7 @@ class GProfilerKernelMessagesProvider(DefaultKernelMessagesProvider):  # type: i
         logger.warning("Missed some kernel messages.")
 
 
-def get_kernel_messages_provider():
+def get_kernel_messages_provider() -> KernelMessagesProvider:
     if DefaultKernelMessagesProvider is EmptyKernelMessagesProvider:
         logger.info("Profilee error monitoring is not supported for this system.")
         return DefaultKernelMessagesProvider()

--- a/gprofiler/kernel_messages.py
+++ b/gprofiler/kernel_messages.py
@@ -14,7 +14,7 @@ logger = get_logger_adapter(__name__)
 # themselves (which is what we do here).
 # see https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
 class GProfilerKernelMessagesProvider(DefaultKernelMessagesProvider):  # type: ignore
-    def on_missed(self):
+    def on_missed(self) -> None:
         logger.warning("Missed some kernel messages.")
 
 

--- a/gprofiler/log.py
+++ b/gprofiler/log.py
@@ -14,8 +14,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, MutableMapping, Optional, Tup
 
 from requests import RequestException
 
-from gprofiler.exceptions import APIError
-from gprofiler.state import State, UninitializedStateException, get_state
+from gprofiler.exceptions import APIError, UninitializedStateException
+from gprofiler.state import State, get_state
 
 if TYPE_CHECKING:
     from gprofiler.client import APIClient
@@ -75,28 +75,28 @@ class GProfilerLoggingAdapter(logging.LoggerAdapter):
         logging_kwargs["extra"] = extra
         return msg, logging_kwargs
 
-    def debug(self, msg: Any, *args, no_server_log: bool = False, **kwargs) -> None:
+    def debug(self, msg: Any, *args: Any, no_server_log: bool = False, **kwargs: Any) -> None:
         super().debug(msg, *args, no_server_log=no_server_log, **kwargs)
 
-    def info(self, msg: Any, *args, no_server_log: bool = False, **kwargs) -> None:
+    def info(self, msg: Any, *args: Any, no_server_log: bool = False, **kwargs: Any) -> None:
         super().info(msg, *args, no_server_log=no_server_log, **kwargs)
 
-    def warning(self, msg: Any, *args, no_server_log: bool = False, **kwargs) -> None:
+    def warning(self, msg: Any, *args: Any, no_server_log: bool = False, **kwargs: Any) -> None:
         super().warning(msg, *args, no_server_log=no_server_log, **kwargs)
 
-    def warn(self, msg: Any, *args, no_server_log: bool = False, **kwargs) -> None:
+    def warn(self, msg: Any, *args: Any, no_server_log: bool = False, **kwargs: Any) -> None:
         super().warn(msg, *args, no_server_log=no_server_log, **kwargs)
 
-    def error(self, msg: Any, *args, no_server_log: bool = False, **kwargs) -> None:
+    def error(self, msg: Any, *args: Any, no_server_log: bool = False, **kwargs: Any) -> None:
         super().error(msg, *args, no_server_log=no_server_log, **kwargs)
 
-    def exception(self, msg: Any, *args, no_server_log: bool = False, **kwargs) -> None:
+    def exception(self, msg: Any, *args: Any, no_server_log: bool = False, **kwargs: Any) -> None:
         super().exception(msg, *args, no_server_log=no_server_log, **kwargs)
 
-    def critical(self, msg: Any, *args, no_server_log: bool = False, **kwargs) -> None:
+    def critical(self, msg: Any, *args: Any, no_server_log: bool = False, **kwargs: Any) -> None:
         super().critical(msg, *args, no_server_log=no_server_log, **kwargs)
 
-    def log(self, level: int, msg: Any, *args, no_server_log: bool = False, **kwargs) -> None:
+    def log(self, level: int, msg: Any, *args: Any, no_server_log: bool = False, **kwargs: Any) -> None:
         super().log(level, msg, *args, no_server_log=no_server_log, **kwargs)
 
 
@@ -120,7 +120,7 @@ class RemoteLogsHandler(logging.Handler):
         # The formatter is needed to format tracebacks
         self.setFormatter(logging.Formatter())
 
-    def init_api_client(self, api_client: "APIClient"):
+    def init_api_client(self, api_client: "APIClient") -> None:
         self._api_client = api_client
 
     def emit(self, record: LogRecord) -> None:
@@ -134,7 +134,7 @@ class RemoteLogsHandler(logging.Handler):
             self._truncated = True
             self._logs[: -self.MAX_BUFFERED_RECORDS] = []
 
-    def _make_dict_record(self, record: LogRecord):
+    def _make_dict_record(self, record: LogRecord) -> Dict[str, Any]:
         formatted_timestamp = datetime.datetime.utcfromtimestamp(record.created).isoformat()
         extra = record.gprofiler_adapter_extra  # type: ignore
 
@@ -177,7 +177,7 @@ class RemoteLogsHandler(logging.Handler):
             CYCLE_ID_KEY: cycle_id,
         }
 
-    def try_send_log_to_server(self):
+    def try_send_log_to_server(self) -> None:
         assert self._api_client is not None, "APIClient is not initialized, can't send logs to server"
         # Snapshot the current num logs because logs list might be extended meanwhile.
         logs_count = len(self._logs)

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -249,10 +249,10 @@ class GProfiler:
         process_profilers_futures = []
         for prof in self.process_profilers:
             prof_future = self._executor.submit(prof.snapshot)
-            prof_future.name = prof.name  # type: ignore
+            prof_future.name = prof.name  # type: ignore # hack, add the profiler's name to the Future object
             process_profilers_futures.append(prof_future)
         system_future = self._executor.submit(self.system_profiler.snapshot)
-        system_future.name = "system"  # type: ignore
+        system_future.name = "system"  # type: ignore # hack, add the profiler's name to the Future object
 
         process_profiles: ProcessToStackSampleCounters = {}
         for future in concurrent.futures.as_completed(process_profilers_futures):

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -13,8 +13,8 @@ import sys
 import time
 from pathlib import Path
 from threading import Event
-from types import FrameType
-from typing import Iterable, Optional, cast, Any
+from types import FrameType, TracebackType
+from typing import Iterable, Optional, cast, Any, Type
 
 import configargparse
 from granulate_utils.linux.ns import is_running_in_init_pid
@@ -146,7 +146,8 @@ class GProfiler:
         self.start()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException],
+                 exc_ctb: Optional[TracebackType]) -> None:
         self.stop()
 
     def _update_last_output(self, last_output_name: str, output_path: str) -> None:
@@ -265,7 +266,8 @@ class GProfiler:
             )
             raise
         metadata = (
-            get_current_metadata(self._static_metadata) if self._collect_metadata else {"hostname": get_hostname()}
+            get_current_metadata(cast(Metadata, self._static_metadata)) if self._collect_metadata
+            else {"hostname": get_hostname()}
         )
         metrics = self._system_metrics_monitor.get_metrics()
         if NoopProfiler.is_noop_profiler(self.system_profiler):

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -272,7 +272,8 @@ class GProfiler:
             )
             raise
         metadata = (
-            get_current_metadata(cast(Metadata, self._static_metadata)) if self._collect_metadata
+            get_current_metadata(cast(Metadata, self._static_metadata))
+            if self._collect_metadata
             else {"hostname": get_hostname()}
         )
         metrics = self._system_metrics_monitor.get_metrics()

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -14,7 +14,7 @@ import time
 from pathlib import Path
 from threading import Event
 from types import FrameType, TracebackType
-from typing import Iterable, Optional, cast, Any, Type
+from typing import Any, Iterable, Optional, Type, cast
 
 import configargparse
 from granulate_utils.linux.ns import is_running_in_init_pid
@@ -25,14 +25,14 @@ from requests import RequestException, Timeout
 from gprofiler import __version__, merge
 from gprofiler.client import DEFAULT_UPLOAD_TIMEOUT, GRANULATE_SERVER_HOST, APIClient
 from gprofiler.docker_client import DockerClient
-from gprofiler.exceptions import SystemProfilerInitFailure, APIError
-from gprofiler.gprofiler_types import UserArgs, positive_integer, ProcessToStackSampleCounters
+from gprofiler.exceptions import APIError, SystemProfilerInitFailure
+from gprofiler.gprofiler_types import ProcessToStackSampleCounters, UserArgs, positive_integer
 from gprofiler.log import RemoteLogsHandler, initial_root_logger_setup
 from gprofiler.metadata.metadata_collector import get_current_metadata, get_static_metadata
 from gprofiler.metadata.metadata_type import Metadata
 from gprofiler.metadata.system_metadata import get_hostname, get_run_mode, get_static_system_info
 from gprofiler.profilers.factory import get_profilers
-from gprofiler.profilers.profiler_base import NoopProfiler, ProfilerInterface, ProcessProfilerBase
+from gprofiler.profilers.profiler_base import NoopProfiler, ProcessProfilerBase, ProfilerInterface
 from gprofiler.profilers.registry import get_profilers_registry
 from gprofiler.state import State, init_state
 from gprofiler.system_metrics import NoopSystemMetricsMonitor, SystemMetricsMonitor, SystemMetricsMonitorBase
@@ -146,8 +146,12 @@ class GProfiler:
         self.start()
         return self
 
-    def __exit__(self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException],
-                 exc_ctb: Optional[TracebackType]) -> None:
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_ctb: Optional[TracebackType],
+    ) -> None:
         self.stop()
 
     def _update_last_output(self, last_output_name: str, output_path: str) -> None:

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -260,7 +260,8 @@ class GProfiler:
             try:
                 process_profiles.update(future.result())
             except Exception:
-                logger.exception(f"{future.name} profiling failed")  # type: ignore
+                future_name = future.name  # type: ignore # hack, add the profiler's name to the Future object
+                logger.exception(f"{future_name} profiling failed")
 
         local_end_time = local_start_time + datetime.timedelta(seconds=(time.monotonic() - monotonic_start_time))
 

--- a/gprofiler/merge.py
+++ b/gprofiler/merge.py
@@ -137,7 +137,7 @@ def add_highest_avg_depth_stacks_per_process(
     fp_perf: ProcessToStackSampleCounters,
     fp_to_dwarf_sample_ratio: float,
     merged_pid_to_stacks_counters: ProcessToStackSampleCounters,
-):
+) -> None:
     for pid, fp_collapsed_stacks_counters in fp_perf.items():
         if pid not in dwarf_perf:
             merged_pid_to_stacks_counters[pid] = fp_collapsed_stacks_counters
@@ -224,7 +224,7 @@ def _make_profile_metadata(
     return "# " + json.dumps(profile_metadata)
 
 
-def _get_container_name(pid: int, docker_client: Optional[DockerClient], add_container_names: bool):
+def _get_container_name(pid: int, docker_client: Optional[DockerClient], add_container_names: bool) -> str:
     return docker_client.get_container_name(pid) if add_container_names and docker_client is not None else ""
 
 

--- a/gprofiler/metadata/py_module_version.py
+++ b/gprofiler/metadata/py_module_version.py
@@ -172,7 +172,7 @@ def _get_python_full_version(process: Process) -> Optional[str]:
 _STANDARD_LIB_PATTERN = re.compile(r"/python\d\.\d\d?/(?!.*(site|dist)-packages)")
 
 
-def _populate_standard_libs_version(result: Dict[str, Optional[Tuple[str, str]]], process: Process):
+def _populate_standard_libs_version(result: Dict[str, Optional[Tuple[str, str]]], process: Process) -> None:
     py_version = None
 
     for path in result:
@@ -213,7 +213,7 @@ def _get_packages_files(process: Process, packages_path: str) -> Dict[str, Tuple
 _warned_no__normalized_cached = False
 
 
-def _populate_packages_versions(packages_versions: Dict[str, Optional[Tuple[str, str]]], process: Process):
+def _populate_packages_versions(packages_versions: Dict[str, Optional[Tuple[str, str]]], process: Process) -> None:
     # A little monkey patch to prevent pkg_resources from converting "/proc/{pid}/root/" to "/".
     # This function resolves symlinks and makes paths absolute for comparison purposes which isn't required
     # for our usage.

--- a/gprofiler/metadata/py_module_version.py
+++ b/gprofiler/metadata/py_module_version.py
@@ -17,7 +17,7 @@ from typing import Dict, Iterator, Optional, Tuple
 
 # pkg_resources is a part of setuptools, but it has a standalone deprecated version. That's the version mypy
 # is looking for, but the stubs there are extremely deprecated
-import pkg_resources  # type: ignore
+import pkg_resources
 from granulate_utils.linux.ns import get_mnt_ns_ancestor, resolve_host_path
 from psutil import AccessDenied, NoSuchProcess, Process
 
@@ -46,7 +46,7 @@ def _get_packages_dir(file_path: str) -> Optional[str]:
 def _get_metadata(dist: pkg_resources.Distribution) -> Dict[str, str]:
     """Based on pip._internal.utils.get_metadata"""
     metadata_name = "METADATA"
-    if isinstance(dist, pkg_resources.DistInfoDistribution) and dist.has_metadata(metadata_name):
+    if isinstance(dist, pkg_resources.DistInfoDistribution) and dist.has_metadata(metadata_name):  # type: ignore
         metadata = dist.get_metadata(metadata_name)
     elif dist.has_metadata("PKG-INFO"):
         metadata_name = "PKG-INFO"
@@ -109,7 +109,7 @@ def _files_from_legacy(dist: pkg_resources.Distribution) -> Optional[Iterator[st
         return None
     paths = (p for p in text.splitlines(keepends=False) if p)
     root = dist.location
-    info = dist.egg_info
+    info = dist.egg_info  # type: ignore
     if root is None or info is None:
         return paths
     try:
@@ -186,8 +186,8 @@ def _populate_standard_libs_version(result: Dict[str, Optional[Tuple[str, str]]]
             if py_version is None:
                 # No need to continue trying if we failed
                 return
-        # (mypy fails to understand that py_version isn't Optional at this point)
-        result[path] = ("standard-library", py_version)  # type: ignore
+
+        result[path] = ("standard-library", py_version)
 
 
 @functools.lru_cache(maxsize=128)
@@ -218,8 +218,8 @@ def _populate_packages_versions(packages_versions: Dict[str, Optional[Tuple[str,
     # This function resolves symlinks and makes paths absolute for comparison purposes which isn't required
     # for our usage.
     if hasattr(pkg_resources, "_normalize_cached"):
-        original__normalize_cache = pkg_resources._normalize_cached
-        pkg_resources._normalize_cached = lambda path: path
+        original__normalize_cache = pkg_resources._normalize_cached  # type: ignore
+        pkg_resources._normalize_cached = lambda path: path  # type: ignore
     else:
         global _warned_no__normalized_cached
         if not _warned_no__normalized_cached:
@@ -249,7 +249,7 @@ def _populate_packages_versions(packages_versions: Dict[str, Optional[Tuple[str,
                 packages_versions[module_path] = package_info
     finally:
         # Don't forget to restore the original implementation in case someone else uses this function
-        pkg_resources._normalize_cached = original__normalize_cache
+        pkg_resources._normalize_cached = original__normalize_cache  # type: ignore
 
 
 _exceptions_logged = 0

--- a/gprofiler/metadata/system_metadata.py
+++ b/gprofiler/metadata/system_metadata.py
@@ -114,7 +114,7 @@ def get_mac_address() -> str:
     outbytes = struct.unpack("iL", fcntl.ioctl(s.fileno(), 0x8912, ifconf))[0]  # SIOCGIFCONF
     data = buf.tobytes()[:outbytes]
     for index in range(0, len(data), SIZE_OF_STUCT_ifreq):
-        iface = data[index : index + SIZE_OF_STUCT_ifreq]
+        iface = data[index: index + SIZE_OF_STUCT_ifreq]
 
         # iface is now a struct ifreq which starts with the interface name.
         # we can use it for further calls.
@@ -181,7 +181,8 @@ def get_static_system_info() -> SystemInfo:
         kernel_version=uname.version,
         system_name=uname.system,
         processors=cpu_count,
-        memory_capacity_mb=round(psutil.virtual_memory().total / 1024 / 1024),  # type: ignore
+        memory_capacity_mb=round(psutil.virtual_memory().total / 1024 / 1024),  # type: ignore # virtual_memory doesn't
+        # have a return type is types-psutil
         hostname=hostname,
         os_name=os_name,
         os_release=os_release,

--- a/gprofiler/metadata/system_metadata.py
+++ b/gprofiler/metadata/system_metadata.py
@@ -11,13 +11,14 @@ import sys
 import time
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Dict, Optional, Tuple, Any
+from typing import Dict, Optional, Tuple, Any, cast
 
 import distro  # type: ignore
 import psutil
 
 from gprofiler.log import get_logger_adapter
-from gprofiler.utils import is_pyinstaller, run_in_ns, run_process
+from gprofiler.utils import is_pyinstaller, run_process
+from granulate_utils.linux.ns import run_in_ns
 
 logger = get_logger_adapter(__name__)
 hostname: Optional[str] = None
@@ -84,7 +85,7 @@ def get_local_ip() -> str:
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
         s.connect(("8.8.8.8", 53))
-        return s.getsockname()[0]
+        return cast(str, s.getsockname()[0])
     except socket.error:
         return "unknown"
     finally:
@@ -124,8 +125,8 @@ def get_mac_address() -> str:
 
         # okay, not loopback, get its MAC address.
         res = fcntl.ioctl(s.fileno(), 0x8927, iface)  # SIOCGIFHWADDR
-        address = struct.unpack(f"{IFNAMSIZ}sH{MAC_BYTES_LEN}s", res[: IFNAMSIZ + SIZE_OF_SHORT + MAC_BYTES_LEN])[2]
-        mac = struct.unpack(f"{MAC_BYTES_LEN}B", address)
+        address_bytes = struct.unpack(f"{IFNAMSIZ}sH{MAC_BYTES_LEN}s", res[: IFNAMSIZ + SIZE_OF_SHORT + MAC_BYTES_LEN])[2]
+        mac = struct.unpack(f"{MAC_BYTES_LEN}B", address_bytes)
         address = ":".join(["%02X" % i for i in mac])
         return address
 

--- a/gprofiler/metadata/system_metadata.py
+++ b/gprofiler/metadata/system_metadata.py
@@ -11,14 +11,14 @@ import sys
 import time
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Dict, Optional, Tuple, Any, cast
+from typing import Any, Dict, Optional, Tuple, cast
 
 import distro  # type: ignore
 import psutil
+from granulate_utils.linux.ns import run_in_ns
 
 from gprofiler.log import get_logger_adapter
 from gprofiler.utils import is_pyinstaller, run_process
-from granulate_utils.linux.ns import run_in_ns
 
 logger = get_logger_adapter(__name__)
 hostname: Optional[str] = None

--- a/gprofiler/metadata/system_metadata.py
+++ b/gprofiler/metadata/system_metadata.py
@@ -11,7 +11,7 @@ import sys
 import time
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple, Any
 
 import distro  # type: ignore
 import psutil
@@ -198,7 +198,7 @@ def get_hostname() -> str:
     return hostname
 
 
-def _initialize_system_info():
+def _initialize_system_info() -> Any:
     # initialized first
     global hostname
     hostname = "<unknown>"
@@ -210,7 +210,7 @@ def _initialize_system_info():
     # move to host mount NS for distro & ldd.
     # now, distro will read the files on host.
     # also move to host UTS NS for the hostname.
-    def get_infos():
+    def get_infos() -> Any:
         nonlocal distribution, libc_version, mac_address, local_ip
         global hostname
 

--- a/gprofiler/metadata/system_metadata.py
+++ b/gprofiler/metadata/system_metadata.py
@@ -125,7 +125,9 @@ def get_mac_address() -> str:
 
         # okay, not loopback, get its MAC address.
         res = fcntl.ioctl(s.fileno(), 0x8927, iface)  # SIOCGIFHWADDR
-        address_bytes = struct.unpack(f"{IFNAMSIZ}sH{MAC_BYTES_LEN}s", res[: IFNAMSIZ + SIZE_OF_SHORT + MAC_BYTES_LEN])[2]
+        address_bytes = struct.unpack(f"{IFNAMSIZ}sH{MAC_BYTES_LEN}s", res[: IFNAMSIZ + SIZE_OF_SHORT + MAC_BYTES_LEN])[
+            2
+        ]
         mac = struct.unpack(f"{MAC_BYTES_LEN}B", address_bytes)
         address = ":".join(["%02X" % i for i in mac])
         return address

--- a/gprofiler/metadata/system_metadata.py
+++ b/gprofiler/metadata/system_metadata.py
@@ -114,7 +114,7 @@ def get_mac_address() -> str:
     outbytes = struct.unpack("iL", fcntl.ioctl(s.fileno(), 0x8912, ifconf))[0]  # SIOCGIFCONF
     data = buf.tobytes()[:outbytes]
     for index in range(0, len(data), SIZE_OF_STUCT_ifreq):
-        iface = data[index: index + SIZE_OF_STUCT_ifreq]
+        iface = data[index : index + SIZE_OF_STUCT_ifreq]
 
         # iface is now a struct ifreq which starts with the interface name.
         # we can use it for further calls.

--- a/gprofiler/metadata/system_metadata.py
+++ b/gprofiler/metadata/system_metadata.py
@@ -179,7 +179,7 @@ def get_static_system_info() -> SystemInfo:
         kernel_version=uname.version,
         system_name=uname.system,
         processors=cpu_count,
-        memory_capacity_mb=round(psutil.virtual_memory().total / 1024 / 1024),
+        memory_capacity_mb=round(psutil.virtual_memory().total / 1024 / 1024),  # type: ignore
         hostname=hostname,
         os_name=os_name,
         os_release=os_release,

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -60,7 +60,7 @@ from gprofiler.utils.perf import can_i_use_perf_events
 logger = get_logger_adapter(__name__)
 
 
-def frequency_to_ap_interval(frequency: int):
+def frequency_to_ap_interval(frequency: int) -> int:
     # async-profiler accepts interval between samples (nanoseconds)
     return int((1 / frequency) * 1_000_000_000)
 

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -14,7 +14,8 @@ from itertools import dropwhile
 from pathlib import Path
 from subprocess import CompletedProcess
 from threading import Event
-from typing import List, Optional, Set, Any, cast
+from types import TracebackType
+from typing import List, Optional, Set, Any, cast, Type
 
 import psutil
 from granulate_utils.java import (
@@ -201,7 +202,8 @@ class AsyncProfiledProcess:
 
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException],
+                 exc_ctb: Optional[TracebackType]) -> None:
         # ignore_errors because we are deleting paths via /proc/pid/root - and the pid
         # we're using might have gone down already.
         # remove them as best effort.
@@ -807,7 +809,7 @@ class JavaProfiler(ProcessProfilerBase):
         super().start()
         try:
             # needs to run in init net NS - see netlink_kernel_create() call on init_net in cn_init().
-            run_in_ns(["net"], lambda: proc_events.register_exit_callback(self._proc_exit_callback), 1)
+            run_in_ns(["net"], lambda: proc_events.register_exit_callback(self._proc_exit_callback), 1)  # type: ignore
         except Exception:
             logger.warning("Failed to enable proc_events listener for exited Java processes", exc_info=True)
         else:

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from subprocess import CompletedProcess
 from threading import Event
 from types import TracebackType
-from typing import Any, List, Optional, Set, Type, cast
+from typing import Any, List, Optional, Set, Type
 
 import psutil
 from granulate_utils.java import (
@@ -103,7 +103,9 @@ SUPPORTED_AP_MODES = ["cpu", "itimer"]
 
 
 class JattachException(CalledProcessError):
-    def __init__(self, returncode: int, cmd: Any, stdout: Any, stderr: Any, target_pid: int, ap_log: str, is_loaded: bool):
+    def __init__(
+        self, returncode: int, cmd: Any, stdout: Any, stderr: Any, target_pid: int, ap_log: str, is_loaded: bool
+    ):
         super().__init__(returncode, cmd, stdout, stderr)
         self._target_pid = target_pid
         self._ap_log = ap_log

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from subprocess import CompletedProcess
 from threading import Event
 from types import TracebackType
-from typing import Any, List, Optional, Set, Type, TypeVar
+from typing import Any, List, Optional, Set, Type, TypeVar, cast
 
 import psutil
 from granulate_utils.java import (
@@ -846,7 +846,7 @@ class JavaProfiler(ProcessProfilerBase):
         super().start()
         try:
             # needs to run in init net NS - see netlink_kernel_create() call on init_net in cn_init().
-            run_in_ns(["net"], lambda: proc_events.register_exit_callback(self._proc_exit_callback), 1)  # type: ignore
+            run_in_ns(["net"], lambda: cast(None, proc_events.register_exit_callback(self._proc_exit_callback)), 1)
         except Exception:
             logger.warning("Failed to enable proc_events listener for exited Java processes", exc_info=True)
         else:

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from subprocess import CompletedProcess
 from threading import Event
 from types import TracebackType
-from typing import Any, List, Optional, Set, Type
+from typing import Any, List, Optional, Set, Type, TypeVar
 
 import psutil
 from granulate_utils.java import (
@@ -137,6 +137,9 @@ def get_ap_version() -> str:
     return Path(resource_path("java/async-profiler-version")).read_text()
 
 
+T = TypeVar("T", bound="AsyncProfiledProcess")
+
+
 class AsyncProfiledProcess:
     """
     Represents a process profiled with async-profiler.
@@ -206,7 +209,7 @@ class AsyncProfiledProcess:
         self._ap_safemode = ap_safemode
         self._ap_args = ap_args
 
-    def __enter__(self) -> "AsyncProfiledProcess":
+    def __enter__(self: T) -> T:
         os.makedirs(self._ap_dir_host, 0o755, exist_ok=True)
         os.makedirs(self._storage_dir_host, 0o755, exist_ok=True)
 

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from subprocess import CompletedProcess
 from threading import Event
 from types import TracebackType
-from typing import List, Optional, Set, Any, cast, Type
+from typing import Any, List, Optional, Set, Type, cast
 
 import psutil
 from granulate_utils.java import (
@@ -220,8 +220,12 @@ class AsyncProfiledProcess:
 
         return self
 
-    def __exit__(self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException],
-                 exc_ctb: Optional[TracebackType]) -> None:
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_ctb: Optional[TracebackType],
+    ) -> None:
         # ignore_errors because we are deleting paths via /proc/pid/root - and the pid
         # we're using might have gone down already.
         # remove them as best effort.

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -11,7 +11,8 @@ from typing import List, Optional
 
 from gprofiler.exceptions import StopEventSetException
 from gprofiler.log import get_logger_adapter
-from gprofiler.merge import ProcessToStackSampleCounters, merge_global_perfs
+from gprofiler.merge import merge_global_perfs
+from gprofiler.gprofiler_types import ProcessToStackSampleCounters
 from gprofiler.profilers.profiler_base import ProfilerBase
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
 from gprofiler.utils import resource_path, run_process, start_process, wait_event, wait_for_file_by_prefix

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -10,9 +10,9 @@ from threading import Event
 from typing import List, Optional
 
 from gprofiler.exceptions import StopEventSetException
+from gprofiler.gprofiler_types import ProcessToStackSampleCounters
 from gprofiler.log import get_logger_adapter
 from gprofiler.merge import merge_global_perfs
-from gprofiler.gprofiler_types import ProcessToStackSampleCounters
 from gprofiler.profilers.profiler_base import ProfilerBase
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
 from gprofiler.utils import run_process, start_process, wait_event, wait_for_file_by_prefix

--- a/gprofiler/profilers/php.py
+++ b/gprofiler/profilers/php.py
@@ -108,10 +108,11 @@ class PHPSpyProfiler(ProfilerBase):
             self._process = process
 
         # Set the stderr fd as non-blocking so the read operation on it won't block if no data is available.
+        assert self._process.stderr is not None
         fcntl.fcntl(
-            self._process.stderr.fileno(),  # type: ignore
+            self._process.stderr.fileno(),
             fcntl.F_SETFL,
-            fcntl.fcntl(self._process.stderr.fileno(), fcntl.F_GETFL) | os.O_NONBLOCK,  # type: ignore
+            fcntl.fcntl(self._process.stderr.fileno(), fcntl.F_GETFL) | os.O_NONBLOCK,
         )
 
         # Ignoring type since _process.stderr is typed as Optional[IO[Any]] which doesn't have the `read1` method.

--- a/gprofiler/profilers/php.py
+++ b/gprofiler/profilers/php.py
@@ -12,7 +12,7 @@ from functools import lru_cache
 from pathlib import Path
 from subprocess import Popen
 from threading import Event
-from typing import List, Optional, Pattern
+from typing import List, Optional, Pattern, cast
 
 from gprofiler.exceptions import StopEventSetException
 from gprofiler.gprofiler_types import ProcessToStackSampleCounters
@@ -109,9 +109,9 @@ class PHPSpyProfiler(ProfilerBase):
 
         # Set the stderr fd as non-blocking so the read operation on it won't block if no data is available.
         fcntl.fcntl(
-            self._process.stderr.fileno(),
+            self._process.stderr.fileno(),  # type: ignore
             fcntl.F_SETFL,
-            fcntl.fcntl(self._process.stderr.fileno(), fcntl.F_GETFL) | os.O_NONBLOCK,
+            fcntl.fcntl(self._process.stderr.fileno(), fcntl.F_GETFL) | os.O_NONBLOCK,  # type: ignore
         )
 
         # Ignoring type since _process.stderr is typed as Optional[IO[Any]] which doesn't have the `read1` method.
@@ -161,7 +161,7 @@ class PHPSpyProfiler(ProfilerBase):
                 raise CorruptedPHPSpyOutputException(
                     f"Couldn't extract metadata via regex '{re_expr.pattern}', line '{metadata_line}'"
                 )
-            return match.group(1)
+            return cast(str, match.group(1))
 
         results: ProcessToStackSampleCounters = defaultdict(Counter)
 

--- a/gprofiler/profilers/php.py
+++ b/gprofiler/profilers/php.py
@@ -69,7 +69,7 @@ class PHPSpyProfiler(ProfilerBase):
         self._output_path = Path(self._storage_dir) / f"phpspy.{random_prefix()}.col"
         self._process_filter = php_process_filter
 
-    def start(self):
+    def start(self) -> None:
         logger.info("Starting profiling of PHP processes with phpspy")
         phpspy_path = resource_path(self.PHPSPY_RESOURCE)
         cmd = [
@@ -212,12 +212,12 @@ class PHPSpyProfiler(ProfilerBase):
             self._process = None
         return code
 
-    def stop(self):
+    def stop(self) -> None:
         code = self._terminate()
         if code is not None:
             logger.info("Finished profiling PHP processes with phpspy")
 
-    def _process_stderr(self, stderr: str):
+    def _process_stderr(self, stderr: str) -> None:
         skip_re = self._get_stderr_skip_regex()
         lines = stderr.splitlines()
         for line in lines:

--- a/gprofiler/profilers/profiler_base.py
+++ b/gprofiler/profilers/profiler_base.py
@@ -18,7 +18,7 @@ from gprofiler.utils import limit_frequency
 logger = get_logger_adapter(__name__)
 
 
-T = TypeVar('T', bound='ProfilerInterface')
+T = TypeVar("T", bound="ProfilerInterface")
 
 
 class ProfilerInterface:
@@ -44,8 +44,12 @@ class ProfilerInterface:
         self.start()
         return self
 
-    def __exit__(self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException],
-                 exc_ctb: Optional[TracebackType]) -> None:
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_ctb: Optional[TracebackType],
+    ) -> None:
         self.stop()
 
 

--- a/gprofiler/profilers/profiler_base.py
+++ b/gprofiler/profilers/profiler_base.py
@@ -5,7 +5,8 @@
 
 import concurrent.futures
 from threading import Event
-from typing import List, Optional
+from types import TracebackType
+from typing import List, Optional, Type
 
 from psutil import NoSuchProcess, Process
 
@@ -40,7 +41,8 @@ class ProfilerInterface:
         self.start()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException],
+                 exc_ctb: Optional[TracebackType]) -> None:
         self.stop()
 
 

--- a/gprofiler/profilers/profiler_base.py
+++ b/gprofiler/profilers/profiler_base.py
@@ -40,7 +40,7 @@ class ProfilerInterface:
         self.start()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         self.stop()
 
 

--- a/gprofiler/profilers/profiler_base.py
+++ b/gprofiler/profilers/profiler_base.py
@@ -36,7 +36,7 @@ class ProfilerInterface:
     def stop(self) -> None:
         pass
 
-    def __enter__(self):
+    def __enter__(self) -> "ProfilerInterface":
         self.start()
         return self
 

--- a/gprofiler/profilers/profiler_base.py
+++ b/gprofiler/profilers/profiler_base.py
@@ -6,7 +6,7 @@
 import concurrent.futures
 from threading import Event
 from types import TracebackType
-from typing import List, Optional, Type
+from typing import List, Optional, Type, TypeVar
 
 from psutil import NoSuchProcess, Process
 
@@ -16,6 +16,9 @@ from gprofiler.log import get_logger_adapter
 from gprofiler.utils import limit_frequency
 
 logger = get_logger_adapter(__name__)
+
+
+T = TypeVar('T', bound='ProfilerInterface')
 
 
 class ProfilerInterface:
@@ -37,7 +40,7 @@ class ProfilerInterface:
     def stop(self) -> None:
         pass
 
-    def __enter__(self) -> "ProfilerInterface":
+    def __enter__(self: T) -> T:
         self.start()
         return self
 

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -336,7 +336,9 @@ class PythonEbpfProfiler(ProfilerBase):
             wait_event(self._POLL_TIMEOUT, self._stop_event, lambda: os.path.exists(self.output_path))
         except TimeoutError:
             process.kill()
-            logger.error(f"PyPerf failed to start. stdout {process.stdout.read()!r} stderr {process.stderr.read()!r}")  # type: ignore
+            stdout = process.stdout.read()  # type: ignore
+            stderr = process.stderr.read()  # type: ignore
+            logger.error(f"PyPerf failed to start. stdout {stdout!r} stderr {stderr!r}")
             raise
         else:
             self.process = process

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -9,10 +9,9 @@ import resource
 import signal
 from collections import Counter, defaultdict
 from pathlib import Path
-from re import Match
 from subprocess import Popen
 from threading import Event
-from typing import Dict, List, NoReturn, Optional, cast
+from typing import Dict, List, Match, NoReturn, Optional, cast
 
 from granulate_utils.linux.process import is_process_running, process_exe
 from psutil import NoSuchProcess, Process

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -335,8 +335,9 @@ class PythonEbpfProfiler(ProfilerBase):
             wait_event(self._POLL_TIMEOUT, self._stop_event, lambda: os.path.exists(self.output_path))
         except TimeoutError:
             process.kill()
-            stdout = process.stdout.read()  # type: ignore
-            stderr = process.stderr.read()  # type: ignore
+            assert process.stdout is not None and process.stderr is not None
+            stdout = process.stdout.read()
+            stderr = process.stderr.read()
             logger.error(f"PyPerf failed to start. stdout {stdout!r} stderr {stderr!r}")
             raise
         else:

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from re import Match
 from subprocess import Popen
 from threading import Event
-from typing import Dict, List, Optional, NoReturn, cast
+from typing import Dict, List, NoReturn, Optional, cast
 
 from granulate_utils.linux.process import is_process_running, process_exe
 from psutil import NoSuchProcess, Process

--- a/gprofiler/profilers/registry.py
+++ b/gprofiler/profilers/registry.py
@@ -35,14 +35,14 @@ class ProfilerArgument:
 class ProfilerConfig:
     def __init__(
         self,
-        profiler_mode_help: str,
-        disablement_help: str,
-        profiler_class,
+        profiler_mode_help: Optional[str],
+        disablement_help: Optional[str],
+        profiler_class: Any,
         possible_modes: List[str],
         supported_archs: List[str],
         default_mode: str = "enabled",
         arguments: List[ProfilerArgument] = None,
-    ):
+    ) -> None:
         self.profiler_mode_help = profiler_mode_help
         self.possible_modes = possible_modes
         self.supported_archs = supported_archs
@@ -63,7 +63,7 @@ def register_profiler(
     profiler_mode_argument_help: Optional[str] = None,
     profiler_arguments: Optional[List[ProfilerArgument]] = None,
     disablement_help: Optional[str] = None,
-):
+) -> Any:
     if profiler_mode_argument_help is None:
         profiler_mode_argument_help = (
             f"Choose the mode for profiling {profiler_name} processes. '{default_mode}'"
@@ -74,7 +74,7 @@ def register_profiler(
     if disablement_help is None:
         disablement_help = f"Disable the runtime-profiling of {profiler_name} processes"
 
-    def profiler_decorator(profiler_class):
+    def profiler_decorator(profiler_class: Any) -> Any:
         assert profiler_name not in profilers_config, f"{profiler_name} is already registered!"
         assert all(
             arg.dest.startswith(profiler_name.lower()) for arg in profiler_arguments or []

--- a/gprofiler/profilers/ruby.py
+++ b/gprofiler/profilers/ruby.py
@@ -34,7 +34,7 @@ class RbSpyProfiler(ProcessProfilerBase):
         super().__init__(frequency, duration, stop_event, storage_dir)
         assert ruby_mode == "rbspy", "Ruby profiler should not be initialized, wrong ruby_mode value given"
 
-    def _make_command(self, pid: int, output_path: str):
+    def _make_command(self, pid: int, output_path: str) -> List[str]:
         return [
             resource_path(self.RESOURCE_PATH),
             "record",

--- a/gprofiler/system_metrics.py
+++ b/gprofiler/system_metrics.py
@@ -70,7 +70,8 @@ class SystemMetricsMonitor(SystemMetricsMonitorBase):
 
     def _continuously_poll_memory(self, polling_rate_seconds: int) -> None:
         while not self._stop_event.is_set():
-            current_ram_percent = psutil.virtual_memory().percent  # type: ignore
+            current_ram_percent = psutil.virtual_memory().percent  # type: ignore # virtual_memory doesn't have a
+            # return type is types-psutil
             self._mem_percentages.append(current_ram_percent)
             self._stop_event.wait(timeout=polling_rate_seconds)
 

--- a/gprofiler/system_metrics.py
+++ b/gprofiler/system_metrics.py
@@ -70,7 +70,7 @@ class SystemMetricsMonitor(SystemMetricsMonitorBase):
 
     def _continuously_poll_memory(self, polling_rate_seconds: int) -> None:
         while not self._stop_event.is_set():
-            current_ram_percent = psutil.virtual_memory().percent
+            current_ram_percent = psutil.virtual_memory().percent  # type: ignore
             self._mem_percentages.append(current_ram_percent)
             self._stop_event.wait(timeout=polling_rate_seconds)
 

--- a/gprofiler/system_metrics.py
+++ b/gprofiler/system_metrics.py
@@ -22,11 +22,11 @@ class Metrics:
 
 class SystemMetricsMonitorBase(metaclass=ABCMeta):
     @abstractmethod
-    def start(self):
+    def start(self) -> None:
         pass
 
     @abstractmethod
-    def stop(self):
+    def stop(self) -> None:
         pass
 
     @abstractmethod
@@ -49,18 +49,18 @@ class SystemMetricsMonitor(SystemMetricsMonitorBase):
         self._polling_rate_seconds = polling_rate_seconds
         self._mem_percentages: List[float] = []
         self._stop_event = stop_event
-        self._thread = None
+        self._thread: Optional[Thread] = None
         self._lock = RLock()
 
         self._get_cpu_utilization()  # Call this once to set the necessary data
 
-    def start(self):
+    def start(self) -> None:
         assert self._thread is None, "SystemMetricsMonitor is already running"
         assert not self._stop_event.is_set(), "Stop condition is already set (perhaps gProfiler was already stopped?)"
         self._thread = Thread(target=self._continuously_poll_memory, args=(self._polling_rate_seconds,))
         self._thread.start()
 
-    def stop(self):
+    def stop(self) -> None:
         assert self._thread is not None, "SystemMetricsMonitor is not running"
         assert self._stop_event.is_set(), "Stop event was not set before stopping the SystemMetricsMonitor"
         self._thread.join(STOP_TIMEOUT_SECONDS)
@@ -68,7 +68,7 @@ class SystemMetricsMonitor(SystemMetricsMonitorBase):
             raise ThreadStopTimeoutError("Timed out while waiting for the SystemMetricsMonitor internal thread to stop")
         self._thread = None
 
-    def _continuously_poll_memory(self, polling_rate_seconds: int):
+    def _continuously_poll_memory(self, polling_rate_seconds: int) -> None:
         while not self._stop_event.is_set():
             current_ram_percent = psutil.virtual_memory().percent
             self._mem_percentages.append(current_ram_percent)
@@ -93,10 +93,10 @@ class SystemMetricsMonitor(SystemMetricsMonitorBase):
 
 
 class NoopSystemMetricsMonitor(SystemMetricsMonitorBase):
-    def start(self):
+    def start(self) -> None:
         pass
 
-    def stop(self):
+    def stop(self) -> None:
         pass
 
     def _get_average_memory_utilization(self) -> Optional[float]:

--- a/gprofiler/usage_loggers.py
+++ b/gprofiler/usage_loggers.py
@@ -15,13 +15,13 @@ CGROUPFS_ROOT = "/sys/fs/cgroup"  # TODO extract from /proc/mounts, this may cha
 
 
 class UsageLoggerInterface:
-    def init_cycles(self):
+    def init_cycles(self) -> None:
         raise NotImplementedError
 
-    def log_cycle(self):
+    def log_cycle(self) -> None:
         raise NotImplementedError
 
-    def log_run(self):
+    def log_run(self) -> None:
         raise NotImplementedError
 
 
@@ -40,11 +40,11 @@ class CpuUsageLogger(UsageLoggerInterface):
         """
         return int(self._cpuacct_usage.read_text())
 
-    def init_cycles(self):
+    def init_cycles(self) -> None:
         self._last_usage = self._read_cgroup_cpu_usage()
         self._last_ts = time.monotonic()
 
-    def log_cycle(self):
+    def log_cycle(self) -> None:
         assert self._last_usage is not None and self._last_ts is not None, "didn't call init_cycles()?"
 
         current_usage = self._read_cgroup_cpu_usage()
@@ -62,7 +62,7 @@ class CpuUsageLogger(UsageLoggerInterface):
         self._last_usage = current_usage
         self._last_ts = current_ts
 
-    def log_run(self):
+    def log_run(self) -> None:
         total_usage = self._read_cgroup_cpu_usage()
         total_usage_s = total_usage / self.NSEC_PER_SEC
         total_ts = time.time() - psutil.Process().create_time()  # uptime of this process
@@ -90,10 +90,10 @@ class MemoryUsageLogger(UsageLoggerInterface):
         """
         return int(self._memory_usage.read_text()), int(self._memory_watermark.read_text())
 
-    def init_cycles(self):
+    def init_cycles(self) -> None:
         self._last_usage, self._last_watermark = self._read_cgroup_memory_usage()
 
-    def log_cycle(self):
+    def log_cycle(self) -> None:
         assert self._last_usage is not None and self._last_watermark is not None, "didn't call init_cycles()?"
 
         current_usage, current_watermark = self._read_cgroup_memory_usage()
@@ -111,7 +111,7 @@ class MemoryUsageLogger(UsageLoggerInterface):
         self._last_usage = current_usage
         self._last_watermark = current_watermark
 
-    def log_run(self):
+    def log_run(self) -> None:
         current_usage, current_watermark = self._read_cgroup_memory_usage()
 
         self._logger.debug(
@@ -126,25 +126,25 @@ class CgroupsUsageLogger(UsageLoggerInterface):
         self._cpu_logger = CpuUsageLogger(logger, cgroup)
         self._memory_logger = MemoryUsageLogger(logger, cgroup)
 
-    def init_cycles(self):
+    def init_cycles(self) -> None:
         self._cpu_logger.init_cycles()
         self._memory_logger.init_cycles()
 
-    def log_cycle(self):
+    def log_cycle(self) -> None:
         self._cpu_logger.log_cycle()
         self._memory_logger.log_cycle()
 
-    def log_run(self):
+    def log_run(self) -> None:
         self._cpu_logger.log_run()
         self._memory_logger.log_run()
 
 
 class NoopUsageLogger(UsageLoggerInterface):
-    def init_cycles(self):
+    def init_cycles(self) -> None:
         pass
 
-    def log_cycle(self):
+    def log_cycle(self) -> None:
         pass
 
-    def log_run(self):
+    def log_run(self) -> None:
         pass

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -210,7 +210,7 @@ def run_process(
     communicate: bool = True,
     stdin: bytes = None,
     **kwargs: Any,
-) -> CompletedProcess:
+) -> "CompletedProcess[bytes]":
     stdout = None
     stderr = None
     with start_process(cmd, via_staticx, **kwargs) as process:
@@ -243,14 +243,14 @@ def run_process(
             raise
         retcode = process.poll()
         assert retcode is not None  # only None if child has not terminated
-    result: CompletedProcess = CompletedProcess(process.args, retcode, stdout, stderr)
+    result: CompletedProcess[bytes] = CompletedProcess(process.args, retcode, stdout, stderr)
 
     logger.debug(f"({process.args!r}) exit code: {result.returncode}")
     if not suppress_log:
         if result.stdout:
-            logger.debug(f"({process.args!r}) stdout: {result.stdout}")
+            logger.debug(f"({process.args!r}) stdout: {result.stdout.decode()}")
         if result.stderr:
-            logger.debug(f"({process.args!r}) stderr: {result.stderr}")
+            logger.debug(f"({process.args!r}) stderr: {result.stderr.decode()}")
     if check and retcode != 0:
         raise CalledProcessError(retcode, process.args, output=stdout, stderr=stderr)
     return result

--- a/gprofiler/utils.py
+++ b/gprofiler/utils.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from subprocess import CompletedProcess, Popen, TimeoutExpired
 from tempfile import TemporaryDirectory
 from threading import Event
-from typing import Callable, Iterator, List, Optional, Tuple, Union
+from typing import Callable, Iterator, List, Optional, Tuple, Union, Any
 
 import importlib_resources
 import psutil
@@ -79,7 +79,7 @@ def get_process_nspid(pid: int) -> Optional[int]:
 libc: Optional[ctypes.CDLL] = None
 
 
-def prctl(*argv):
+def prctl(*argv: Any) -> int:
     global libc
     if libc is None:
         libc = ctypes.CDLL("libc.so.6", use_errno=True)
@@ -99,7 +99,7 @@ def set_child_termination_on_parent_death():
     return ret
 
 
-def wrap_callbacks(callbacks):
+def wrap_callbacks(callbacks) -> Callable:
     # Expects array of callback.
     # Returns one callback that call each one of them, and returns the retval of last callback
     def wrapper():
@@ -112,7 +112,7 @@ def wrap_callbacks(callbacks):
     return wrapper
 
 
-def start_process(cmd: Union[str, List[str]], via_staticx: bool, term_on_parent_death: bool = True, **kwargs) -> Popen:
+def start_process(cmd: Union[str, List[str]], via_staticx: bool, term_on_parent_death: bool = True, **kwargs: Any) -> Popen:
     cmd_text = " ".join(cmd) if isinstance(cmd, list) else cmd
     logger.debug(f"Running command: ({cmd_text})")
     if isinstance(cmd, str):

--- a/gprofiler/utils/__init__.py
+++ b/gprofiler/utils/__init__.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from subprocess import CompletedProcess, Popen, TimeoutExpired
 from tempfile import TemporaryDirectory
 from threading import Event
-from typing import Callable, Iterator, List, Optional, Tuple, Union, Any
+from typing import Any, Callable, Iterator, List, Optional, Tuple, Union
 
 import importlib_resources
 import psutil

--- a/gprofiler/utils/__init__.py
+++ b/gprofiler/utils/__init__.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from subprocess import CompletedProcess, Popen, TimeoutExpired
 from tempfile import TemporaryDirectory
 from threading import Event
-from typing import Any, Callable, Iterator, List, Optional, Tuple, Union
+from typing import Any, Callable, Iterator, List, Optional, Tuple, Union, cast
 
 import importlib_resources
 import psutil
@@ -71,7 +71,7 @@ def prctl(*argv: Any) -> int:
     global libc
     if libc is None:
         libc = ctypes.CDLL("libc.so.6", use_errno=True)
-    return libc.prctl(*argv)  # type: ignore
+    return cast(int, libc.prctl(*argv))
 
 
 PR_SET_PDEATHSIG = 1

--- a/gprofiler/utils/__init__.py
+++ b/gprofiler/utils/__init__.py
@@ -100,8 +100,9 @@ def wrap_callbacks(callbacks: List[Callable]) -> Callable:
     return wrapper
 
 
-def start_process(cmd: Union[str, List[str]], via_staticx: bool, term_on_parent_death: bool = True,
-                  **kwargs: Any) -> Popen:
+def start_process(
+    cmd: Union[str, List[str]], via_staticx: bool, term_on_parent_death: bool = True, **kwargs: Any
+) -> Popen:
     cmd_text = " ".join(cmd) if isinstance(cmd, list) else cmd
     logger.debug(f"Running command: ({cmd_text})")
     if isinstance(cmd, str):
@@ -308,7 +309,7 @@ def pgrep_maps(match: str) -> List[Process]:
     processes: List[Process] = []
     for line in result.stdout.splitlines():
         assert line.startswith(b"/proc/") and line.endswith(b"/maps"), f"unexpected 'grep' line: {line!r}"
-        pid = int(line[len(b"/proc/"): -len(b"/maps")])
+        pid = int(line[len(b"/proc/") : -len(b"/maps")])
         try:
             processes.append(Process(pid))
         except psutil.NoSuchProcess:
@@ -328,7 +329,7 @@ def get_iso8601_format_time(time: datetime.datetime) -> str:
 def remove_prefix(s: str, prefix: str) -> str:
     # like str.removeprefix of Python 3.9, but this also ensures the prefix exists.
     assert s.startswith(prefix), f"{s} doesn't start with {prefix}"
-    return s[len(prefix):]
+    return s[len(prefix) :]
 
 
 def touch_path(path: str, mode: int) -> None:
@@ -443,8 +444,9 @@ def reset_umask() -> None:
     os.umask(0o022)
 
 
-def limit_frequency(limit: Optional[int], requested: int, msg_header: str, runtime_logger: logging.LoggerAdapter) \
-        -> int:
+def limit_frequency(
+    limit: Optional[int], requested: int, msg_header: str, runtime_logger: logging.LoggerAdapter
+) -> int:
     if limit is not None and requested > limit:
         runtime_logger.warning(
             f"{msg_header}: Requested frequency ({requested}) is higher than the limit {limit}, "

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,6 +6,8 @@ platform = linux
 strict = True
 no_implicit_optional = False
 disallow_any_generics = False
+warn_redundant_casts = True
+warn_unused_ignores = True
 
 # typeshed package for this one seems outdated: we get "incorrect" type errors when installing
 # types-setuptools

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.7
+python_version = 3.6
 warn_unused_configs = True
 exclude = venv/|deploy/dataflow/|granulate-utils
 platform = linux

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,8 +1,11 @@
 [mypy]
-python_version = 3.6
+python_version = 3.7
 warn_unused_configs = True
 exclude = venv/|deploy/dataflow/|granulate-utils
 platform = linux
+strict = True
+no_implicit_optional = False
+disallow_any_generics = False
 
 # typeshed package for this one seems outdated: we get "incorrect" type errors when installing
 # types-setuptools

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,8 +119,9 @@ def check_app_exited() -> bool:
 
 
 @fixture
-def application_process(in_container: bool, command_line: List[str], check_app_exited: bool)\
-        -> Iterator[Optional[subprocess.Popen]]:
+def application_process(
+    in_container: bool, command_line: List[str], check_app_exited: bool
+) -> Iterator[Optional[subprocess.Popen]]:
     if in_container:
         yield None
         return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,13 +9,15 @@ from contextlib import contextmanager
 from functools import partial
 from pathlib import Path
 from time import sleep
-from typing import Callable, Generator, Iterable, List, Mapping, Optional
+from typing import Callable, Generator, Iterable, List, Mapping, Optional, Iterator, cast, Any
 
 import docker
+
 from docker import DockerClient
 from docker.models.containers import Container
 from docker.models.images import Image
 from psutil import Process
+from pytest import FixtureRequest
 from pytest import fixture
 
 from gprofiler.metadata.application_identifiers import get_application_name
@@ -40,7 +42,7 @@ def profiler_type() -> str:
 
 
 @contextmanager
-def chdir(path):
+def chdir(path: Path) -> Iterator[None]:
     cwd = os.getcwd()
     try:
         os.chdir(path)
@@ -50,8 +52,8 @@ def chdir(path):
 
 
 @fixture(params=[False, True])
-def in_container(request) -> bool:
-    return request.param
+def in_container(request: FixtureRequest) -> bool:
+    return cast(bool, request.param)  # type: ignore
 
 
 @fixture
@@ -89,7 +91,7 @@ def command_line(runtime: str, java_command_line: List[str]) -> List[str]:
 
 
 @fixture
-def gprofiler_exe(request, tmp_path: Path) -> Path:
+def gprofiler_exe(request: FixtureRequest, tmp_path: Path) -> Path:
     precompiled = request.config.getoption("--executable")
     if precompiled is not None:
         return Path(precompiled)
@@ -118,13 +120,14 @@ def check_app_exited() -> bool:
 
 
 @fixture
-def application_process(in_container: bool, command_line: List[str], check_app_exited: bool):
+def application_process(in_container: bool, command_line: List[str], check_app_exited: bool)\
+        -> Iterator[Optional[subprocess.Popen]]:
     if in_container:
         yield None
         return
     else:
         # run as non-root to catch permission errors, etc.
-        def lower_privs():
+        def lower_privs() -> None:
             os.setgid(1000)
             os.setuid(1000)
 
@@ -255,7 +258,7 @@ def output_directory(tmp_path: Path) -> Path:
 def application_pid(
     in_container: bool, application_process: subprocess.Popen, application_docker_container: Container
 ) -> int:
-    pid = application_docker_container.attrs["State"]["Pid"] if in_container else application_process.pid
+    pid: int = application_docker_container.attrs["State"]["Pid"] if in_container else application_process.pid
 
     # Application might be run using "sh -c ...", we detect the case and return the "real" application pid
     process = Process(pid)
@@ -311,7 +314,7 @@ def assert_application_name(application_pid: int, runtime: str, in_container: bo
 
 
 @fixture
-def exec_container_image(request, docker_client: DockerClient) -> Optional[Image]:
+def exec_container_image(request: FixtureRequest, docker_client: DockerClient) -> Optional[Image]:
     image_name = request.config.getoption("--exec-container-image")
     if image_name is None:
         return None
@@ -344,7 +347,7 @@ def profiler_flags(runtime: str, profiler_type: str) -> List[str]:
     return flags
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: Any) -> None:
     parser.addoption("--exec-container-image", action="store", default=None)
     parser.addoption("--executable", action="store", default=None)
 
@@ -360,4 +363,4 @@ def python_version(in_container: bool, application_docker_container: Container) 
         output = subprocess.check_output("python --version", stderr=subprocess.STDOUT, shell=True)
 
     # Output is expected to look like e.g. "Python 3.9.7"
-    return output.decode().strip().split()[-1]
+    return cast(str, output.decode().strip().split()[-1])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ from psutil import Process
 from pytest import FixtureRequest
 from pytest import fixture
 
+from gprofiler.gprofiler_types import StackToSampleCount
 from gprofiler.metadata.application_identifiers import get_application_name
 from tests import CONTAINERS_DIRECTORY, PARENT, PHPSPY_DURATION
 from tests.utils import assert_function_in_collapsed, chmod_path_parts
@@ -286,8 +287,11 @@ def runtime_specific_args(runtime: str) -> List[str]:
     }.get(runtime, [])
 
 
+AssertInCollapsed = Callable[[StackToSampleCount], None]
+
+
 @fixture
-def assert_collapsed(runtime: str) -> Callable[[Mapping[str, int]], None]:
+def assert_collapsed(runtime: str) -> AssertInCollapsed:
     function_name = {
         "java": "Fibonacci.main",
         "python": "burner",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,8 @@ def chdir(path: Path) -> Iterator[None]:
 
 @fixture(params=[False, True])
 def in_container(request: FixtureRequest) -> bool:
-    return cast(bool, request.param)  # type: ignore
+    return cast(bool, request.param)  # type: ignore # SubRequest isn't exported yet,
+    # https://github.com/pytest-dev/pytest/issues/7469
 
 
 @fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,16 +9,14 @@ from contextlib import contextmanager
 from functools import partial
 from pathlib import Path
 from time import sleep
-from typing import Callable, Generator, Iterable, List, Mapping, Optional, Iterator, cast, Any
+from typing import Any, Callable, Generator, Iterable, Iterator, List, Mapping, Optional, cast
 
 import docker
-
 from docker import DockerClient
 from docker.models.containers import Container
 from docker.models.images import Image
 from psutil import Process
-from pytest import FixtureRequest
-from pytest import fixture
+from pytest import FixtureRequest, fixture
 
 from gprofiler.gprofiler_types import StackToSampleCount
 from gprofiler.metadata.application_identifiers import get_application_name

--- a/tests/containers/python/lister.py
+++ b/tests/containers/python/lister.py
@@ -6,23 +6,23 @@
 import os
 from threading import Thread
 
-import yaml  # type: ignore
+import yaml
 
 
-def lister():
+def lister() -> None:
     os.listdir("/")  # have some kernel stacks
 
 
-def burner():
+def burner() -> None:
     while True:  # have some Python stacks
         pass
 
 
-def parser():
+def parser() -> None:
     while True:
         # Have some package stacks.
         # Notice the name of the package name (PyYAML) is different from the name of the module (yaml)
-        yaml.parse("")
+        yaml.parse("")  # type: ignore
 
 
 if __name__ == "__main__":

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -69,7 +69,7 @@ def test_async_profiler_already_running(
             ap_safemode=0,
             ap_args="",
         ) as ap_proc:
-            ap_proc.status_async_profiler()  # type: ignore
+            ap_proc.status_async_profiler()
             # printed the output file, see ACTION_STATUS case in async-profiler/profiler.cpp
             assert "Profiling is running for " in cast_away_optional(ap_proc.read_output())
 
@@ -271,11 +271,11 @@ def test_async_profiler_stops_after_given_timeout(
     ) as ap_proc:
         assert ap_proc.start_async_profiler(frequency_to_ap_interval(11), ap_timeout=timeout_s)
 
-        ap_proc.status_async_profiler()  # type: ignore
+        ap_proc.status_async_profiler()
         assert "Profiling is running for " in cast_away_optional(ap_proc.read_output())
 
         # let the timeout trigger
         time.sleep(timeout_s)
 
-        ap_proc.status_async_profiler()  # type: ignore
+        ap_proc.status_async_profiler()
         assert "Profiler is not active\n" in cast_away_optional(ap_proc.read_output())

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -139,7 +139,8 @@ def test_java_safemode_version_check(
         assert collapsed == Counter({"java;[Profiling skipped: profiling this JVM is not supported]": 1})
 
     log_record = next(filter(lambda r: r.message == "Unsupported JVM version", caplog.records))
-    assert log_record.gprofiler_adapter_extra["jvm_version"] == repr(jvm_version)  # type: ignore
+    log_extra = log_record.gprofiler_adapter_extra  # type: ignore
+    assert log_extra["jvm_version"] == repr(jvm_version)
 
 
 def test_java_safemode_build_number_check(
@@ -157,7 +158,8 @@ def test_java_safemode_build_number_check(
         assert collapsed == Counter({"java;[Profiling skipped: profiling this JVM is not supported]": 1})
 
     log_record = next(filter(lambda r: r.message == "Unsupported JVM version", caplog.records))
-    assert log_record.gprofiler_adapter_extra["jvm_version"] == repr(jvm_version)  # type: ignore
+    log_extra = log_record.gprofiler_adapter_extra  # type: ignore
+    assert log_extra["jvm_version"] == repr(jvm_version)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -11,13 +11,13 @@ from collections import Counter
 from pathlib import Path
 from subprocess import Popen
 from threading import Event
-from typing import Optional, Any
+from typing import Any, Optional
 
 import psutil
 import pytest
 from docker.models.containers import Container
-from pytest import LogCaptureFixture, MonkeyPatch
 from packaging.version import Version
+from pytest import LogCaptureFixture, MonkeyPatch
 
 from gprofiler.profilers.java import AsyncProfiledProcess, JavaProfiler, frequency_to_ap_interval, parse_jvm_version
 from tests.conftest import AssertInCollapsed
@@ -123,8 +123,11 @@ def test_java_safemode_parameters(tmp_path: Path) -> None:
 
 
 def test_java_safemode_version_check(
-    tmp_path: Path, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture, application_docker_container: Container,
-        application_process: Optional[Popen]
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    caplog: LogCaptureFixture,
+    application_docker_container: Container,
+    application_process: Optional[Popen],
 ) -> None:
     monkeypatch.setitem(JavaProfiler.MINIMAL_SUPPORTED_VERSIONS, 8, (Version("8.999"), 0))
 
@@ -139,8 +142,11 @@ def test_java_safemode_version_check(
 
 
 def test_java_safemode_build_number_check(
-    tmp_path: Path, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture, application_docker_container: Container,
-        application_process: Optional[Popen]
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    caplog: LogCaptureFixture,
+    application_docker_container: Container,
+    application_process: Optional[Popen],
 ) -> None:
     with make_java_profiler(storage_dir=str(tmp_path)) as profiler:
         process = profiler._select_processes_to_profile()[0]
@@ -161,8 +167,9 @@ def test_java_safemode_build_number_check(
         (True, [], False),  # containerized (other params are ignored)
     ],
 )
-def test_hotspot_error_file(application_pid: int, tmp_path: Path, monkeypatch: MonkeyPatch,
-                            caplog: LogCaptureFixture) -> None:
+def test_hotspot_error_file(
+    application_pid: int, tmp_path: Path, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture
+) -> None:
     start_async_profiler = AsyncProfiledProcess.start_async_profiler
 
     # Simulate crashing process
@@ -187,8 +194,9 @@ def test_hotspot_error_file(application_pid: int, tmp_path: Path, monkeypatch: M
     assert profiler._safemode_disable_reason is not None
 
 
-def test_disable_java_profiling(application_pid: int, tmp_path: Path, monkeypatch: MonkeyPatch,
-                                caplog: LogCaptureFixture) -> None:
+def test_disable_java_profiling(
+    application_pid: int, tmp_path: Path, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture
+) -> None:
     caplog.set_level(logging.DEBUG)
 
     profiler = make_java_profiler(storage_dir=str(tmp_path))
@@ -201,8 +209,9 @@ def test_disable_java_profiling(application_pid: int, tmp_path: Path, monkeypatc
     assert "Java profiling has been disabled, skipping profiling of all java process" in caplog.text
 
 
-def test_already_loaded_async_profiler_profiling_failure(tmp_path: Path, monkeypatch: MonkeyPatch,
-                                                         caplog: LogCaptureFixture, application_pid: int) -> None:
+def test_already_loaded_async_profiler_profiling_failure(
+    tmp_path: Path, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture, application_pid: int
+) -> None:
     with monkeypatch.context() as m:
         m.setattr("gprofiler.profilers.java.TEMPORARY_STORAGE_PATH", "/tmp/fake_gprofiler_tmp")
         with make_java_profiler(storage_dir=str(tmp_path)) as profiler:
@@ -219,9 +228,9 @@ def test_already_loaded_async_profiler_profiling_failure(tmp_path: Path, monkeyp
 # test only once; and don't test in container - as it will go down once we kill the Java app.
 @pytest.mark.parametrize("in_container", [False])
 @pytest.mark.parametrize("check_app_exited", [False])  # we're killing it, the exit check will raise.
-def test_async_profiler_output_written_upon_jvm_exit(tmp_path: Path, application_pid: int,
-                                                     assert_collapsed: AssertInCollapsed,
-                                                     caplog: LogCaptureFixture) -> None:
+def test_async_profiler_output_written_upon_jvm_exit(
+    tmp_path: Path, application_pid: int, assert_collapsed: AssertInCollapsed, caplog: LogCaptureFixture
+) -> None:
     """
     Make sure async-profiler writes output upon process exit (and we manage to read it correctly)
     """
@@ -243,9 +252,9 @@ def test_async_profiler_output_written_upon_jvm_exit(tmp_path: Path, application
 
 # test only once
 @pytest.mark.parametrize("in_container", [False])
-def test_async_profiler_stops_after_given_timeout(tmp_path: Path, application_pid: int,
-                                                  assert_collapsed: AssertInCollapsed,
-                                                  caplog: LogCaptureFixture) -> None:
+def test_async_profiler_stops_after_given_timeout(
+    tmp_path: Path, application_pid: int, assert_collapsed: AssertInCollapsed, caplog: LogCaptureFixture
+) -> None:
     caplog.set_level(logging.DEBUG)
 
     process = psutil.Process(application_pid)

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -38,8 +38,9 @@ def runtime() -> str:
     return "java"
 
 
-def test_async_profiler_already_running(application_pid: int, assert_collapsed: AssertInCollapsed,
-                                        tmp_path: Path, caplog: LogCaptureFixture) -> None:
+def test_async_profiler_already_running(
+    application_pid: int, assert_collapsed: AssertInCollapsed, tmp_path: Path, caplog: LogCaptureFixture
+) -> None:
     """
     Test we're able to restart async-profiler in case it's already running in the process and get results normally.
     """

--- a/tests/test_libpython.py
+++ b/tests/test_libpython.py
@@ -2,10 +2,13 @@
 # Copyright (c) Granulate. All rights reserved.
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
+from pathlib import Path
 from threading import Event
+from typing import Callable, Mapping
 
 import pytest
 from docker import DockerClient
+from docker.models.containers import Container
 from docker.models.images import Image
 
 from gprofiler.profilers.python import PythonProfiler
@@ -27,9 +30,9 @@ def application_docker_image(docker_client: DockerClient) -> Image:
 
 @pytest.mark.parametrize("in_container", [True])
 def test_python_select_by_libpython(
-    tmp_path,
-    application_docker_container,
-    assert_collapsed,
+    tmp_path: Path,
+    application_docker_container: Container,
+    assert_collapsed: Callable[[Mapping[str, int]], None],
 ) -> None:
     """
     Tests that profiling of processes running Python, whose basename(readlink("/proc/pid/exe")) isn't "python".

--- a/tests/test_libpython.py
+++ b/tests/test_libpython.py
@@ -13,7 +13,6 @@ from docker.models.images import Image
 from gprofiler.profilers.python import PythonProfiler
 from tests import CONTAINERS_DIRECTORY
 from tests.conftest import AssertInCollapsed
-from tests.type_utils import cast_away_optional
 
 
 @pytest.fixture
@@ -42,6 +41,6 @@ def test_python_select_by_libpython(
     """
     with PythonProfiler(1000, 1, Event(), str(tmp_path), "pyspy", True, None) as profiler:
         process_collapsed = profiler.snapshot()
-    collapsed = cast_away_optional(process_collapsed.get(application_docker_container.attrs["State"]["Pid"]))
+    collapsed = process_collapsed[application_docker_container.attrs["State"]["Pid"]]
     assert_collapsed(collapsed)
     assert all(stack.startswith("shmython") for stack in collapsed.keys())

--- a/tests/test_libpython.py
+++ b/tests/test_libpython.py
@@ -4,7 +4,6 @@
 #
 from pathlib import Path
 from threading import Event
-from typing import Callable, Mapping
 
 import pytest
 from docker import DockerClient

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -17,11 +17,12 @@ from gprofiler.profilers.php import PHPSpyProfiler
 from gprofiler.profilers.python import PySpyProfiler, PythonEbpfProfiler
 from gprofiler.profilers.ruby import RbSpyProfiler
 from tests import PHPSPY_DURATION
+from tests.conftest import AssertInCollapsed
 from tests.utils import (
     RUNTIME_PROFILERS,
     assert_function_in_collapsed,
     run_gprofiler_in_container,
-    snapshot_one_collaped, AssertInCollapsed,
+    snapshot_one_collaped
 )
 
 

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -4,7 +4,7 @@
 #
 from pathlib import Path
 from threading import Event
-from typing import Any, Callable, Counter, List, Mapping, Optional
+from typing import Any, Callable, List, Optional
 
 import pytest
 from docker import DockerClient

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -30,7 +30,7 @@ def test_java_from_host(
     tmp_path: Path,
     application_pid: int,
     assert_application_name: Callable,
-    assert_collapsed,
+    assert_collapsed: Callable[[Mapping[str, int]], None],
 ) -> None:
     with JavaProfiler(
         1000,

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -4,7 +4,7 @@
 #
 from pathlib import Path
 from threading import Event
-from typing import Callable, List, Mapping, Optional
+from typing import Callable, List, Mapping, Optional, Counter, Any
 
 import pytest
 from docker import DockerClient
@@ -21,7 +21,7 @@ from tests.utils import (
     RUNTIME_PROFILERS,
     assert_function_in_collapsed,
     run_gprofiler_in_container,
-    snapshot_one_collaped,
+    snapshot_one_collaped, AssertInCollapsed,
 )
 
 
@@ -30,7 +30,7 @@ def test_java_from_host(
     tmp_path: Path,
     application_pid: int,
     assert_application_name: Callable,
-    assert_collapsed: Callable[[Mapping[str, int]], None],
+    assert_collapsed: AssertInCollapsed,
 ) -> None:
     with JavaProfiler(
         1000,
@@ -54,14 +54,14 @@ def test_java_from_host(
 def test_pyspy(
     tmp_path: Path,
     application_pid: int,
-    assert_collapsed,
+    assert_collapsed: AssertInCollapsed,
     assert_application_name: Callable,
     python_version: Optional[str],
 ) -> None:
     _ = assert_application_name  # Required for mypy unused argument warning
     with PySpyProfiler(1000, 3, Event(), str(tmp_path), add_versions=True) as profiler:
         # not using snapshot_one_collaped because there are multiple Python processes running usually.
-        process_collapsed = profiler.snapshot().get(application_pid)
+        process_collapsed = profiler.snapshot()[application_pid]
         assert_collapsed(process_collapsed)
         assert_function_in_collapsed("PyYAML==6.0", process_collapsed)  # Ensure package info is presented
         # Ensure Python version is presented
@@ -73,12 +73,12 @@ def test_pyspy(
 def test_phpspy(
     tmp_path: Path,
     application_pid: int,
-    assert_collapsed,
+    assert_collapsed: AssertInCollapsed,
 ) -> None:
     with PHPSpyProfiler(
         1000, PHPSPY_DURATION, Event(), str(tmp_path), php_process_filter="php", php_mode="phpspy"
     ) as profiler:
-        process_collapsed = profiler.snapshot().get(application_pid)
+        process_collapsed = profiler.snapshot()[application_pid]
         assert_collapsed(process_collapsed)
 
 
@@ -86,7 +86,7 @@ def test_phpspy(
 def test_rbspy(
     tmp_path: Path,
     application_pid: int,
-    assert_collapsed,
+    assert_collapsed: AssertInCollapsed,
     gprofiler_docker_image: Image,
 ) -> None:
     with RbSpyProfiler(1000, 3, Event(), str(tmp_path), "rbspy") as profiler:
@@ -98,13 +98,13 @@ def test_rbspy(
 def test_nodejs(
     tmp_path: Path,
     application_pid: int,
-    assert_collapsed,
+    assert_collapsed: AssertInCollapsed,
     gprofiler_docker_image: Image,
 ) -> None:
     with SystemProfiler(
         1000, 6, Event(), str(tmp_path), perf_mode="fp", perf_inject=True, perf_dwarf_stack_size=0
     ) as profiler:
-        process_collapsed = profiler.snapshot().get(application_pid)
+        process_collapsed = profiler.snapshot()[application_pid]
         assert_collapsed(process_collapsed)
 
 
@@ -112,16 +112,16 @@ def test_nodejs(
 def test_python_ebpf(
     tmp_path: Path,
     application_pid: int,
-    assert_collapsed: Callable,
+    assert_collapsed: AssertInCollapsed,
     assert_application_name: Callable,
     gprofiler_docker_image: Image,
     python_version: Optional[str],
-    no_kernel_headers,
+    no_kernel_headers: Any,
 ) -> None:
     _ = assert_application_name  # Required for mypy unused argument warning
     with PythonEbpfProfiler(1000, 5, Event(), str(tmp_path), add_versions=True) as profiler:
         collapsed = profiler.snapshot()
-        process_collapsed = collapsed.get(application_pid)
+        process_collapsed = collapsed[application_pid]
         assert_collapsed(process_collapsed)
         assert_function_in_collapsed("do_syscall_64_[k]", process_collapsed)  # ensure kernels stacks exist
         assert_function_in_collapsed(
@@ -143,7 +143,7 @@ def test_from_container(
     runtime_specific_args: List[str],
     gprofiler_docker_image: Image,
     output_directory: Path,
-    assert_collapsed: Callable[[Mapping[str, int]], None],
+    assert_collapsed: AssertInCollapsed,
     assert_application_name: Callable,
     profiler_flags: List[str],
 ) -> None:

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -4,7 +4,7 @@
 #
 from pathlib import Path
 from threading import Event
-from typing import Callable, List, Mapping, Optional, Counter, Any
+from typing import Any, Callable, Counter, List, Mapping, Optional
 
 import pytest
 from docker import DockerClient
@@ -22,7 +22,7 @@ from tests.utils import (
     RUNTIME_PROFILERS,
     assert_function_in_collapsed,
     run_gprofiler_in_container,
-    snapshot_one_collaped
+    snapshot_one_collaped,
 )
 
 

--- a/tests/type_utils.py
+++ b/tests/type_utils.py
@@ -1,0 +1,12 @@
+#
+# Copyright (c) Granulate. All rights reserved.
+# Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
+#
+from typing import TypeVar, Optional
+
+T = TypeVar('T')
+
+
+def cast_away_optional(arg: Optional[T]) -> T:
+    assert arg is not None
+    return arg

--- a/tests/type_utils.py
+++ b/tests/type_utils.py
@@ -2,9 +2,9 @@
 # Copyright (c) Granulate. All rights reserved.
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
-from typing import TypeVar, Optional
+from typing import Optional, TypeVar
 
-T = TypeVar('T')
+T = TypeVar("T")
 
 
 def cast_away_optional(arg: Optional[T]) -> T:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 from pathlib import Path
-from typing import Dict, List, Mapping, Optional, Tuple
+from typing import Dict, List, Mapping, Optional, Tuple, Any
 
 from docker import DockerClient
 from docker.models.containers import Container
@@ -25,8 +25,8 @@ def run_privileged_container(
     image: Image,
     command: List[str],
     volumes: Dict[str, Dict[str, str]] = None,
-    auto_remove=True,
-    **extra_kwargs,
+    auto_remove: bool = True,
+    **extra_kwargs: Any,
 ) -> Tuple[Optional[Container], str]:
     if volumes is None:
         volumes = {}
@@ -56,13 +56,13 @@ def run_privileged_container(
     return container, logs
 
 
-def _no_errors(logs: str):
+def _no_errors(logs: str) -> None:
     # example line: [2021-06-12 10:13:57,528] ERROR: gprofiler: ruby profiling failed
     assert "] ERROR: " not in logs, "found ERRORs in gProfiler logs!"
 
 
 def run_gprofiler_in_container(
-    docker_client: DockerClient, image: Image, command: List[str], **kwargs
+    docker_client: DockerClient, image: Image, command: List[str], **kwargs: Any
 ) -> Tuple[Optional[Container], str]:
     """
     Wrapper around run_privileged_container() that also verifies there are not ERRORs in gProfiler's output log.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 from pathlib import Path
 from threading import Event
-from typing import Dict, List, Mapping, Optional, Tuple, Any
+from typing import Dict, List, Mapping, Optional, Tuple, Any, Counter, Callable
 
 from docker import DockerClient
 from docker.models.containers import Container
@@ -98,7 +98,10 @@ def chmod_path_parts(path: Path, add_mode: int) -> None:
         os.chmod(subpath, os.stat(subpath).st_mode | add_mode)
 
 
-def assert_function_in_collapsed(function_name: str, collapsed: Mapping[str, int]) -> None:
+AssertInCollapsed = Callable[[StackToSampleCount], None]
+
+
+def assert_function_in_collapsed(function_name: str, collapsed: StackToSampleCount) -> None:
     print(f"collapsed: {collapsed}")
     assert any(
         (function_name in record) for record in collapsed.keys()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 from pathlib import Path
 from threading import Event
-from typing import Dict, List, Optional, Tuple, Any
+from typing import Any, Dict, List, Optional, Tuple
 
 from docker import DockerClient
 from docker.models.containers import Container

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 from pathlib import Path
 from threading import Event
-from typing import Dict, List, Mapping, Optional, Tuple, Any, Counter, Callable
+from typing import Dict, List, Optional, Tuple, Any
 
 from docker import DockerClient
 from docker.models.containers import Container
@@ -96,9 +96,6 @@ def chmod_path_parts(path: Path, add_mode: int) -> None:
     for i in range(1, len(path.parts)):
         subpath = os.path.join(*path.parts[:i])
         os.chmod(subpath, os.stat(subpath).st_mode | add_mode)
-
-
-AssertInCollapsed = Callable[[StackToSampleCount], None]
 
 
 def assert_function_in_collapsed(function_name: str, collapsed: StackToSampleCount) -> None:


### PR DESCRIPTION
## Description
From now on, mypy will be set to `strict = True` it its config file.

## Motivation and Context
`pre-commit` and CI both run `lint.sh` that runs `mypy .`, but mypy wasn't strict, so it didn't check much, now it will.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your changes are tested by the CI, you can just write that.-->
* Made sure `pre-commit` hook works
* Made sure CI catches problems

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [x] I have tested mypy fails CI when appropriate
