### PR TITLE
Python: Bugfix: Catch OSError when getting dists metadata

### DIFF
--- a/gprofiler/metadata/py_module_version.py
+++ b/gprofiler/metadata/py_module_version.py
@@ -95,7 +95,7 @@ def _files_from_record(dist: pkg_resources.Distribution) -> Optional[Iterator[st
     """Based on _files_from_record in pip._internal.commands.show.search_packages_info"""
     try:
         text = dist.get_metadata("RECORD")
-    except (FileNotFoundError, KeyError):
+    except (OSError, KeyError):
         return None
     # This extra Path-str cast normalizes entries.
     return (str(pathlib.Path(row[0])) for row in csv.reader(text.splitlines()))
@@ -105,7 +105,7 @@ def _files_from_legacy(dist: pkg_resources.Distribution) -> Optional[Iterator[st
     """Based on _files_from_legacy in pip._internal.commands.show.search_packages_info"""
     try:
         text = dist.get_metadata("installed-files.txt")
-    except (FileNotFoundError, KeyError):
+    except (OSError, KeyError):
         return None
     paths = (p for p in text.splitlines(keepends=False) if p)
     root = dist.location


### PR DESCRIPTION
## Description
Except the more general `OSError` instead of `FileNotFoundError` when calling `dist.get_metadata`. Apparently it might be `raise`d.

## Related Issue
<!--- If there's an issue related, please link it here -->
<!--- If suggesting a new feature or a medium/big change, please discuss it in an issue first. -->
<!--- For small changes, it's okay to open a PR immediately. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What does it improve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your changes are tested by the CI, you can just write that.-->

## Screenshots
<!--- (if appropriate) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
