### PR TITLE
Upgrade Black & zlib

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 pytest==6.2.4
 flake8==3.9.2
-black==21.5b2
+black==22.3.0
 mypy==0.901
 isort==5.8.0
 types-requests==0.1.9

--- a/gprofiler/metadata/system_metadata.py
+++ b/gprofiler/metadata/system_metadata.py
@@ -45,15 +45,15 @@ def get_libc_version() -> Tuple[str, str]:
     except FileNotFoundError:
         ldd_version = b"ldd not found"
     # catches GLIBC & EGLIBC
-    m = re.search(br"GLIBC (.*?)\)", ldd_version)
+    m = re.search(rb"GLIBC (.*?)\)", ldd_version)
     if m is not None:
         return "glibc", decode_libc_version(m.group(1))
     # catches GNU libc
-    m = re.search(br"\(GNU libc\) (.*?)\n", ldd_version)
+    m = re.search(rb"\(GNU libc\) (.*?)\n", ldd_version)
     if m is not None:
         return "glibc", decode_libc_version(m.group(1))
     # musl
-    m = re.search(br"musl libc.*?\nVersion (.*?)\n", ldd_version, re.M)
+    m = re.search(rb"musl libc.*?\nVersion (.*?)\n", ldd_version, re.M)
     if m is not None:
         return "musl", decode_libc_version(m.group(1))
 
@@ -97,7 +97,7 @@ def get_mac_address() -> str:
     Gets the MAC address of the first non-loopback interface.
     """
 
-    assert sys.maxsize > 2 ** 32, "expected to run on 64-bit!"
+    assert sys.maxsize > 2**32, "expected to run on 64-bit!"
     SIZE_OF_STUCT_ifreq = 40  # correct for 64-bit
 
     IFNAMSIZ = 16

--- a/scripts/prepare_machine-unknown-linux-musl.sh
+++ b/scripts/prepare_machine-unknown-linux-musl.sh
@@ -44,5 +44,4 @@ CC=musl-gcc ./configure --prefix=/usr/local/musl/$(uname -m)-unknown-linux-musl 
 make
 make install
 popd
-rm -r zlib-*
-rm $ZLIB_FILE
+rm -fr $ZLIB_FILE zlib-*

--- a/scripts/prepare_machine-unknown-linux-musl.sh
+++ b/scripts/prepare_machine-unknown-linux-musl.sh
@@ -39,7 +39,8 @@ pushd "zlib-$ZLIB_VERSION"
 # note the use of --prefix here. it matches the directory https://github.com/benfred/remoteprocess/blob/master/build.rs expects to find libs for musl.
 # the libunwind configure may install it in /usr/local/lib for all I care, but if we override /usr/local/lib/libz... with the musl ones,
 # it won't do any good...
-CC=musl-gcc ./configure --prefix=/usr/local/musl/$(uname -m)-unknown-linux-musl --disable-shared
+# --static - we don't need the shared build, we compile everything statically anyway.
+CC=musl-gcc ./configure --prefix=/usr/local/musl/$(uname -m)-unknown-linux-musl --static
 make
 make install
 popd

--- a/scripts/prepare_machine-unknown-linux-musl.sh
+++ b/scripts/prepare_machine-unknown-linux-musl.sh
@@ -31,9 +31,11 @@ popd
 rm -r libunwind-1.5.0
 rm libunwind-1.5.0.tar.gz
 
-wget https://zlib.net/zlib-1.2.11.tar.xz
-tar -xf zlib-1.2.11.tar.xz
-pushd zlib-1.2.11
+ZLIB_VERSION=1.2.12
+ZLIB_FILE="zlib-$ZLIB_VERSION.tar.xz"
+wget "https://zlib.net/$ZLIB_FILE"
+tar -xf "$ZLIB_FILE"
+pushd "zlib-$ZLIB_VERSION"
 # note the use of --prefix here. it matches the directory https://github.com/benfred/remoteprocess/blob/master/build.rs expects to find libs for musl.
 # the libunwind configure may install it in /usr/local/lib for all I care, but if we override /usr/local/lib/libz... with the musl ones,
 # it won't do any good...
@@ -41,5 +43,5 @@ CC=musl-gcc ./configure --prefix=/usr/local/musl/$(uname -m)-unknown-linux-musl
 make
 make install
 popd
-rm -r zlib-1.2.11
-rm zlib-1.2.11.tar.xz
+rm -r zlib-*
+rm $ZLIB_FILE

--- a/scripts/prepare_machine-unknown-linux-musl.sh
+++ b/scripts/prepare_machine-unknown-linux-musl.sh
@@ -39,7 +39,7 @@ pushd "zlib-$ZLIB_VERSION"
 # note the use of --prefix here. it matches the directory https://github.com/benfred/remoteprocess/blob/master/build.rs expects to find libs for musl.
 # the libunwind configure may install it in /usr/local/lib for all I care, but if we override /usr/local/lib/libz... with the musl ones,
 # it won't do any good...
-CC=musl-gcc ./configure --prefix=/usr/local/musl/$(uname -m)-unknown-linux-musl
+CC=musl-gcc ./configure --prefix=/usr/local/musl/$(uname -m)-unknown-linux-musl --disable-shared
 make
 make install
 popd


### PR DESCRIPTION
* zlib release 1.2.11 was removed from site, probably due to the recently discovered issues, https://twitter.com/taviso/status/1507781911023742976?s=20&t=UEQka6r_9Qm7TQIp2I6ybA
* `click` 8.1.0 breaks with black, a fix was released in 22.3.0, see https://github.com/psf/black/commit/e9681a40dcb3d38b56b301d811bb1c55201fd97e