### PR TITLE
Removes intermediate containers when using docker SDK to build images.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -178,11 +178,11 @@ def gprofiler_docker_image(docker_client: DockerClient) -> Iterable[Image]:
 def application_docker_images(docker_client: DockerClient) -> Iterable[Mapping[str, Image]]:
     images = {}
     for runtime in os.listdir(str(CONTAINERS_DIRECTORY)):
-        images[runtime], _ = docker_client.images.build(path=str(CONTAINERS_DIRECTORY / runtime))
+        images[runtime], _ = docker_client.images.build(path=str(CONTAINERS_DIRECTORY / runtime), rm=True)
         musl_dockerfile = CONTAINERS_DIRECTORY / runtime / "musl.Dockerfile"
         if musl_dockerfile.exists():
             images[runtime + "_musl"], _ = docker_client.images.build(
-                path=str(CONTAINERS_DIRECTORY / runtime), dockerfile=str(musl_dockerfile)
+                path=str(CONTAINERS_DIRECTORY / runtime), dockerfile=str(musl_dockerfile), rm=True
             )
 
     yield images

--- a/tests/test_libpython.py
+++ b/tests/test_libpython.py
@@ -23,7 +23,7 @@ def runtime() -> str:
 @pytest.fixture(scope="session")
 def application_docker_image(docker_client: DockerClient) -> Image:
     dockerfile = CONTAINERS_DIRECTORY / "python" / "Dockerfile.libpython"
-    image: Image = docker_client.images.build(path=str(dockerfile.parent), dockerfile=str(dockerfile))[0]
+    image: Image = docker_client.images.build(path=str(dockerfile.parent), dockerfile=str(dockerfile), rm=True)[0]
     yield image
     docker_client.images.remove(image.id, force=True)
 


### PR DESCRIPTION
From the documentation:
```
rm (bool): Remove intermediate containers. The ``docker build``
                command now defaults to ``--rm=true``, but we have kept the old
                default of `False` to preserve backward compatibility
```

<!--- Provide a general summary of your changes in the Title above -->

