### PR TITLE
Fix celery app name when no app name is given in args

### DIFF
--- a/gprofiler/metadata/application_identifiers.py
+++ b/gprofiler/metadata/application_identifiers.py
@@ -204,7 +204,7 @@ class _CeleryApplicationIdentifier(_ApplicationIdentifier):
         app_name = _get_cli_arg_by_name(process.cmdline(), "-A") or _get_cli_arg_by_name(
             process.cmdline(), "--app", check_for_equals_arg=True
         )
-        if app_name is None:
+        if app_name is _NON_AVAILABLE_ARG:
             _logger.warning(
                 f"{self.__class__.__name__}: Couldn't find positional argument -A or --app for application indication",
                 cmdline=process.cmdline(),

--- a/tests/test_appids.py
+++ b/tests/test_appids.py
@@ -110,6 +110,8 @@ def test_celery() -> None:
     assert "celery: /path/to/app3 (/path/to/app3.py)" == get_application_name(
         process_with_cmdline(["celery", "a", "b", "--app=/path/to/app3"])
     )
+    # No app
+    assert get_application_name(process_with_cmdline(["celery", "a", "b"])) is None
 
 
 def test_pyspark() -> None:


### PR DESCRIPTION
Currently, when no app name is given in celery, the resulting app name will be something like `appid: celery: (/opt/dir/.py)`. After this fix it will be `None`.
