### PR TITLE
java: Fix _check_async_profiler_loaded() for cases where resolved storage path differs

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -737,7 +737,7 @@ class JavaProfiler(ProcessProfilerBase):
             # the resolved path of TEMPORARY_STORAGE_PATH might be different from TEMPORARY_STORAGE_PATH itself,
             # and in the mmap.path we're seeing the resolved path. it's a hassle to resolve it here - this
             # check is good enough, possibly only too strict, not too loose.
-            if "libasyncProfiler.so" in mmap.path and GPROFILER_DIRECTORY_NAME in mmap.path:
+            if "libasyncProfiler.so" in mmap.path and GPROFILER_DIRECTORY_NAME not in mmap.path:
                 logger.warning(
                     "Non-gProfiler async-profiler is already loaded to the target process."
                     f" Disable --java-safemode={JavaSafemodeOptions.AP_LOADED_CHECK} to bypass this check.",

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -737,7 +737,7 @@ class JavaProfiler(ProcessProfilerBase):
             # the resolved path of TEMPORARY_STORAGE_PATH might be different from TEMPORARY_STORAGE_PATH itself,
             # and in the mmap.path we're seeing the resolved path. it's a hassle to resolve it here - this
             # check is good enough, possibly only too strict, not too loose.
-            if "libasyncProfiler.so" in mmap.path and GPROFILER_DIRECTORY_NAME not in mmap.path:
+            if "libasyncProfiler.so" in mmap.path and f"/{GPROFILER_DIRECTORY_NAME}/" not in mmap.path:
                 logger.warning(
                     "Non-gProfiler async-profiler is already loaded to the target process."
                     f" Disable --java-safemode={JavaSafemodeOptions.AP_LOADED_CHECK} to bypass this check.",

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -45,6 +45,7 @@ from gprofiler.merge import parse_one_collapsed
 from gprofiler.profilers.profiler_base import ProcessProfilerBase
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
 from gprofiler.utils import (
+    GPROFILER_DIRECTORY_NAME,
     TEMPORARY_STORAGE_PATH,
     pgrep_maps,
     remove_path,
@@ -732,7 +733,11 @@ class JavaProfiler(ProcessProfilerBase):
             return False
 
         for mmap in process.memory_maps():
-            if "libasyncProfiler.so" in mmap.path and not mmap.path.startswith(TEMPORARY_STORAGE_PATH):
+            # checking only with GPROFILER_DIRECTORY_NAME and not TEMPORARY_STORAGE_PATH;
+            # the resolved path of TEMPORARY_STORAGE_PATH might be different from TEMPORARY_STORAGE_PATH itself,
+            # and in the mmap.path we're seeing the resolved path. it's a hassle to resolve it here - this
+            # check is good enough, possibly only too strict, not too loose.
+            if "libasyncProfiler.so" in mmap.path and GPROFILER_DIRECTORY_NAME in mmap.path:
                 logger.warning(
                     "Non-gProfiler async-profiler is already loaded to the target process."
                     f" Disable --java-safemode={JavaSafemodeOptions.AP_LOADED_CHECK} to bypass this check.",

--- a/gprofiler/utils/__init__.py
+++ b/gprofiler/utils/__init__.py
@@ -43,7 +43,8 @@ from gprofiler.log import get_logger_adapter
 
 logger = get_logger_adapter(__name__)
 
-TEMPORARY_STORAGE_PATH = "/tmp/gprofiler_tmp"
+GPROFILER_DIRECTORY_NAME = "gprofiler_tmp"
+TEMPORARY_STORAGE_PATH = f"/tmp/{GPROFILER_DIRECTORY_NAME}"
 
 gprofiler_mutex: Optional[socket.socket] = None
 


### PR DESCRIPTION
If e.g `/tmp` is a symlink to `/var/tmp`, then this check would fail. Now it'll pass in either case.