### PR TITLE
utils: run_process(): repr() output before logging it

### DIFF
--- a/gprofiler/utils/__init__.py
+++ b/gprofiler/utils/__init__.py
@@ -254,9 +254,9 @@ def run_process(
     logger.debug(f"({process.args!r}) exit code: {result.returncode}")
     if not suppress_log:
         if result.stdout:
-            logger.debug(f"({process.args!r}) stdout: {result.stdout.decode()}")
+            logger.debug(f"({process.args!r}) stdout: {result.stdout.decode()!r}")
         if result.stderr:
-            logger.debug(f"({process.args!r}) stderr: {result.stderr.decode()}")
+            logger.debug(f"({process.args!r}) stderr: {result.stderr.decode()!r}")
     if reraise_exc is not None:
         raise reraise_exc
     elif check and retcode != 0:


### PR DESCRIPTION
Before:
```
[2022-02-15 01:15:44,919] DEBUG: gprofiler.utils: (['/app/gprofiler/resources/java/jattach', '170186', 'load', '/tmp/gprofiler_tmp/async-profiler-v2.6g1/glibc/libasyncProfiler.so', 'true', 'stop,log=/tmp/gprofiler_tmp/tmpz041724c/async-profiler-170186.log,file=/tmp/gprofiler_tmp/tmpz041724c/async-profiler-170186.output,collapsed,ann,sig']) stdout: Connected to remote JVM
JVM response code = 0
0


....
```
After:
```
[2022-02-15 01:17:52,956] DEBUG: gprofiler.utils: (['/app/gprofiler/resources/java/jattach', '170186', 'load', '/tmp/gprofiler_tmp/async-profiler-v2.6g1/glibc/libasyncProfiler.so', 'true', 'stop,log=/tmp/gprofiler_tmp/tmpb521zx97/async-profiler-170186.log,file=/tmp/gprofiler_tmp/tmpb521zx97/async-profiler-170186.output,collapsed,ann,sig']) stdout: 'Connected to remote JVM\nJVM response code = 0\n0\n\n'
```