### PR TITLE
utils: Raise NoSuchProcess from process_comm() if process is missing

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -44,7 +44,6 @@ from gprofiler.profilers.registry import ProfilerArgument, register_profiler
 from gprofiler.utils import (
     TEMPORARY_STORAGE_PATH,
     pgrep_maps,
-    process_comm,
     remove_path,
     remove_prefix,
     resource_path,
@@ -53,6 +52,7 @@ from gprofiler.utils import (
     wait_event,
 )
 from gprofiler.utils.perf import can_i_use_perf_events
+from gprofiler.utils.process import process_comm
 
 logger = get_logger_adapter(__name__)
 

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -32,7 +32,6 @@ from gprofiler.profilers.registry import ProfilerArgument, register_profiler
 from gprofiler.utils import (
     pgrep_maps,
     poll_process,
-    process_comm,
     random_prefix,
     removed_path,
     resource_path,
@@ -41,6 +40,7 @@ from gprofiler.utils import (
     wait_event,
     wait_for_file_by_prefix,
 )
+from gprofiler.utils.process import process_comm
 
 logger = get_logger_adapter(__name__)
 

--- a/gprofiler/profilers/ruby.py
+++ b/gprofiler/profilers/ruby.py
@@ -16,7 +16,8 @@ from gprofiler.log import get_logger_adapter
 from gprofiler.merge import parse_one_collapsed_file
 from gprofiler.profilers.profiler_base import ProcessProfilerBase
 from gprofiler.profilers.registry import register_profiler
-from gprofiler.utils import pgrep_maps, process_comm, random_prefix, removed_path, resource_path, run_process
+from gprofiler.utils import pgrep_maps, random_prefix, removed_path, resource_path, run_process
+from gprofiler.utils.process import process_comm
 
 logger = get_logger_adapter(__name__)
 

--- a/gprofiler/utils/__init__.py
+++ b/gprofiler/utils/__init__.py
@@ -457,13 +457,6 @@ def random_prefix() -> str:
     return "".join(random.choice(string.ascii_letters) for _ in range(16))
 
 
-def process_comm(process: Process) -> str:
-    status = Path(f"/proc/{process.pid}/status").read_text()
-    name_line = status.splitlines()[0]
-    assert name_line.startswith("Name:\t")
-    return name_line.split("\t", 1)[1]
-
-
 PERF_EVENT_MLOCK_KB = "/proc/sys/kernel/perf_event_mlock_kb"
 
 

--- a/gprofiler/utils/process.py
+++ b/gprofiler/utils/process.py
@@ -1,0 +1,15 @@
+#
+# Copyright (c) Granulate. All rights reserved.
+# Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
+#
+
+from pathlib import Path
+
+from psutil import Process
+
+
+def process_comm(process: Process) -> str:
+    status = Path(f"/proc/{process.pid}/status").read_text()
+    name_line = status.splitlines()[0]
+    assert name_line.startswith("Name:\t")
+    return name_line.split("\t", 1)[1]

--- a/gprofiler/utils/process.py
+++ b/gprofiler/utils/process.py
@@ -5,11 +5,15 @@
 
 from pathlib import Path
 
-from psutil import Process
+from psutil import NoSuchProcess, Process
 
 
 def process_comm(process: Process) -> str:
-    status = Path(f"/proc/{process.pid}/status").read_text()
+    try:
+        status = Path(f"/proc/{process.pid}/status").read_text()
+    except FileNotFoundError:
+        raise NoSuchProcess(process.pid)
+
     name_line = status.splitlines()[0]
     assert name_line.startswith("Name:\t")
     return name_line.split("\t", 1)[1]


### PR DESCRIPTION
Avoid the `FileNotFoundError` - `NoSuchProcess` is handled gracefully.