### PR TITLE
Move run_process and friends to granulate-utils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -146,9 +146,13 @@ RUN pip3 install --upgrade pip
 # done separately from the 'pip3 install -e' below; so we don't reinstall all dependencies on each
 # code change.
 COPY requirements.txt ./
+# copy needed files from granulate-utils to run the pip install
 COPY granulate-utils/setup.py granulate-utils/requirements.txt granulate-utils/README.md granulate-utils/
-COPY granulate-utils/granulate_utils granulate-utils/granulate_utils
+COPY granulate-utils/granulate_utils/__init__.py granulate-utils/granulate_utils/py.typed granulate-utils/granulate_utils/
 RUN pip3 install --no-cache-dir -r requirements.txt
+
+# and finally copy granulate-utils code itself
+COPY granulate-utils/granulate_utils granulate-utils/granulate_utils/
 
 COPY LICENSE.md MANIFEST.in README.md setup.py  ./
 COPY gprofiler gprofiler

--- a/gprofiler/exceptions.py
+++ b/gprofiler/exceptions.py
@@ -4,10 +4,6 @@
 #
 
 
-class StopEventSetException(Exception):
-    pass
-
-
 class ProgramMissingException(Exception):
     def __init__(self, program: str):
         super().__init__(f"The program {program!r} is missing! Please install it")

--- a/gprofiler/exceptions.py
+++ b/gprofiler/exceptions.py
@@ -2,40 +2,10 @@
 # Copyright (c) Granulate. All rights reserved.
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
-import signal
-import subprocess
-from typing import Any, List, Union
 
 
 class StopEventSetException(Exception):
     pass
-
-
-class ProcessStoppedException(Exception):
-    pass
-
-
-class CalledProcessError(subprocess.CalledProcessError):
-    def __str__(self) -> str:
-        if self.returncode and self.returncode < 0:
-            try:
-                base = f"Command '{self.cmd}' died with {signal.Signals(-self.returncode)!r}."
-            except ValueError:
-                base = f"Command '{self.cmd}' died with unknown signal {-self.returncode}."
-        else:
-            base = f"Command '{self.cmd}' returned non-zero exit status {self.returncode}. "
-        return f"{base}\nstdout: {self.stdout}\nstderr: {self.stderr}"
-
-
-class CalledProcessTimeoutError(CalledProcessError):
-    def __init__(
-        self, timeout: float, returncode: int, cmd: Union[str, List[str]], output: Any = str, stderr: Any = str
-    ):
-        super().__init__(returncode, cmd, output, stderr)
-        self.timeout = timeout
-
-    def __str__(self) -> str:
-        return f"Timed out after {self.timeout} seconds\n" + super().__str__()
 
 
 class ProgramMissingException(Exception):

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -47,7 +47,7 @@ from gprofiler.utils import (
     is_root,
     reset_umask,
     resource_path,
-    run_process,
+    run_process_logged,
 )
 
 logger: logging.LoggerAdapter
@@ -191,7 +191,7 @@ class GProfiler:
                 .read_text()
                 .replace(
                     "{{{JSON_DATA}}}",
-                    run_process(
+                    run_process_logged(
                         [resource_path("burn"), "convert", "--type=folded"],
                         suppress_log=True,
                         stdin=stripped_collapsed_data.encode(),

--- a/gprofiler/metadata/application_identifiers.py
+++ b/gprofiler/metadata/application_identifiers.py
@@ -8,13 +8,13 @@ import re
 from abc import ABCMeta, abstractmethod
 from typing import List, Optional, TextIO, Tuple, Union
 
+from granulate_utils.exceptions import CalledProcessError
 from granulate_utils.linux.ns import resolve_host_path, resolve_proc_root_links
 from psutil import NoSuchProcess, Process
 
-from gprofiler.exceptions import CalledProcessError
 from gprofiler.log import get_logger_adapter
 from gprofiler.profilers.java import jattach_path
-from gprofiler.utils import run_process
+from gprofiler.utils import run_process_logged
 
 _logger = get_logger_adapter(__name__)
 
@@ -248,7 +248,7 @@ class _JavaJarApplicationIdentifier(_ApplicationIdentifier):
             return None
 
         try:
-            java_properties = run_process([jattach_path(), str(process.pid), "properties"]).stdout.decode()
+            java_properties = run_process_logged([jattach_path(), str(process.pid), "properties"]).stdout.decode()
             for line in java_properties.splitlines():
                 if line.startswith("sun.java.command"):
                     app_id = line[line.find("=") + 1 :].split(" ", 1)[0]

--- a/gprofiler/metadata/system_metadata.py
+++ b/gprofiler/metadata/system_metadata.py
@@ -18,7 +18,7 @@ import psutil
 from granulate_utils.linux.ns import run_in_ns
 
 from gprofiler.log import get_logger_adapter
-from gprofiler.utils import is_pyinstaller, run_process
+from gprofiler.utils import is_pyinstaller, run_process_logged
 
 logger = get_logger_adapter(__name__)
 hostname: Optional[str] = None
@@ -39,7 +39,7 @@ def get_libc_version() -> Tuple[str, str]:
         return version.decode("utf-8", errors="replace")
 
     try:
-        ldd_version = run_process(
+        ldd_version = run_process_logged(
             ["ldd", "--version"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, suppress_log=True, check=False
         ).stdout
     except FileNotFoundError:

--- a/gprofiler/metadata/system_metadata.py
+++ b/gprofiler/metadata/system_metadata.py
@@ -6,7 +6,6 @@ import platform
 import re
 import socket
 import struct
-import subprocess
 import sys
 import time
 from dataclasses import dataclass
@@ -39,9 +38,7 @@ def get_libc_version() -> Tuple[str, str]:
         return version.decode("utf-8", errors="replace")
 
     try:
-        ldd_version = run_process_logged(
-            ["ldd", "--version"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, suppress_log=True, check=False
-        ).stdout
+        ldd_version = run_process_logged(["ldd", "--version"], suppress_log=True, check=False).stdout
     except FileNotFoundError:
         ldd_version = b"ldd not found"
     # catches GLIBC & EGLIBC

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -33,6 +33,7 @@ from granulate_utils.linux.ns import get_proc_root_path, get_process_nspid, reso
 from granulate_utils.linux.oom import get_oom_entry
 from granulate_utils.linux.process import is_process_running, process_exe
 from granulate_utils.linux.signals import get_signal_entry
+from granulate_utils.wait_event import wait_event
 from packaging.version import Version
 from psutil import Process
 
@@ -52,7 +53,6 @@ from gprofiler.utils import (
     resource_path,
     run_process_logged,
     touch_path,
-    wait_event,
 )
 from gprofiler.utils.elf import get_mapped_dso_elf_id
 from gprofiler.utils.fs import safe_copy

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -9,13 +9,15 @@ from subprocess import Popen
 from threading import Event
 from typing import List, Optional
 
+from granulate_utils.exceptions import StopEventSetException
+from granulate_utils.wait_event import wait_event
+
 from gprofiler import merge
-from gprofiler.exceptions import StopEventSetException
 from gprofiler.gprofiler_types import ProcessToStackSampleCounters
 from gprofiler.log import get_logger_adapter
 from gprofiler.profilers.profiler_base import ProfilerBase
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
-from gprofiler.utils import run_process_logged, start_process_staticx, wait_event, wait_for_file_by_prefix
+from gprofiler.utils import RunProcessStaticx, run_process_logged, wait_for_file_by_prefix
 from gprofiler.utils.perf import perf_path
 
 logger = get_logger_adapter(__name__)
@@ -67,7 +69,7 @@ class PerfProcess:
 
     def start(self) -> None:
         logger.info(f"Starting perf ({self._type} mode)")
-        process = start_process_staticx(self._get_perf_cmd(), via_staticx=False)
+        process = RunProcessStaticx(self._get_perf_cmd()).start(via_staticx=False)
         try:
             wait_event(self._poll_timeout_s, self._stop_event, lambda: os.path.exists(self._output_path))
         except TimeoutError:

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -15,7 +15,7 @@ from gprofiler.gprofiler_types import ProcessToStackSampleCounters
 from gprofiler.log import get_logger_adapter
 from gprofiler.profilers.profiler_base import ProfilerBase
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
-from gprofiler.utils import run_process, start_process, wait_event, wait_for_file_by_prefix
+from gprofiler.utils import run_process_logged, start_process_staticx, wait_event, wait_for_file_by_prefix
 from gprofiler.utils.perf import perf_path
 
 logger = get_logger_adapter(__name__)
@@ -67,7 +67,7 @@ class PerfProcess:
 
     def start(self) -> None:
         logger.info(f"Starting perf ({self._type} mode)")
-        process = start_process(self._get_perf_cmd(), via_staticx=False)
+        process = start_process_staticx(self._get_perf_cmd(), via_staticx=False)
         try:
             wait_event(self._poll_timeout_s, self._stop_event, lambda: os.path.exists(self._output_path))
         except TimeoutError:
@@ -102,13 +102,13 @@ class PerfProcess:
 
         if self._inject_jit:
             inject_data = Path(f"{str(perf_data)}.inject")
-            run_process(
+            run_process_logged(
                 [perf_path(), "inject", "--jit", "-o", str(inject_data), "-i", str(perf_data)],
             )
             perf_data.unlink()
             perf_data = inject_data
 
-        perf_script_proc = run_process(
+        perf_script_proc = run_process_logged(
             [perf_path(), "script", "-F", "+pid", "-i", str(perf_data)],
             suppress_log=True,
         )

--- a/gprofiler/profilers/php.py
+++ b/gprofiler/profilers/php.py
@@ -19,7 +19,7 @@ from gprofiler.gprofiler_types import ProcessToStackSampleCounters
 from gprofiler.log import get_logger_adapter
 from gprofiler.profilers.profiler_base import ProfilerBase
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
-from gprofiler.utils import random_prefix, resource_path, start_process, wait_event
+from gprofiler.utils import random_prefix, resource_path, start_process_staticx, wait_event
 
 logger = get_logger_adapter(__name__)
 # Currently tracing only php-fpm, TODO: support mod_php in apache.
@@ -93,7 +93,7 @@ class PHPSpyProfiler(ProfilerBase):
         phpspy_dir = os.path.dirname(phpspy_path)
         env = os.environ.copy()
         env["PATH"] = f"{env.get('PATH')}:{phpspy_dir}"
-        process = start_process(cmd, env=env, via_staticx=False)
+        process = start_process_staticx(cmd, env=env, via_staticx=False)
         # Executing phpspy, expecting the output file to be created, phpspy creates it at bootstrap after argument
         # parsing.
         # If an error occurs after this stage it's probably a spied _process specific and not phpspy general error.

--- a/gprofiler/profilers/php.py
+++ b/gprofiler/profilers/php.py
@@ -14,12 +14,14 @@ from subprocess import Popen
 from threading import Event
 from typing import List, Optional, Pattern, cast
 
-from gprofiler.exceptions import StopEventSetException
+from granulate_utils.exceptions import StopEventSetException
+from granulate_utils.wait_event import wait_event
+
 from gprofiler.gprofiler_types import ProcessToStackSampleCounters
 from gprofiler.log import get_logger_adapter
 from gprofiler.profilers.profiler_base import ProfilerBase
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
-from gprofiler.utils import random_prefix, resource_path, start_process_staticx, wait_event
+from gprofiler.utils import RunProcessStaticx, random_prefix, resource_path
 
 logger = get_logger_adapter(__name__)
 # Currently tracing only php-fpm, TODO: support mod_php in apache.
@@ -93,7 +95,7 @@ class PHPSpyProfiler(ProfilerBase):
         phpspy_dir = os.path.dirname(phpspy_path)
         env = os.environ.copy()
         env["PATH"] = f"{env.get('PATH')}:{phpspy_dir}"
-        process = start_process_staticx(cmd, env=env, via_staticx=False)
+        process = RunProcessStaticx(cmd).start(env=env, via_staticx=False)
         # Executing phpspy, expecting the output file to be created, phpspy creates it at bootstrap after argument
         # parsing.
         # If an error occurs after this stage it's probably a spied _process specific and not phpspy general error.

--- a/gprofiler/profilers/profiler_base.py
+++ b/gprofiler/profilers/profiler_base.py
@@ -9,9 +9,9 @@ from threading import Event
 from types import TracebackType
 from typing import List, Optional, Type, TypeVar
 
+from granulate_utils.exceptions import StopEventSetException
 from psutil import NoSuchProcess, Process
 
-from gprofiler.exceptions import StopEventSetException
 from gprofiler.gprofiler_types import ProcessToStackSampleCounters, StackToSampleCount
 from gprofiler.log import get_logger_adapter
 from gprofiler.utils import limit_frequency

--- a/gprofiler/profilers/ruby.py
+++ b/gprofiler/profilers/ruby.py
@@ -9,12 +9,11 @@ from subprocess import CompletedProcess
 from threading import Event
 from typing import Any, Dict, List, Optional
 
-from granulate_utils.exceptions import ProcessStoppedException
+from granulate_utils.exceptions import ProcessStoppedException, StopEventSetException
 from granulate_utils.linux.ns import get_process_nspid, run_in_ns
 from psutil import Process
 
 from gprofiler import merge
-from gprofiler.exceptions import StopEventSetException
 from gprofiler.gprofiler_types import StackToSampleCount
 from gprofiler.log import get_logger_adapter
 from gprofiler.metadata.application_metadata import ApplicationMetadata

--- a/gprofiler/utils/__init__.py
+++ b/gprofiler/utils/__init__.py
@@ -75,6 +75,9 @@ class RunProcessStaticx(RunProcess):
     def start(
         self, term_on_parent_death: bool = True, via_staticx: bool = False, **popen_kwargs: Any
     ) -> subprocess.Popen:
+        """
+        Override start() to add staticx related logics.
+        """
         env = popen_kwargs.pop("env", None)
         staticx_dir = get_staticx_dir()
         # are we running under staticx?

--- a/gprofiler/utils/__init__.py
+++ b/gprofiler/utils/__init__.py
@@ -59,6 +59,19 @@ def is_root() -> bool:
 
 
 class RunProcessStaticx(RunProcess):
+    def __init__(
+        self,
+        cmd: List[str],
+        stop_event: Event = None,
+        suppress_log: bool = False,
+        check: bool = True,
+        timeout: int = None,
+        kill_signal: signal.Signals = signal.SIGKILL,
+        communicate: bool = True,
+        stdin: bytes = None,
+    ) -> None:
+        super().__init__(cmd, logger, stop_event, suppress_log, check, timeout, kill_signal, communicate, stdin)
+
     def start(
         self, term_on_parent_death: bool = True, via_staticx: bool = False, **popen_kwargs: Any
     ) -> subprocess.Popen:
@@ -90,9 +103,8 @@ def run_process_logged(
     kill_signal: signal.Signals = signal.SIGKILL,
     communicate: bool = True,
     stdin: bytes = None,
-    **kwargs: Any,
 ) -> "subprocess.CompletedProcess[bytes]":
-    return run_process(cmd, logger, stop_event, suppress_log, check, timeout, kill_signal, communicate, stdin, **kwargs)
+    return run_process(cmd, logger, stop_event, suppress_log, check, timeout, kill_signal, communicate, stdin)
 
 
 def wait_for_file_by_prefix(prefix: str, timeout: float, stop_event: Event) -> Path:
@@ -138,9 +150,6 @@ def pgrep_maps(match: str) -> List[Process]:
     result = run_process(
         ["/bin/sh", "-c", f"grep -lP '{match}' /proc/*/maps"],
         logger=logger,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        shell=True,
         suppress_log=True,
         check=False,
     )

--- a/gprofiler/utils/perf.py
+++ b/gprofiler/utils/perf.py
@@ -3,8 +3,9 @@
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
 
-from gprofiler.exceptions import CalledProcessError
-from gprofiler.utils import resource_path, run_process
+from granulate_utils.exceptions import CalledProcessError
+
+from gprofiler.utils import resource_path, run_process_logged
 
 
 def perf_path() -> str:
@@ -16,7 +17,7 @@ def can_i_use_perf_events() -> bool:
     # TODO invoking perf has a toll of about 1 second on my box; maybe we want to directly call
     # perf_event_open here for this test?
     try:
-        run_process([perf_path(), "record", "-o", "/dev/null", "--", "/bin/true"])
+        run_process_logged([perf_path(), "record", "-o", "/dev/null", "--", "/bin/true"])
     except CalledProcessError as e:
         # perf's output upon start error (e.g due to permissions denied error)
         if e.returncode == 255 and (

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ six==1.16.0
 dataclasses==0.8; python_version < '3.7'
 packaging==21.2
 pyelftools==0.28
-./granulate-utils/
+-e ./granulate-utils/

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def read_requirements(path: str) -> Iterator[str]:
             if line.startswith("#"):
                 continue
             # install_requires doesn't like paths
-            if line.strip() == "./granulate-utils/":
+            if line.strip() == "-e ./granulate-utils/":
                 yield "granulate-utils"
                 continue
             yield line


### PR DESCRIPTION
Move `run_process` and related utils to granulate-utils, in preparation of moving other parts that are dependent on them; all in all, to make them all available for other projects.

Basically:
* `run_process` is now wrapped by `run_process_logged` which includes the gProfiler logger.
* This whole concept was transformed to a class `RunProcess`, to allow for easier extending. gProfiler adds `RunProcessStaticx` which adds the staticx-related logics.

This refactor came out larger than I anticipated, but it's a change in a good direction -
* It will help us break down and refactor `run_process` furthermore
* It will allow us to share other components in granulate-utils, that depend on `run_process`.

TODOs:
* [x] ~~Make sure that all `run_process_logged` invocations actually use `start_process_staticx` (the `via_staticx=False` part is important)~~