### PR TITLE
appid: Remove full path from java appid

### DIFF
--- a/gprofiler/metadata/application_identifiers.py
+++ b/gprofiler/metadata/application_identifiers.py
@@ -252,7 +252,7 @@ class _JavaJarApplicationIdentifier(_ApplicationIdentifier):
             for line in java_properties.splitlines():
                 if line.startswith("sun.java.command"):
                     app_id = line[line.find("=") + 1 :].split(" ", 1)[0]
-                    return f"java: {app_id} ({_append_file_to_proc_wd(process, app_id)})"
+                    return f"java: {app_id}"
         except CalledProcessError as e:
             _logger.warning(f"Couldn't get Java properties for process {process.pid}: {e.stderr}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -308,7 +308,7 @@ def assert_collapsed(runtime: str) -> AssertInCollapsed:
 @fixture
 def assert_application_name(application_pid: int, runtime: str, in_container: bool) -> Generator:
     desired_names = {
-        "java": "java: Fibonacci.jar (/app/Fibonacci.jar)",
+        "java": "java: Fibonacci.jar",
         "python": "python: lister.py (/app/lister.py)",
     }
     # We test the application name only after test has finished because the test may wait until the application is


### PR DESCRIPTION
## Description
The full path to java app ids might contain random elements, until we
find a good way to strip those, we want to remove this part of the appid.
