### PR TITLE
java: repr(jvm_version) in all sites, as it's not serializable

### DIFF
--- a/gprofiler/log.py
+++ b/gprofiler/log.py
@@ -138,6 +138,13 @@ class RemoteLogsHandler(logging.Handler):
         formatted_timestamp = datetime.datetime.utcfromtimestamp(record.created).isoformat()
         extra = record.gprofiler_adapter_extra  # type: ignore
 
+        run_id = extra.pop(RUN_ID_KEY, None)
+        if run_id is None:
+            self._logger.error("state.run_id is not defined! probably a bug!")
+            run_id = ""
+
+        cycle_id = extra.pop(CYCLE_ID_KEY, "")
+
         # We don't want to serialize a JSON inside JSON but either don't want to fail record because of extra
         # serialization, so we test if the extra can be serialized and have a fail-safe.
         try:
@@ -147,13 +154,6 @@ class RemoteLogsHandler(logging.Handler):
                 f"Can't serialize extra (extra={extra!r}), sending empty extra", bad_extra=repr(extra)
             )
             extra = {}
-
-        run_id = extra.pop(RUN_ID_KEY, None)
-        if run_id is None:
-            self._logger.error("state.run_id is not defined! probably a bug!")
-            run_id = ""
-
-        cycle_id = extra.pop(CYCLE_ID_KEY, "")
 
         assert self.formatter is not None
         if record.exc_info:

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -623,7 +623,7 @@ class JavaProfiler(ProcessProfilerBase):
     def _is_jvm_version_supported(self, java_version_cmd_output: str) -> bool:
         try:
             jvm_version = parse_jvm_version(java_version_cmd_output)
-            logger.info("Checking support for java version", jvm_version=jvm_version)
+            logger.info("Checking support for java version", jvm_version=repr(jvm_version))
         except Exception:
             logger.exception("Failed to parse java -version output", java_version_cmd_output=java_version_cmd_output)
             return False


### PR DESCRIPTION
## Description
Solves this:
```
[2022-02-23 10:40:27,597] ERROR: gprofiler.RemoteLogsHandler: Can't serialize extra (extra={'jvm_version': JvmVersion(8.111, 14, 'OpenJDK 64-Bit Server VM'), 'run_id': 'ec30de5e-2c78-4a15-bce9-b740e2b43668', 'cycle_id': 'ec30de5e-2c78-4a15-bce9-b740e2b43668'}), sending empty extra
Traceback (most recent call last):
  File "/app/gprofiler/log.py", line 144, in _make_dict_record
    json.dumps(extra)
  File "/usr/lib/python3.8/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/python3.8/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.8/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib/python3.8/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type JvmVersion is not JSON serializable (bad_extra={'jvm_version': JvmVersion(8.111, 14, 'OpenJDK 64-Bit Server VM'), 'run_id': 'ec30de5e-2c78-4a15-bce9-b740e2b43668', 'cycle_id': 'ec30de5e-2c78-4a15-bce9-b740e2b43668'})
```

and also this:
```
[2022-02-23 10:40:27,598] ERROR: gprofiler.RemoteLogsHandler: state.run_id is not defined! probably a bug!
```