### PR TITLE
appids: Support gunicorns which use setproctitle()

### DIFF
--- a/gprofiler/metadata/application_identifiers.py
+++ b/gprofiler/metadata/application_identifiers.py
@@ -117,7 +117,7 @@ class _GunicornTitleApplicationIdentifier(_ApplicationIdentifier):
         # There should be one entry in the commandline, starting with "gunicorn: ",
         # and the rest should be empty strings per Process.cmdline() (I suppose that setproctitle
         # zeros out the arguments array).
-        if cmdline[0].startswith("gunicorn: ") and len(list(filter(lambda s: s, cmdline))) == 1:
+        if _get_cli_arg_by_index(cmdline, 0).startswith("gunicorn: ") and len(list(filter(lambda s: s, cmdline))) == 1:
             return cmdline[0]
         return None
 


### PR DESCRIPTION
## Description
Support another "flavor" of proc names that gunicorn uses, depending on its config.

## How Has This Been Tested?
I ran `Process(pid).cmdline()` on a system which has a gunicorn that uses `setproctitle()`. I took the output and ran it via this new class - and it returned the correct appid. This was the input:
```
['gunicorn: worker [myapp.wsgi:app]', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '']
```
