### PR TITLE
Exit with an error log if all profilers are disabled

### DIFF
--- a/gprofiler/exceptions.py
+++ b/gprofiler/exceptions.py
@@ -71,3 +71,7 @@ class ThreadStopTimeoutError(Exception):
 
 class SystemProfilerInitFailure(Exception):
     pass
+
+
+class NoProfilersEnabledError(Exception):
+    pass

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -25,7 +25,7 @@ from requests import RequestException, Timeout
 from gprofiler import __version__
 from gprofiler.client import DEFAULT_UPLOAD_TIMEOUT, GRANULATE_SERVER_HOST, APIClient
 from gprofiler.containers_client import ContainerNamesClient
-from gprofiler.exceptions import APIError, SystemProfilerInitFailure
+from gprofiler.exceptions import APIError, NoProfilersEnabledError, SystemProfilerInitFailure
 from gprofiler.gprofiler_types import ProcessToStackSampleCounters, UserArgs, positive_integer
 from gprofiler.log import RemoteLogsHandler, initial_root_logger_setup
 from gprofiler.merge import EnrichmentOptions, concatenate_profiles, merge_profiles
@@ -630,7 +630,7 @@ def verify_preconditions(args: Any) -> None:
     if args.log_usage and get_run_mode() not in ("k8s", "container"):
         # TODO: we *can* move into another cpuacct cgroup, to let this work also when run as a standalone
         # executable.
-        print("--log-usage is available only when run as a container!")
+        print("--log-usage is available only when run as a container!", file=sys.stderr)
         sys.exit(1)
 
 
@@ -761,8 +761,12 @@ def main() -> None:
 
     except KeyboardInterrupt:
         pass
+    except NoProfilersEnabledError:
+        logger.error("All profilers are disabled! Please enable at least one of them!")
+        sys.exit(1)
     except Exception:
         logger.exception("Unexpected error occurred")
+        sys.exit(1)
 
     usage_logger.log_run()
 

--- a/gprofiler/profilers/factory.py
+++ b/gprofiler/profilers/factory.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Any, List, Tuple, Union
 
-from gprofiler.exceptions import SystemProfilerInitFailure
+from gprofiler.exceptions import NoProfilersEnabledError, SystemProfilerInitFailure
 from gprofiler.log import get_logger_adapter
 from gprofiler.metadata.system_metadata import get_arch
 from gprofiler.profilers.perf import SystemProfiler
@@ -48,5 +48,8 @@ def get_profilers(
                 system_profiler = profiler_instance
             else:
                 process_profilers_instances.append(profiler_instance)
+
+    if isinstance(system_profiler, NoopProfiler) and len(process_profilers_instances) == 0:
+        raise NoProfilersEnabledError()
 
     return system_profiler, process_profilers_instances


### PR DESCRIPTION
A user probably doesn't want to run gProfiler this way, as no data will be collected.

If gProfiler is run this way, an empty stackcollapsed file is produced.

I tried to make this error pop at the arguments validation stage, which seems more appropriate; but it's not very convenient to do so, and also not very logical (you actually do want to ensure that at least one profiler has been initialized correctly, so you do need to run their initialization code, etc).

See my comment [here](https://github.com/Granulate/gprofiler/issues/327#issuecomment-1083735555).