### PR TITLE
python: Fix PyPerf for 3.10

### DIFF
--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -5,7 +5,7 @@
 #
 set -e
 
-git clone --depth 1 -b v1.2.1 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 3f1d60180946852aa89e3644b786e4bf8934e7a9
+git clone --depth 1 -b fix-3.10 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard d5f93874f84bf38cad8c913edf9ba0020518c319
 
 # (after clone, because we copy the licenses)
 # TODO support aarch64

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -5,7 +5,7 @@
 #
 set -e
 
-git clone --depth 1 -b fix-3.10 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard d5f93874f84bf38cad8c913edf9ba0020518c319
+git clone --depth 1 -b v1.2.2 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 2c991423e7b20d36a3bda3ff9393967c87139227
 
 # (after clone, because we copy the licenses)
 # TODO support aarch64

--- a/tests/containers/python/lister.py
+++ b/tests/containers/python/lister.py
@@ -9,13 +9,16 @@ from threading import Thread
 import yaml
 
 
-def lister() -> None:
-    os.listdir("/")  # have some kernel stacks
+class Lister(object):
+    @classmethod
+    def lister(cls) -> None:
+        os.listdir("/")  # have some kernel stacks & Python stacks from a class method
 
 
-def burner() -> None:
-    while True:  # have some Python stacks
-        pass
+class Burner(object):
+    def burner(self) -> None:
+        while True:  # have some Python stacks from an instance method
+            pass
 
 
 def parser() -> None:
@@ -26,7 +29,8 @@ def parser() -> None:
 
 
 if __name__ == "__main__":
-    Thread(target=burner).start()
+    Thread(target=Burner().burner).start()
     Thread(target=parser).start()
+    lister = Lister()
     while True:
-        lister()
+        lister.lister()

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -128,8 +128,12 @@ def test_python_ebpf(
         assert_function_in_collapsed(
             "_PyEval_EvalFrameDefault_[pn]", process_collapsed
         )  # ensure native user stacks exist
-        assert_function_in_collapsed("PyYAML==6.0", process_collapsed)  # ensure package info is presented
-        # ensure Python version is presented
+        # ensure class name exist for instance methods
+        assert_function_in_collapsed("lister.Burner.burner", process_collapsed)
+        # ensure class name exist for class methods
+        assert_function_in_collapsed("lister.Lister.lister", process_collapsed)
+        assert_function_in_collapsed("PyYAML==6.0", process_collapsed)  # ensure package info is present
+        # ensure Python version is present
         assert python_version is not None, "Failed to find python version"
         assert_function_in_collapsed(f"standard-library=={python_version}", process_collapsed)
 

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -128,12 +128,12 @@ def test_python_ebpf(
         assert_function_in_collapsed(
             "_PyEval_EvalFrameDefault_[pn]", process_collapsed
         )  # ensure native user stacks exist
-        # ensure class name exist for instance methods
+        # ensure class name exists for instance methods
         assert_function_in_collapsed("lister.Burner.burner", process_collapsed)
-        # ensure class name exist for class methods
+        # ensure class name exists for class methods
         assert_function_in_collapsed("lister.Lister.lister", process_collapsed)
-        assert_function_in_collapsed("PyYAML==6.0", process_collapsed)  # ensure package info is present
-        # ensure Python version is present
+        assert_function_in_collapsed("PyYAML==6.0", process_collapsed)  # ensure package info exists
+        # ensure Python version exists
         assert python_version is not None, "Failed to find python version"
         assert_function_in_collapsed(f"standard-library=={python_version}", process_collapsed)
 


### PR DESCRIPTION
BCC PR: https://github.com/Granulate/bcc/pull/35

Basically, upgrade PyPerf reference post the fixing PR, and add some tests that would catch the issue explicitly.

I found this using https://github.com/Granulate/gprofiler/pull/268 - which showed me that tests occasionally failed because Python 3.10 was running on the runner (e.g was running our pytest) and it had class names which were read incorrectly - reading random binary data which was later not decoded correctly. That's why it was statistical - because profiling is statistical :/ and sometimes stacks with class names were not encountered in the profile.

Lessons learned: try and test all flows, because some flows that you don't test might be "automatically" tested by your system-wide profiler doing its profiling on random crap on your system. Failing your tests unexpectedly. Argh