### PR TITLE
Bugfix/ uwsgi-config-file-parsing

### DIFF
--- a/gprofiler/metadata/application_identifiers.py
+++ b/gprofiler/metadata/application_identifiers.py
@@ -114,7 +114,7 @@ class _UwsgiApplicationIdentifier(_ApplicationIdentifier):
         if not os.path.isabs(config_file):
             config_file = os.path.join(process.cwd(), config_file)
 
-        config = configparser.ConfigParser()
+        config = configparser.ConfigParser(strict=False)
         config.read(resolve_host_path(process, config_file))
         try:
             # Note that `ConfigParser.get` doesn't act like `dict.get` and raises exceptions if section/option


### PR DESCRIPTION
## Description
Fix a small bug, when trying to identify applications, we may parse uwsgi config file which is an ini file, the file format allows overriding config options, although by default Python's [configparser](https://docs.python.org/3.9/library/configparser.html)
raises exception upon this scenario, this PR fixes this issue by disabling this behavior. 

## Related Issue
See explanation below.