### PR TITLE
Replace old DockerClient with newer API compatible with Docker and CRI

### DIFF
--- a/.github/workflows/build-container-and-test.yml
+++ b/.github/workflows/build-container-and-test.yml
@@ -30,13 +30,39 @@ jobs:
     - name: Run linters
       run: ./lint.sh --ci
 
-  build-container-and-test:
+  build-container:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    # the tests need the gprofiler image built (from Dockerfile). I run it separately here, because "docker build" prints the build logs
+    # more nicely. the tests will then be able to use the built image.
+    - name: Build gProfiler image
+      run: ./scripts/build_x86_64_container.sh -t gprofiler
+
+    - name: Export gProfiler image
+      run: mkdir -p output && docker image save gprofiler > output/gprofiler.img
+
+    - name: Upload the image artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: gprofiler.img
+        path: output/
+        retention-days: 1
+
+  test:
+    needs: build-container
+
+    runs-on: ubuntu-latest
+
     strategy:
       fail-fast: false  # helps detecting flakiness / errors specific to one Python version
       matrix:
         python-version: [3.6, 3.7, 3.8.8, 3.9.2, 3.10.0]
-
-    runs-on: ubuntu-latest
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}
@@ -62,10 +88,15 @@ jobs:
       with:
         submodules: true
 
-      # the tests need the gprofiler image built (from Dockerfile). I run it separately here, because "docker build" prints the build logs
-      # more nicely. the tests will then be able to use the built image.
-    - name: Build gProfiler image
-      run: ./scripts/build_x86_64_container.sh -t gprofiler
+    - name: Download the executable from previous job
+      uses: actions/download-artifact@v2
+      with:
+        name: gprofiler.img
+        path: output/
+
+    # used for next step (Copy resources ...) and also used in the tests themselves.
+    - name: Import gProfiler image
+      run: docker image load < output/gprofiler.img
 
     - name: Copy resources from gProfiler image
       run: ./scripts/copy_resources_from_image.sh gprofiler

--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ Run the following to have gProfiler running continuously, uploading to Granulate
 docker pull granulate/gprofiler:latest
 docker run --name granulate-gprofiler -d --restart=on-failure:10 \
     --pid=host --userns=host --privileged \
-    -v /var/run/docker.sock:/var/run/docker.sock \
 	granulate/gprofiler:latest -cu --token <token> --service-name <service> [options]
 ```
 

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -8,7 +8,4 @@ services:
     pid: "host"
     userns_mode: "host"
     privileged: true
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-
     command: '-cu --token "<TOKEN>" --service-name "<SERVICE NAME>"'

--- a/deploy/ecs/gprofiler_task_definition.json
+++ b/deploy/ecs/gprofiler_task_definition.json
@@ -16,34 +16,8 @@
                 "--service-name",
                 "<SERVICE NAME>"
             ],
-            "mountPoints": [
-                {
-                  "containerPath": "/var/run/docker.sock",
-                  "sourceVolume": "docker-socket"
-                }
-            ],
             "user": "0:0",
             "privileged": true
-        }
-    ],
-    "volumes": [
-        {
-            "host": {
-                "sourcePath": "/var/run/docker.sock"
-            },
-            "name": "docker-socket"
-        },
-        {
-            "host": {
-                "sourcePath": "/usr/src"
-            },
-            "name": "usr-src"
-        },
-        {
-            "host": {
-                "sourcePath": "/lib/modules"
-            },
-            "name": "lib-modules"
         }
     ],
     "cpu": "500",

--- a/deploy/k8s/gprofiler.yaml
+++ b/deploy/k8s/gprofiler.yaml
@@ -19,10 +19,6 @@ spec:
       labels:
         app: granulate-gprofiler
     spec:
-      volumes:
-        - name: docker-sock # Allow containers to fetch the names
-          hostPath:
-            path: /var/run/docker.sock
       hostPID: true
       securityContext:
         runAsUser: 0
@@ -41,9 +37,6 @@ spec:
               memory: 1Gi
           image: index.docker.io/granulate/gprofiler:latest
           imagePullPolicy: Always
-          volumeMounts:
-            - name: docker-sock
-              mountPath: /var/run/docker.sock
           args:
             - -cu
             - --token

--- a/deploy/k8s/helm-charts/templates/daemonset.yaml
+++ b/deploy/k8s/helm-charts/templates/daemonset.yaml
@@ -34,15 +34,8 @@ spec:
           resources: {{ toYaml .Values.resources | nindent 12 }}
           securityContext:
             privileged: true
-          volumeMounts:
-          - mountPath: /var/run/docker.sock
-            name: docker-sock
       hostPID: true
       restartPolicy: Always
       securityContext:
         runAsGroup: 0
         runAsUser: 0
-      volumes:
-      - hostPath:
-          path: /var/run/docker.sock
-        name: docker-sock

--- a/gprofiler/containers_client.py
+++ b/gprofiler/containers_client.py
@@ -4,7 +4,7 @@
 #
 from typing import Dict, List, Optional, Set
 
-import docker
+from granulate_utils.containers.client import ContainersClient
 from granulate_utils.linux.containers import get_process_container_id
 from psutil import NoSuchProcess
 
@@ -13,20 +13,9 @@ from gprofiler.log import get_logger_adapter
 logger = get_logger_adapter(__name__)
 
 
-class DockerClient:
+class ContainerNamesClient:
     def __init__(self) -> None:
-        try:
-            self._client = docker.from_env()
-        except Exception:
-            logger.warning(
-                "Could not initiate the Docker client, so the profiling data will not include the container"
-                " names. If you are running gProfiler in a container, please mount the Docker sock file"
-                " by running the Docker run command with the following argument:"
-                ' "-v /var/run/docker.sock:/var/run/docker.sock". Otherwise, please open a new issue here:'
-                " https://github.com/Granulate/gprofiler/issues/new"
-            )
-            self._client = None
-
+        self._containers_client = ContainersClient()
         self._pid_to_container_name_cache: Dict[int, str] = {}
         self._current_container_names: Set[str] = set()
         self._container_id_to_name_cache: Dict[str, Optional[str]] = {}
@@ -40,8 +29,6 @@ class DockerClient:
         return list(self._current_container_names)
 
     def get_container_name(self, pid: int) -> str:
-        if self._client is None:
-            return ""
         if pid in self._pid_to_container_name_cache:
             return self._pid_to_container_name_cache[pid]
         container_name: Optional[str] = self._safely_get_process_container_name(pid)
@@ -84,6 +71,5 @@ class DockerClient:
     def _refresh_container_names_cache(self) -> None:
         # We re-fetch all of the currently running containers, so in order to keep the cache small we clear it
         self._container_id_to_name_cache.clear()
-        running_containers = self._client.containers.list()
-        for container in running_containers:
+        for container in self._containers_client.list_containers():
             self._container_id_to_name_cache[container.id] = container.name

--- a/gprofiler/containers_client.py
+++ b/gprofiler/containers_client.py
@@ -41,12 +41,17 @@ class ContainerNamesClient:
         return list(self._current_container_names)
 
     def get_container_name(self, pid: int) -> str:
+        if self._containers_client is None:
+            return ""
+
         if pid in self._pid_to_container_name_cache:
             return self._pid_to_container_name_cache[pid]
+
         container_name: Optional[str] = self._safely_get_process_container_name(pid)
         if container_name is None:
             self._pid_to_container_name_cache[pid] = ""
             return ""
+
         self._pid_to_container_name_cache[pid] = container_name
         return container_name
 

--- a/gprofiler/containers_client.py
+++ b/gprofiler/containers_client.py
@@ -25,6 +25,7 @@ class ContainerNamesClient:
                 " please open a new issue here:"
                 " https://github.com/Granulate/gprofiler/issues/new"
             )
+        logger.info(f"Discovered container runtimes: {self._containers_client.get_runtimes()}")
 
         self._pid_to_container_name_cache: Dict[int, str] = {}
         self._current_container_names: Set[str] = set()

--- a/gprofiler/containers_client.py
+++ b/gprofiler/containers_client.py
@@ -5,6 +5,7 @@
 from typing import Dict, List, Optional, Set
 
 from granulate_utils.containers.client import ContainersClient
+from granulate_utils.exceptions import NoContainerRuntimesError
 from granulate_utils.linux.containers import get_process_container_id
 from psutil import NoSuchProcess
 
@@ -15,7 +16,16 @@ logger = get_logger_adapter(__name__)
 
 class ContainerNamesClient:
     def __init__(self) -> None:
-        self._containers_client = ContainersClient()
+        try:
+            self._containers_client = ContainersClient()
+        except NoContainerRuntimesError:
+            logger.warning(
+                "Could not find a Docker daemon or CRI-compatible daemon, profiling data will not"
+                " include the container names. If you do have a containers runtime and it's not supported,"
+                " please open a new issue here:"
+                " https://github.com/Granulate/gprofiler/issues/new"
+            )
+
         self._pid_to_container_name_cache: Dict[int, str] = {}
         self._current_container_names: Set[str] = set()
         self._container_id_to_name_cache: Dict[str, Optional[str]] = {}

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -24,7 +24,7 @@ from requests import RequestException, Timeout
 
 from gprofiler import __version__, merge
 from gprofiler.client import DEFAULT_UPLOAD_TIMEOUT, GRANULATE_SERVER_HOST, APIClient
-from gprofiler.docker_client import DockerClient
+from gprofiler.containers_client import ContainerNamesClient
 from gprofiler.exceptions import APIError, SystemProfilerInitFailure
 from gprofiler.gprofiler_types import ProcessToStackSampleCounters, UserArgs, positive_integer
 from gprofiler.log import RemoteLogsHandler, initial_root_logger_setup
@@ -128,9 +128,9 @@ class GProfiler:
             logger.exception("System profiler initialization has failed, exiting...")
             sys.exit(1)
         if include_container_names and profile_api_version != "v1":
-            self._docker_client: Optional[DockerClient] = DockerClient()
+            self._container_names_client: Optional[ContainerNamesClient] = ContainerNamesClient()
         else:
-            self._docker_client = None
+            self._container_names_client = None
         self._usage_logger = usage_logger
         if collect_metrics:
             self._system_metrics_monitor: SystemMetricsMonitorBase = SystemMetricsMonitor(self._stop_event)
@@ -282,7 +282,7 @@ class GProfiler:
             assert system_result == {}, system_result  # should be empty!
             merged_result, total_samples = merge.concatenate_profiles(
                 process_profiles,
-                self._docker_client,
+                self._container_names_client,
                 self._profile_api_version != "v1",
                 self._identify_applications,
                 metadata,
@@ -293,7 +293,7 @@ class GProfiler:
             merged_result, total_samples = merge.merge_profiles(
                 system_result,
                 process_profiles,
-                self._docker_client,
+                self._container_names_client,
                 self._profile_api_version != "v1",
                 self._identify_applications,
                 metadata,

--- a/lint.sh
+++ b/lint.sh
@@ -10,7 +10,7 @@ if [[ "$1" = "--ci" ]]; then
     check_arg="--check"
 fi
 
-isort --settings-path .isort.cfg --skip granulate_utils/ .
-black --line-length 120 $check_arg --exclude granulate_utils/ .
+isort --settings-path .isort.cfg --skip granulate-utils .
+black --line-length 120 $check_arg --exclude granulate-utils .
 flake8 --config .flake8 .
 mypy .

--- a/lint.sh
+++ b/lint.sh
@@ -10,7 +10,7 @@ if [[ "$1" = "--ci" ]]; then
     check_arg="--check"
 fi
 
-isort --settings-path .isort.cfg .
-black --line-length 120 $check_arg .
+isort --settings-path .isort.cfg --skip granulate_utils/ .
+black --line-length 120 $check_arg --exclude granulate_utils/ .
 flake8 --config .flake8 .
 mypy .

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ psutil==5.8.0
 requests==2.25.1
 ConfigArgParse==1.3
 distro==1.5.0
-docker==5.0.0
 setuptools==59.4.0  # For pkg_resources
 six==1.16.0
 dataclasses==0.8; python_version < '3.7'

--- a/scripts/async_profiler_env_glibc.sh
+++ b/scripts/async_profiler_env_glibc.sh
@@ -18,4 +18,12 @@ function fix_legacy_repos() {
 fix_legacy_repos
 yum install -y centos-release-scl
 fix_legacy_repos  # fix again, after adding new scl repos
-yum install -y devtoolset-7-toolchain make java-1.8.0-openjdk-devel glibc-static git
+# install with retries - this tends to fail in the CI for networking reasons.
+retries=5
+counter=0
+until yum install -y devtoolset-7-toolchain make java-1.8.0-openjdk-devel glibc-static git
+do
+   [[ counter -eq $retries ]] && echo "yum install failed $retries times!" && exit 1
+   echo "Trying yum install again... $counter"
+   ((counter++))
+done

--- a/scripts/async_profiler_env_glibc.sh
+++ b/scripts/async_profiler_env_glibc.sh
@@ -18,12 +18,4 @@ function fix_legacy_repos() {
 fix_legacy_repos
 yum install -y centos-release-scl
 fix_legacy_repos  # fix again, after adding new scl repos
-# install with retries - this tends to fail in the CI for networking reasons.
-retries=5
-counter=0
-until yum install -y devtoolset-7-toolchain make java-1.8.0-openjdk-devel glibc-static git
-do
-   [[ counter -eq $retries ]] && echo "yum install failed $retries times!" && exit 1
-   echo "Trying yum install again... $counter"
-   ((counter++))
-done
+yum install -y devtoolset-7-toolchain make java-1.8.0-openjdk-devel glibc-static git


### PR DESCRIPTION
## Description
Builds upon https://github.com/Granulate/granulate-utils/pull/32 and https://github.com/Granulate/granulate-utils/pull/31 which provide unified API to list containers across other runtimes, for container name resolving (up until now we had just Docker, now we've gained support for CRI-based ones in k8s: containerd and cri-o).

Along the way, I no longer require to map the Docker socket. We run as host PID so from now on we'll use `/proc/1/root/var/run/docker.sock` etc.

## Motivation and Context
[Docker is going away in k8s](https://kubernetes.io/blog/2020/12/02/dont-panic-kubernetes-and-docker/) so resolving names via Docker doesn't work in newer k8s clusters.

## How Has This Been Tested?
1. Tested the API on a local k8s minikube (importing stuff from granulate-utils)
2. Tested gProfiler on my box (Docker) and container names are still resolved okay.
3. Ran gProfiler on a runtime=container k8s cluster and container names were resolved okay.

To be tested:
* [x] runtime=crio cluster