### PR TITLE
README: add AWS EMR instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,13 +292,11 @@ sudo sh -c "setsid ./gprofiler -cu --token \"<TOKEN>\" --service-name \"SERVICE\
      - Expand *Bootstrap Actions* section
      - Add Action of type *Custom Action*
      - Fill in script location with the appropriate script location on your S3, for example `s3://my-s3-bucket/grofiler-bootstrap.sh`
-     
+     ![img](https://user-images.githubusercontent.com/33522503/153854671-5b7a8b20-0587-49cd-a843-7b9a42dc09f6.png)
    - AWS CLI Example: 
      ```bash
      aws emr create-cluster --name MY-Cluster ... --bootstrap-actions "Path=s3://my-s3-bucket/grofiler-bootstrap.sh"
      ```
-     
-
 
 ### Debugging problems
 If you are experiencing issues with your gProfiler installation (such as no flamegraphs available in the [Performance Studio](https://profiler.granulate.io)

--- a/README.md
+++ b/README.md
@@ -268,6 +268,20 @@ gcloud dataproc clusters create <CLUSTER NAME> \
   - Replace `<CLUSTER NAME>` with the cluster name you wish to use
   - Replace `<REGION>` with the region you wish to use
 
+### Debugging problems
+If you are experiencing issues with your gProfiler installation (such as no flamegraphs available in the [Performance Studio](https://profiler.granulate.io)
+after waiting for more than 1 hour) you can look at gProfiler's logs and see if there are any errors. \
+To see gProfiler's logs, you must enable its output by providing `enable-stdout="1"` in the cluster metadata when creating the Dataproc cluster. You can use the example above.
+Wait at least 10 minutes after creating your cluster, and then you can SSH into one of your cluster instances via either Dataproc's web interface or the command line.
+After connecting to your instance, run the following command:
+```shell
+tail -f /var/log/dataproc-initialization-script-0.log
+```
+If you have more than one initialization script, try running the command with an increasing number instead of `0` in the command find the appropriate gProfiler log file.
+
+### Disabling gProfiler stdout output
+By default, gProfiler's output is written to the Dataproc initialization script output file (`/var/log/dataproc-initialization-script-{Incrementing number}.log`).
+If you wish to disable this behaviour, change the `enable-stdout` metadata variable value to "0" (the default is "1").
 
 ## Running on AWS EMR
 To run gProfiler on your AWS EMR cluster, you should create a bootstrap action that will launch the gProfiler on each
@@ -297,21 +311,6 @@ sudo sh -c "setsid ./gprofiler -cu --token \"<TOKEN>\" --service-name \"SERVICE\
      ```bash
      aws emr create-cluster --name MY-Cluster ... --bootstrap-actions "Path=s3://my-s3-bucket/gprofiler-bootstrap.sh"
      ```
-
-### Debugging problems
-If you are experiencing issues with your gProfiler installation (such as no flamegraphs available in the [Performance Studio](https://profiler.granulate.io)
-after waiting for more than 1 hour) you can look at gProfiler's logs and see if there are any errors. \
-To see gProfiler's logs, you must enable its output by providing `enable-stdout="1"` in the cluster metadata when creating the Dataproc cluster. You can use the example above.
-Wait at least 10 minutes after creating your cluster, and then you can SSH into one of your cluster instances via either Dataproc's web interface or the command line.
-After connecting to your instance, run the following command:
-```shell
-tail -f /var/log/dataproc-initialization-script-0.log
-```
-If you have more than one initialization script, try running the command with an increasing number instead of `0` in the command find the appropriate gProfiler log file.
-
-### Disabling gProfiler stdout output
-By default, gProfiler's output is written to the Dataproc initialization script output file (`/var/log/dataproc-initialization-script-{Incrementing number}.log`).
-If you wish to disable this behaviour, change the `enable-stdout` metadata variable value to "0" (the default is "1").
 
 ## Running from source
 gProfiler requires Python 3.6+ to run.

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ sudo sh -c "setsid ./gprofiler -cu --token \"<TOKEN>\" --service-name \"SERVICE\
   Make sure to:
   - Replace `<TOKEN>` with your token you got from the [gProfiler Performance Studio](https://profiler.granulate.io/installation) site.
   - Replace `<SERVICE>` with the service name you wish to use.
-2. Upload the script to an S3 bucket, for example: `s3://my-s3-bucket/grofiler-bootstrap.sh` 
+2. Upload the script to an S3 bucket, for example: `s3://my-s3-bucket/gprofiler-bootstrap.sh` 
 3. Create the EMR cluster with bootstrap-action to run the bootstrap script, this can be done both from the AWS Console and AWS CLI.
    - AWS Console Example:
      - Create an EMR Cluster from the AWS Console
@@ -291,11 +291,11 @@ sudo sh -c "setsid ./gprofiler -cu --token \"<TOKEN>\" --service-name \"SERVICE\
      - Proceed to Step 3 - *General Cluster Settings*
      - Expand *Bootstrap Actions* section
      - Add Action of type *Custom Action*
-     - Fill in script location with the appropriate script location on your S3, for example `s3://my-s3-bucket/grofiler-bootstrap.sh`
-     ![img](https://user-images.githubusercontent.com/33522503/153854671-5b7a8b20-0587-49cd-a843-7b9a42dc09f6.png)
+     - Fill in script location with the appropriate script location on your S3, for example `s3://my-s3-bucket/gprofiler-bootstrap.sh`
+     ![img](https://user-images.githubusercontent.com/33522503/153876647-5f844c46-8d62-4d89-b612-9616043f1825.png)
    - AWS CLI Example: 
      ```bash
-     aws emr create-cluster --name MY-Cluster ... --bootstrap-actions "Path=s3://my-s3-bucket/grofiler-bootstrap.sh"
+     aws emr create-cluster --name MY-Cluster ... --bootstrap-actions "Path=s3://my-s3-bucket/gprofiler-bootstrap.sh"
      ```
 
 ### Debugging problems


### PR DESCRIPTION

## Description
Add AWS EMR Installation instructions to project README

## Motivation and Context
Make gProfiler installation easy and well explained on AWS EMR.
