### PR TITLE
Python: Bugfix: Don't emit incorrect Python versions

### DIFF
--- a/gprofiler/metadata/py_module_version.py
+++ b/gprofiler/metadata/py_module_version.py
@@ -166,7 +166,7 @@ def _get_python_full_version(process: Process) -> Optional[str]:
     if len(matches) != 1:
         # If we didn't match anything or for some reason matched more than once just don't get the version
         return None
-    return matches[0].decode()
+    return str(matches[0].decode())  # Explicitly cast to str to silence mypy
 
 
 # Standard library modules are identified by being under a pythonx.y dir and *not* under site/dist-packages


### PR DESCRIPTION
## Description
Previously it was possible to get an incorrect Python versions in cases where the python versions regex matched a wrong string.
This PR prevents it by narrowing down the possible Python versions to expected ones only (2.7 and 3.5-3.12), and by not presenting a Python version in case the regex had more than a single match.

## How Has This Been Tested?
I tested it in a container with an application for which we previously got an incorrect version (conveniently, gprofiler itself...).
