### PR TITLE
python: PyPerf: Aarch64 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN ./perf_build.sh
 # pyperf (bcc)
 FROM ubuntu${PYPERF_BUILDER_UBUNTU} AS bcc-builder-base
 
-RUN apt-get update && apt-get install -y git && if [ $(uname -m) = "aarch64" ]; then exit 0; fi; DEBIAN_FRONTEND=noninteractive apt-get install -y \
+RUN apt-get update && apt-get install -y git && DEBIAN_FRONTEND=noninteractive apt-get install -y \
   curl build-essential iperf llvm-9-dev libclang-9-dev cmake python3 flex bison libelf-dev libz-dev liblzma-dev
 
 # bcc helpers
@@ -66,7 +66,7 @@ RUN ./bcc_helpers_build.sh
 FROM bcc-builder-base AS bcc-builder
 
 COPY ./scripts/libunwind_build.sh .
-RUN if [ $(uname -m) = "aarch64" ]; then exit 0; fi; ./libunwind_build.sh
+RUN ./libunwind_build.sh
 
 WORKDIR /bcc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ RUN ./libunwind_build.sh
 WORKDIR /bcc
 
 COPY ./scripts/pyperf_build.sh .
-RUN ./pyperf_build.sh
+RUN ./pyperf_build.sh container
 
 # phpspy
 FROM ubuntu${PHPSPY_BUILDER_UBUNTU} AS phpspy-builder

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ The runtime stacks are then merged into the data collected by `perf`, substituti
 | perf (native, Golang, ...) | :heavy_check_mark: | :heavy_check_mark: |
 | Java (async-profiler)      | :heavy_check_mark: | :heavy_check_mark: |
 | Python (py-spy)            | :heavy_check_mark: | :heavy_check_mark: |
-| Python (PyPerf eBPF)       | :heavy_check_mark: | :x:                |
+| Python (PyPerf eBPF)       | :heavy_check_mark: | :heavy_check_mark: |
 | Ruby (rbspy)               | :heavy_check_mark: | :heavy_check_mark: |
 | PHP (phpspy)               | :heavy_check_mark: | :x:                |
 | NodeJS (perf)              | :heavy_check_mark: | :heavy_check_mark: |

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -311,6 +311,7 @@ class PythonEbpfProfiler(ProfilerBase):
         cmd = [
             resource_path(self.PYPERF_RESOURCE),
             "-v",
+            "999",
             "--output",
             str(self.output_path),
             "-F",

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -310,6 +310,7 @@ class PythonEbpfProfiler(ProfilerBase):
         logger.info("Starting profiling of Python processes with PyPerf")
         cmd = [
             resource_path(self.PYPERF_RESOURCE),
+            "-v",
             "--output",
             str(self.output_path),
             "-F",

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -84,7 +84,7 @@ RUN ./burn_build.sh
 # these are only relevant for modern kernels, so there's no real reason to build them on CentOS 7 anyway.
 FROM ubuntu${PYPERF_BUILDER_UBUNTU} AS bcc-helpers
 
-RUN if [ $(uname -m) = "aarch64" ]; then exit 0; fi; apt-get update && apt install -y \
+RUN apt-get update && apt install -y \
     clang-10 \
     libelf-dev \
     make \
@@ -107,7 +107,7 @@ FROM centos${GPROFILER_BUILDER} AS build-stage
 RUN yum install -y git
 
 # these are needed to build PyPerf, which we don't build on Aarch64, hence not installing them here.
-RUN if [ $(uname -m) = "aarch64" ]; then exit 0; fi; yum install -y \
+RUN yum install -y \
     curl \
     cmake \
     patch \
@@ -119,22 +119,22 @@ RUN if [ $(uname -m) = "aarch64" ]; then exit 0; fi; yum install -y \
     ncurses-devel \
     elfutils-libelf-devel
 
-RUN if [ $(uname -m) = "aarch64" ]; then exit 0; fi; yum install -y centos-release-scl-rh
+RUN yum install -y centos-release-scl-rh
 # mostly taken from https://github.com/iovisor/bcc/blob/master/INSTALL.md#install-and-compile-llvm
-RUN if [ $(uname -m) = "aarch64" ]; then exit 0; fi; yum install -y devtoolset-8 \
-    llvm-toolset-7 \
-    llvm-toolset-7-llvm-devel \
-    llvm-toolset-7-llvm-static \
-    llvm-toolset-7-clang-devel \
+RUN yum install -y devtoolset-8 \
+    llvm-toolset-7.0 \
+    llvm-toolset-7.0-llvm-devel \
+    llvm-toolset-7.0-llvm-static \
+    llvm-toolset-7.0-clang-devel \
     devtoolset-8-elfutils-libelf-devel
 
 COPY ./scripts/libunwind_build.sh .
-RUN if [ $(uname -m) = "aarch64" ]; then exit 0; fi; ./libunwind_build.sh
+RUN ./libunwind_build.sh
 
 WORKDIR /bcc
 
 COPY ./scripts/pyperf_build.sh .
-RUN if [ $(uname -m) != "aarch64" ]; then source scl_source enable devtoolset-8 llvm-toolset-7; fi && source ./pyperf_build.sh
+RUN source scl_source enable devtoolset-8 llvm-toolset-7.0 && source ./pyperf_build.sh
 
 
 # gProfiler part

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -120,11 +120,12 @@ RUN yum install -y \
 
 RUN yum install -y centos-release-scl-rh
 # mostly taken from https://github.com/iovisor/bcc/blob/master/INSTALL.md#install-and-compile-llvm
-RUN yum install -y devtoolset-8 \
-    llvm-toolset-7.0 \
-    llvm-toolset-7.0-llvm-devel \
-    llvm-toolset-7.0-llvm-static \
-    llvm-toolset-7.0-clang-devel \
+# on x86_64, the package is named llvm-toolset-7. on aarch64, it is named llvm-toolset-7.0...
+RUN if [ $(uname -m) = "aarch64" ]; then v="7.0"; else v="7"; fi; yum install -y devtoolset-8 \
+    llvm-toolset-$v \
+    llvm-toolset-$v-llvm-devel \
+    llvm-toolset-$v-llvm-static \
+    llvm-toolset-$v-clang-devel \
     devtoolset-8-elfutils-libelf-devel
 
 COPY ./scripts/libunwind_build.sh .
@@ -205,7 +206,7 @@ COPY ./scripts/list_needed_libs.sh ./scripts/list_needed_libs.sh
 # we use list_needed_libs.sh to list the dynamic dependencies of *all* of our resources,
 # and make staticx pack them as well.
 # using scl here to get the proper LD_LIBRARY_PATH set
-RUN source scl_source enable devtoolset-8 llvm-toolset-7.0 && libs=$(./scripts/list_needed_libs.sh) && staticx $libs dist/gprofiler dist/gprofiler
+RUN if [ $(uname -m) = "aarch64" ]; then v="7.0"; else v="7"; fi; source scl_source enable devtoolset-8 llvm-toolset-$v && libs=$(./scripts/list_needed_libs.sh) && staticx $libs dist/gprofiler dist/gprofiler
 
 FROM scratch AS export-stage
 

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -205,7 +205,7 @@ COPY ./scripts/list_needed_libs.sh ./scripts/list_needed_libs.sh
 # we use list_needed_libs.sh to list the dynamic dependencies of *all* of our resources,
 # and make staticx pack them as well.
 # using scl here to get the proper LD_LIBRARY_PATH set
-RUN source scl_source enable devtoolset-8 llvm-toolset-7 && libs=$(./scripts/list_needed_libs.sh) && staticx $libs dist/gprofiler dist/gprofiler
+RUN source scl_source enable devtoolset-8 llvm-toolset-7.0 && libs=$(./scripts/list_needed_libs.sh) && staticx $libs dist/gprofiler dist/gprofiler
 
 FROM scratch AS export-stage
 

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -134,7 +134,7 @@ RUN ./libunwind_build.sh
 WORKDIR /bcc
 
 COPY ./scripts/pyperf_build.sh .
-RUN source scl_source enable devtoolset-8 llvm-toolset-7.0 && source ./pyperf_build.sh
+RUN source scl_source enable devtoolset-8 llvm-toolset-7.0 && source ./pyperf_build.sh exe
 
 
 # gProfiler part

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -106,7 +106,6 @@ FROM centos${GPROFILER_BUILDER} AS build-stage
 
 RUN yum install -y git
 
-# these are needed to build PyPerf, which we don't build on Aarch64, hence not installing them here.
 RUN yum install -y \
     curl \
     cmake \
@@ -206,8 +205,7 @@ COPY ./scripts/list_needed_libs.sh ./scripts/list_needed_libs.sh
 # we use list_needed_libs.sh to list the dynamic dependencies of *all* of our resources,
 # and make staticx pack them as well.
 # using scl here to get the proper LD_LIBRARY_PATH set
-# TODO: use staticx for aarch64 as well; currently it doesn't generate correct binaries when run over Docker emulation.
-RUN if [ $(uname -m) != "aarch64" ]; then source scl_source enable devtoolset-8 llvm-toolset-7 && libs=$(./scripts/list_needed_libs.sh) && staticx $libs dist/gprofiler dist/gprofiler; fi
+RUN then source scl_source enable devtoolset-8 llvm-toolset-7 && libs=$(./scripts/list_needed_libs.sh) && staticx $libs dist/gprofiler dist/gprofiler
 
 FROM scratch AS export-stage
 

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -205,7 +205,7 @@ COPY ./scripts/list_needed_libs.sh ./scripts/list_needed_libs.sh
 # we use list_needed_libs.sh to list the dynamic dependencies of *all* of our resources,
 # and make staticx pack them as well.
 # using scl here to get the proper LD_LIBRARY_PATH set
-RUN then source scl_source enable devtoolset-8 llvm-toolset-7 && libs=$(./scripts/list_needed_libs.sh) && staticx $libs dist/gprofiler dist/gprofiler
+RUN source scl_source enable devtoolset-8 llvm-toolset-7 && libs=$(./scripts/list_needed_libs.sh) && staticx $libs dist/gprofiler dist/gprofiler
 
 FROM scratch AS export-stage
 

--- a/scripts/bcc_helpers_build.sh
+++ b/scripts/bcc_helpers_build.sh
@@ -5,14 +5,6 @@
 #
 set -euo pipefail
 
-# TODO support aarch64, after we support it in PyPerf
-if [ $(uname -m) != "x86_64" ]; then
-    mkdir -p /bpf_get_fs_offset /bpf_get_stack_offset
-    touch /bpf_get_fs_offset/get_fs_offset
-    touch /bpf_get_stack_offset/get_stack_offset
-    exit 0
-fi
-
 LLVM_STRIP=llvm-strip
 if ! command -v "$LLVM_STRIP" > /dev/null 2>&1 ; then
     LLVM_STRIP=llvm-strip-10
@@ -20,10 +12,10 @@ fi
 
 LIBBPF_MAKE_FLAGS="BPFTOOL=/bpftool CLANG=clang-10 LLVM_STRIP=$LLVM_STRIP CFLAGS=-static"
 
-cd / && git clone -b v0.0.2 --depth=1 --recurse-submodules https://github.com/Jongy/bpf_get_fs_offset.git
-cd /bpf_get_fs_offset && git reset --hard 8326d39cf44845d4b643ed4267994afca8ccecb3
+cd / && git clone -b aarch64 --depth=1 --recurse-submodules https://github.com/Jongy/bpf_get_fs_offset.git
+cd /bpf_get_fs_offset && git reset --hard 094e93f979308d46dffb8d4ea88823f68d53ba85
 cd /bpf_get_fs_offset && make $LIBBPF_MAKE_FLAGS
 
-cd / && git clone -b v0.0.3 --depth=1 --recurse-submodules https://github.com/Jongy/bpf_get_stack_offset.git
-cd /bpf_get_stack_offset && git reset --hard 54b70ee65708cc8d3d7817277e82376d95205356
+cd / && git clone -b aarch64 --depth=1 --recurse-submodules https://github.com/Jongy/bpf_get_stack_offset.git
+cd /bpf_get_stack_offset && git reset --hard d8b77ce6da674c38ad0bb856686fde1e63ad0814
 cd /bpf_get_stack_offset && make $LIBBPF_MAKE_FLAGS

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -5,7 +5,7 @@
 #
 set -e
 
-git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard e9632c3e9d7a1ad2d58e1abb6cf86ccfdaa81549
+git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard cf3405b7f35f910b5495f4804cfe65630a2688b6
 
 mkdir build
 cd build

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -9,5 +9,5 @@ git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc &&
 
 mkdir build
 cd build
-cmake -DPYTHON_CMD=python3 -DINSTALL_CPP_EXAMPLES=y -DCMAKE_INSTALL_PREFIX=/bcc/root ..
+cmake -DPYTHON_CMD=python3 -DINSTALL_CPP_EXAMPLES=y -DCMAKE_INSTALL_PREFIX=/bcc/root -DENABLE_LLVM_SHARED=1 ..
 make -C examples/cpp/pyperf -j -l VERBOSE=1 install

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -5,7 +5,7 @@
 #
 set -e
 
-git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard c7461900706a6cc710c8ba5aa47a9282c5ce9cfb
+git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 994959b6dd4f9e4f8fc8212110a1dd7d5be9b33d
 
 mkdir build
 cd build

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -5,7 +5,7 @@
 #
 set -e
 
-git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard e4de0ff3ff8174377ea08ef049dfec60418608da
+git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 8347ece735029404c743806a2f1325bc35352673
 
 mkdir build
 cd build

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -5,7 +5,7 @@
 #
 set -e
 
-git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard bb466dfa4ab315e1dd457b708090cc84552e01e7
+git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard c7461900706a6cc710c8ba5aa47a9282c5ce9cfb
 
 mkdir build
 cd build

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -5,7 +5,7 @@
 #
 set -e
 
-git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 8347ece735029404c743806a2f1325bc35352673
+git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard fd3cd7510161a2b7b02a5aff234e4a71b8e8486c
 
 mkdir build
 cd build

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -5,7 +5,7 @@
 #
 set -e
 
-git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard b33dd19493fc7fc3c5c76935f17b2a67c7b30c9c
+git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 91a4accb4c114a6b2185c1622b92437f16a09acc
 
 mkdir build
 cd build

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -5,7 +5,7 @@
 #
 set -e
 
-git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 994959b6dd4f9e4f8fc8212110a1dd7d5be9b33d
+git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard e7f0b07f73221aedbbf0d63a745c51acdc7f4b13
 
 mkdir build
 cd build

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -5,7 +5,7 @@
 #
 set -e
 
-git clone --depth 1 -b v1.2.1 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 3f1d60180946852aa89e3644b786e4bf8934e7a9
+git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 1d502e0ffb93bbfec6d77dddeb7668f0a90e6810
 
 mkdir build
 cd build

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -5,7 +5,7 @@
 #
 set -e
 
-git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard fd3cd7510161a2b7b02a5aff234e4a71b8e8486c
+git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard b33dd19493fc7fc3c5c76935f17b2a67c7b30c9c
 
 mkdir build
 cd build

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -5,7 +5,7 @@
 #
 set -e
 
-git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 95fac2db6e51d3088e076b38eed1d072c8d2d43d
+git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard e4de0ff3ff8174377ea08ef049dfec60418608da
 
 mkdir build
 cd build

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -5,7 +5,7 @@
 #
 set -e
 
-git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard cf3405b7f35f910b5495f4804cfe65630a2688b6
+git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 918fc3138beac21262f5f3b96f92b37b97837bf0
 
 mkdir build
 cd build

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -5,7 +5,7 @@
 #
 set -e
 
-git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 1d502e0ffb93bbfec6d77dddeb7668f0a90e6810
+git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard e9632c3e9d7a1ad2d58e1abb6cf86ccfdaa81549
 
 mkdir build
 cd build

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -5,10 +5,17 @@
 #
 set -e
 
-git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard aba6bdc0dcf089128b5d74f4b30ee0d86b56567b
+git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard bb466dfa4ab315e1dd457b708090cc84552e01e7
 
 mkdir build
 cd build
-# TODO -DENABLE_LLVM_SHARED only for aarch exe
-cmake -DPYTHON_CMD=python3 -DINSTALL_CPP_EXAMPLES=y -DCMAKE_INSTALL_PREFIX=/bcc/root -DENABLE_LLVM_SHARED=1 ..
+
+SHARED_ARG=""
+# need in aarch64 as mentioned here: https://github.com/iovisor/bcc/issues/3333#issuecomment-803432248
+# container mdoe doesn't want it - we don't have the libs bundled.
+# exe mode in x86_64 works fine so I don't change it.
+if [ $(uname -m) = "aarch64" ] && [ "$1" == "exe" ]; then
+    SHARED_ARG=" -DENABLE_LLVM_SHARED=1"
+fi
+cmake -DPYTHON_CMD=python3 -DINSTALL_CPP_EXAMPLES=y -DCMAKE_INSTALL_PREFIX=/bcc/root $SHARED_ARG ..
 make -C examples/cpp/pyperf -j -l VERBOSE=1 install

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -5,9 +5,10 @@
 #
 set -e
 
-git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 91a4accb4c114a6b2185c1622b92437f16a09acc
+git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard aba6bdc0dcf089128b5d74f4b30ee0d86b56567b
 
 mkdir build
 cd build
+# TODO -DENABLE_LLVM_SHARED only for aarch exe
 cmake -DPYTHON_CMD=python3 -DINSTALL_CPP_EXAMPLES=y -DCMAKE_INSTALL_PREFIX=/bcc/root -DENABLE_LLVM_SHARED=1 ..
 make -C examples/cpp/pyperf -j -l VERBOSE=1 install

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -5,7 +5,7 @@
 #
 set -e
 
-git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 918fc3138beac21262f5f3b96f92b37b97837bf0
+git clone --depth 1 -b aarch64 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 95fac2db6e51d3088e076b38eed1d072c8d2d43d
 
 mkdir build
 cd build

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -7,14 +7,6 @@ set -e
 
 git clone --depth 1 -b v1.2.1 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 3f1d60180946852aa89e3644b786e4bf8934e7a9
 
-# (after clone, because we copy the licenses)
-# TODO support aarch64
-if [ $(uname -m) != "x86_64" ]; then
-    mkdir -p /bcc/root/share/bcc/examples/cpp/
-    touch /bcc/root/share/bcc/examples/cpp/PyPerf
-    exit 0
-fi
-
 mkdir build
 cd build
 cmake -DPYTHON_CMD=python3 -DINSTALL_CPP_EXAMPLES=y -DCMAKE_INSTALL_PREFIX=/bcc/root ..


### PR DESCRIPTION
## Description
Support PyPerf running on Aarch64.

This currently passes "sanity" - works on Python 2.7.18 on Ubuntu 20.04 kernel `5.13.0-1008-aws`. I am opening this PR to document what's left to be done & the tests we should run on it.

This depends on:
* BCC PR: https://github.com/Granulate/bcc/pull/34
* Aarch64 support for https://github.com/Jongy/bpf_get_stack_offset/tree/aarch64
* Aarch64 support for https://github.com/Jongy/bpf_get_fs_offset/tree/aarch64

## TODOs
* [ ] Figure out BCC build - with LLVM shared or not - so it works both in container & exe Aarch64 and doesn't break x86_64.
* [ ] Create final tag in https://github.com/Jongy/bpf_get_stack_offset
* [ ] Create final tag in https://github.com/Jongy/bpf_get_fs_offset
* [ ] Figure out if we really depend on https://lore.kernel.org/bpf/796ee46e948bc808d54891a1108435f8652c6ca4.1572649915.git.daniel@iogearbox.net/#r for reading usermode memory. If so, do not attempt to run PyPerf on lower kernel versions.
* [ ] Clean up BCC PR, run tests alongside, then merge it :)

### Testing
x86_64:
* [ ] x86_64 native stacks (as I have made changes in that area) when in user mode
* [ ] x86_64 native stacks (as I have made changes in that area) when in kernel mode
* [ ] x86_64 gProfiler as container PyPerf
* [ ] x86_64 gProfiler as exe PyPerf

Aarch64:
* [ ] Aarch64 gProfiler as container PyPerf
* [ ] Aarch64 gProfiler as exe PyPerf
* [ ] Aarch64 native stacks when in user mode
* [ ] Aarch64 native stacks when in kernel mode
* [ ] Aarch64 kernel stacks
* [ ] Aarch64 Python 2.7 Python stacks incl classes (glibc)
* [ ] Aarch64 Python 3.6 Python stacks incl classes (glibc)
* [ ] Aarch64 Python 3.7 Python stacks incl classes (glibc)
* [ ] Aarch64 Python 3.8 Python stacks incl classes (glibc)
* [ ] Aarch64 Python 3.9 Python stacks incl classes (glibc)
* [ ] Aarch64 Python 3.10 Python stacks incl classes (glibc)
* [ ] Aarch64 Python 3.8 Python stacks (musl based, one Python version is enough)