### PR TITLE
Better java app id resolving

### DIFF
--- a/gprofiler/merge.py
+++ b/gprofiler/merge.py
@@ -10,10 +10,10 @@ from collections import Counter, defaultdict
 from pathlib import Path
 from typing import Iterable, Optional, Tuple
 
-import gprofiler.metadata.application_identifiers
 from gprofiler.containers_client import ContainerNamesClient
 from gprofiler.gprofiler_types import ProcessToStackSampleCounters, StackToSampleCount
 from gprofiler.log import get_logger_adapter
+from gprofiler.metadata import application_identifiers
 from gprofiler.metadata.metadata_type import Metadata
 from gprofiler.system_metrics import Metrics
 
@@ -256,9 +256,7 @@ def concatenate_profiles(
 
     for pid, stacks in process_profiles.items():
         container_name = _get_container_name(pid, container_names_client, add_container_names)
-        application_name = (
-            gprofiler.metadata.application_identifiers.get_application_name(pid) if identify_applications else None
-        )
+        application_name = application_identifiers.get_application_name(pid) if identify_applications else None
         if application_name is not None:
             application_name = f"appid: {application_name}"
         prefix = (container_name + ";") if add_container_names else ""

--- a/gprofiler/merge.py
+++ b/gprofiler/merge.py
@@ -10,10 +10,10 @@ from collections import Counter, defaultdict
 from pathlib import Path
 from typing import Iterable, Optional, Tuple
 
+import gprofiler.metadata.application_identifiers
 from gprofiler.containers_client import ContainerNamesClient
 from gprofiler.gprofiler_types import ProcessToStackSampleCounters, StackToSampleCount
 from gprofiler.log import get_logger_adapter
-from gprofiler.metadata.application_identifiers import get_application_name
 from gprofiler.metadata.metadata_type import Metadata
 from gprofiler.system_metrics import Metrics
 
@@ -256,7 +256,9 @@ def concatenate_profiles(
 
     for pid, stacks in process_profiles.items():
         container_name = _get_container_name(pid, container_names_client, add_container_names)
-        application_name = get_application_name(pid) if identify_applications else None
+        application_name = (
+            gprofiler.metadata.application_identifiers.get_application_name(pid) if identify_applications else None
+        )
         if application_name is not None:
             application_name = f"appid: {application_name}"
         prefix = (container_name + ";") if add_container_names else ""

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -37,11 +37,11 @@ from granulate_utils.linux.signals import get_signal_entry
 from packaging.version import Version
 from psutil import Process
 
+import gprofiler.merge
 from gprofiler.exceptions import CalledProcessError
 from gprofiler.gprofiler_types import ProcessToStackSampleCounters, StackToSampleCount
 from gprofiler.kernel_messages import get_kernel_messages_provider
 from gprofiler.log import get_logger_adapter
-from gprofiler.merge import parse_one_collapsed
 from gprofiler.profilers.profiler_base import ProcessProfilerBase
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
 from gprofiler.utils import (
@@ -809,7 +809,7 @@ class JavaProfiler(ProcessProfilerBase):
             return self._profiling_error_stack("error", "process exited before reading the output", comm)
         else:
             logger.info(f"Finished profiling process {ap_proc.process.pid}")
-            return parse_one_collapsed(output, comm)
+            return gprofiler.merge.parse_one_collapsed(output, comm)
 
     def _check_hotspot_error(self, ap_proc: AsyncProfiledProcess) -> None:
         pid = ap_proc.process.pid

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -37,7 +37,7 @@ from granulate_utils.linux.signals import get_signal_entry
 from packaging.version import Version
 from psutil import Process
 
-import gprofiler.merge
+from gprofiler import merge
 from gprofiler.exceptions import CalledProcessError
 from gprofiler.gprofiler_types import ProcessToStackSampleCounters, StackToSampleCount
 from gprofiler.kernel_messages import get_kernel_messages_provider
@@ -809,7 +809,7 @@ class JavaProfiler(ProcessProfilerBase):
             return self._profiling_error_stack("error", "process exited before reading the output", comm)
         else:
             logger.info(f"Finished profiling process {ap_proc.process.pid}")
-            return gprofiler.merge.parse_one_collapsed(output, comm)
+            return merge.parse_one_collapsed(output, comm)
 
     def _check_hotspot_error(self, ap_proc: AsyncProfiledProcess) -> None:
         pid = ap_proc.process.pid

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -9,10 +9,10 @@ from subprocess import Popen
 from threading import Event
 from typing import List, Optional
 
+import gprofiler.merge
 from gprofiler.exceptions import StopEventSetException
 from gprofiler.gprofiler_types import ProcessToStackSampleCounters
 from gprofiler.log import get_logger_adapter
-from gprofiler.merge import merge_global_perfs
 from gprofiler.profilers.profiler_base import ProfilerBase
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
 from gprofiler.utils import run_process, start_process, wait_event, wait_for_file_by_prefix
@@ -202,7 +202,7 @@ class SystemProfiler(ProfilerBase):
         for perf in self._perfs:
             perf.switch_output()
 
-        return merge_global_perfs(
+        return gprofiler.merge.merge_global_perfs(
             self._perf_fp.wait_and_script() if self._perf_fp is not None else None,
             self._perf_dwarf.wait_and_script() if self._perf_dwarf is not None else None,
         )

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -9,7 +9,7 @@ from subprocess import Popen
 from threading import Event
 from typing import List, Optional
 
-import gprofiler.merge
+from gprofiler import merge
 from gprofiler.exceptions import StopEventSetException
 from gprofiler.gprofiler_types import ProcessToStackSampleCounters
 from gprofiler.log import get_logger_adapter
@@ -202,7 +202,7 @@ class SystemProfiler(ProfilerBase):
         for perf in self._perfs:
             perf.switch_output()
 
-        return gprofiler.merge.merge_global_perfs(
+        return merge.merge_global_perfs(
             self._perf_fp.wait_and_script() if self._perf_fp is not None else None,
             self._perf_dwarf.wait_and_script() if self._perf_dwarf is not None else None,
         )

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -17,7 +17,7 @@ from granulate_utils.linux.process import is_process_running, process_exe
 from granulate_utils.python import _BLACKLISTED_PYTHON_PROCS, DETECTED_PYTHON_PROCESSES_REGEX
 from psutil import NoSuchProcess, Process
 
-import gprofiler.merge
+from gprofiler import merge
 from gprofiler.exceptions import (
     CalledProcessError,
     CalledProcessTimeoutError,
@@ -147,7 +147,7 @@ class PySpyProfiler(ProcessProfilerBase):
                 raise
 
             logger.info(f"Finished profiling process {process.pid} with py-spy")
-            parsed = gprofiler.merge.parse_one_collapsed_file(Path(local_output_path), comm)
+            parsed = merge.parse_one_collapsed_file(Path(local_output_path), comm)
             if self.add_versions:
                 parsed = _add_versions_to_process_stacks(process, parsed)
             return parsed
@@ -368,7 +368,7 @@ class PythonEbpfProfiler(ProfilerBase):
         finally:
             # always remove, even if we get read/decode errors
             collapsed_path.unlink()
-        parsed = gprofiler.merge.parse_many_collapsed(collapsed_text)
+        parsed = merge.parse_many_collapsed(collapsed_text)
         if self.add_versions:
             parsed = _add_versions_to_stacks(parsed)
         return parsed

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -17,6 +17,7 @@ from granulate_utils.linux.process import is_process_running, process_exe
 from granulate_utils.python import _BLACKLISTED_PYTHON_PROCS, DETECTED_PYTHON_PROCESSES_REGEX
 from psutil import NoSuchProcess, Process
 
+import gprofiler.merge
 from gprofiler.exceptions import (
     CalledProcessError,
     CalledProcessTimeoutError,
@@ -25,7 +26,6 @@ from gprofiler.exceptions import (
 )
 from gprofiler.gprofiler_types import ProcessToStackSampleCounters, StackToSampleCount, nonnegative_integer
 from gprofiler.log import get_logger_adapter
-from gprofiler.merge import parse_many_collapsed, parse_one_collapsed_file
 from gprofiler.metadata.py_module_version import get_modules_versions
 from gprofiler.metadata.system_metadata import get_arch
 from gprofiler.profilers.profiler_base import ProcessProfilerBase, ProfilerBase, ProfilerInterface
@@ -147,7 +147,7 @@ class PySpyProfiler(ProcessProfilerBase):
                 raise
 
             logger.info(f"Finished profiling process {process.pid} with py-spy")
-            parsed = parse_one_collapsed_file(Path(local_output_path), comm)
+            parsed = gprofiler.merge.parse_one_collapsed_file(Path(local_output_path), comm)
             if self.add_versions:
                 parsed = _add_versions_to_process_stacks(process, parsed)
             return parsed
@@ -368,7 +368,7 @@ class PythonEbpfProfiler(ProfilerBase):
         finally:
             # always remove, even if we get read/decode errors
             collapsed_path.unlink()
-        parsed = parse_many_collapsed(collapsed_text)
+        parsed = gprofiler.merge.parse_many_collapsed(collapsed_text)
         if self.add_versions:
             parsed = _add_versions_to_stacks(parsed)
         return parsed

--- a/gprofiler/profilers/ruby.py
+++ b/gprofiler/profilers/ruby.py
@@ -10,7 +10,7 @@ from typing import List, Optional
 
 from psutil import Process
 
-import gprofiler.merge
+from gprofiler import merge
 from gprofiler.exceptions import ProcessStoppedException, StopEventSetException
 from gprofiler.gprofiler_types import StackToSampleCount
 from gprofiler.log import get_logger_adapter
@@ -75,7 +75,7 @@ class RbSpyProfiler(ProcessProfilerBase):
                 raise StopEventSetException
 
             logger.info(f"Finished profiling process {process.pid} with rbspy")
-            return gprofiler.merge.parse_one_collapsed_file(Path(local_output_path), process_comm(process))
+            return merge.parse_one_collapsed_file(Path(local_output_path), process_comm(process))
 
     def _select_processes_to_profile(self) -> List[Process]:
         return pgrep_maps(r"(?:^.+/ruby[^/]*$)")

--- a/gprofiler/profilers/ruby.py
+++ b/gprofiler/profilers/ruby.py
@@ -10,10 +10,10 @@ from typing import List, Optional
 
 from psutil import Process
 
+import gprofiler.merge
 from gprofiler.exceptions import ProcessStoppedException, StopEventSetException
 from gprofiler.gprofiler_types import StackToSampleCount
 from gprofiler.log import get_logger_adapter
-from gprofiler.merge import parse_one_collapsed_file
 from gprofiler.profilers.profiler_base import ProcessProfilerBase
 from gprofiler.profilers.registry import register_profiler
 from gprofiler.utils import pgrep_maps, random_prefix, removed_path, resource_path, run_process
@@ -75,7 +75,7 @@ class RbSpyProfiler(ProcessProfilerBase):
                 raise StopEventSetException
 
             logger.info(f"Finished profiling process {process.pid} with rbspy")
-            return parse_one_collapsed_file(Path(local_output_path), process_comm(process))
+            return gprofiler.merge.parse_one_collapsed_file(Path(local_output_path), process_comm(process))
 
     def _select_processes_to_profile(self) -> List[Process]:
         return pgrep_maps(r"(?:^.+/ruby[^/]*$)")

--- a/lint.sh
+++ b/lint.sh
@@ -11,6 +11,6 @@ if [[ "$1" = "--ci" ]]; then
 fi
 
 isort --settings-path .isort.cfg --skip granulate-utils .
-black --line-length 120 $check_arg --exclude granulate-utils .
+black --line-length 120 $check_arg --exclude "granulate-utils|\.venv" .
 flake8 --config .flake8 .
 mypy .


### PR DESCRIPTION
Use the `sun.java.command` Java property as app ID for Java applications. This property contains the JAR if the program is run using `-jar`, or the provided main class otherwise. It also contains the arguments passed to the program.
`sun.java.command` is extracted by running `jattach` in `properties` mode for each Java process.