### PR TITLE
Build async-profiler on CentOS 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,11 @@ ARG PYPERF_BUILDER_UBUNTU=@sha256:cf31af331f38d1d7158470e095b132acd126a7180a54f2
 ARG PERF_BUILDER_UBUNTU=@sha256:d7bb0589725587f2f67d0340edb81fd1fcba6c5f38166639cf2a252c939aa30c
 # phpspy - ubuntu:20.04
 ARG PHPSPY_BUILDER_UBUNTU=@sha256:cf31af331f38d1d7158470e095b132acd126a7180a54f263d386da88eb681d93
-# async-profiler glibc build, requires CentOS 6, so the built DSO can be loaded into machines running with old glibc - centos:6
-ARG AP_BUILDER_CENTOS=@sha256:dec8f471302de43f4cfcf82f56d99a5227b5ea1aa6d02fa56344986e1f4610e7
+# async-profiler glibc build
+# requires CentOS 7 so the built DSO can be loaded into machines running with old glibc (tested up to centos:6),
+# we do make some modifications to the selected versioned symbols so that we don't use anything from >2.12 (what centos:6
+# has)
+ARG AP_BUILDER_CENTOS=@sha256:0f4ec88e21daf75124b8a9e5ca03c37a5e937e0e108a255d890492430789b60e
 # async-profiler musl build - alpine 3.14.2
 ARG AP_BUILDER_ALPINE=@sha256:69704ef328d05a9f806b6b8502915e6a0a4faa4d72018dc42343f511490daf8a
 # burn - golang:1.16.3

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -8,9 +8,8 @@ ARG RUST_BUILDER_VERSION=@sha256:9c106c1222abe1450f45774273f36246ebf257623ed5128
 ARG PERF_BUILDER_UBUNTU=@sha256:d7bb0589725587f2f67d0340edb81fd1fcba6c5f38166639cf2a252c939aa30c
 # phpspy - ubuntu:20.04
 ARG PHPSPY_BUILDER_UBUNTU=@sha256:cf31af331f38d1d7158470e095b132acd126a7180a54f263d386da88eb681d93
-# async-profiler glibc - centos:6
-# requires CentOS 6 so the built DSO can be loaded into machines running with old glibc - centos:6
-ARG AP_BUILDER_CENTOS=@sha256:dec8f471302de43f4cfcf82f56d99a5227b5ea1aa6d02fa56344986e1f4610e7
+# async-profiler glibc - centos:7, see explanation in Dockerfile
+ARG AP_BUILDER_CENTOS=@sha256:0f4ec88e21daf75124b8a9e5ca03c37a5e937e0e108a255d890492430789b60e
 # async-profiler musl build
 ARG AP_BUILDER_ALPINE=@sha256:69704ef328d05a9f806b6b8502915e6a0a4faa4d72018dc42343f511490daf8a
 # burn - golang:1.16.3

--- a/scripts/async_profiler_build_shared.sh
+++ b/scripts/async_profiler_build_shared.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 VERSION=v2.6g2
-GIT_REV="0d04078e0586793e852beb11ab285185c447e986"
+GIT_REV="7847b9f7f2cc07707ab4f407fdce4b734602a2bd"
 
 git clone --depth 1 -b "$VERSION" https://github.com/Granulate/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
 source "$1"

--- a/scripts/async_profiler_build_shared.sh
+++ b/scripts/async_profiler_build_shared.sh
@@ -5,8 +5,8 @@
 #
 set -euo pipefail
 
-VERSION=v2.6g1
-GIT_REV="717d501ddb9da3b8a2cf30e800bc84cf110da150"
+VERSION=v2.6g2
+GIT_REV="0d04078e0586793e852beb11ab285185c447e986"
 
 git clone --depth 1 -b "$VERSION" https://github.com/Granulate/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
 source "$1"

--- a/scripts/async_profiler_env_glibc.sh
+++ b/scripts/async_profiler_env_glibc.sh
@@ -5,17 +5,5 @@
 #
 set -euo pipefail
 
-function fix_legacy_repos() {
-    # needed only on x86_64 (which uses CentOS 6)
-    if [ $(uname -m) = "x86_64" ]; then
-        # fix legacy yum repos. slightly adapted from https://stackoverflow.com/a/53848450
-        # this basically comments out all mirrorlist URLs, uncomments all baseurls (all seem to be commented)
-        # and replaces the domain from mirror.centos.org to vault.centos.org.
-        sed -i -e 's|^mirrorlist|#mirrorlist|' -e 's|^# *baseurl|baseurl|' -e 's|mirror.centos.org|vault.centos.org|' /etc/yum.repos.d/*
-    fi
-}
-
-fix_legacy_repos
 yum install -y centos-release-scl
-fix_legacy_repos  # fix again, after adding new scl repos
 yum install -y devtoolset-7-toolchain make java-1.8.0-openjdk-devel glibc-static git


### PR DESCRIPTION
My trigger for that are the lousy mirrors of CentOS 6, which make our CI flaky.
In any case, it's a hassle to continue using CentOS 6 in any way.

This commit fixes the build to be CentOS 7 based. It's old enough glibc to run on
old kernels, and I verified that the only relevant symbol which required glibc>2.12
now gets versioned to something older as well.

See the fix for AP here: https://github.com/Granulate/async-profiler/commit/0d04078e0586793e852beb11ab285185c447e986

I tested the before & after with https://gist.github.com/Jongy/56f33f4b8a3e04b41d1afb85b47121a1:
before - 
```
glibc version: 2.14
glibcxx version: 3.4.9
```
after -
```
glibc version: 2.4
glibcxx version: 3.4.9
```

and I expect that the executable test on `centos:6` will also cover me here :sweat_smile: 