### PR TITLE
java: Handle /tmp being noexec (on host / container)

### DIFF
--- a/gprofiler/exceptions.py
+++ b/gprofiler/exceptions.py
@@ -75,3 +75,7 @@ class SystemProfilerInitFailure(Exception):
 
 class NoProfilersEnabledError(Exception):
     pass
+
+
+class NoRwExecDirectoryFoundError(Exception):
+    pass

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -63,6 +63,7 @@ logger = get_logger_adapter(__name__)
 
 libap_copy_lock = Lock()
 
+# directories we check for rw,exec as candidates for libasyncProfiler.so placement.
 POSSIBLE_AP_DIRS = (
     TEMPORARY_STORAGE_PATH,
     f"/run/{GPROFILER_DIRECTORY_NAME}",

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from subprocess import CompletedProcess
 from threading import Event, Lock
 from types import TracebackType
-from typing import Any, Dict, List, Optional, Set, Type, TypeVar
+from typing import Any, Dict, List, Optional, Sequence, Set, Type, TypeVar
 
 import psutil
 from granulate_utils.java import (
@@ -36,7 +36,7 @@ from packaging.version import Version
 from psutil import Process
 
 from gprofiler import merge
-from gprofiler.exceptions import CalledProcessError
+from gprofiler.exceptions import CalledProcessError, NoRwExecDirectoryFoundError
 from gprofiler.gprofiler_types import ProcessToStackSampleCounters, StackToSampleCount
 from gprofiler.kernel_messages import get_kernel_messages_provider
 from gprofiler.log import get_logger_adapter
@@ -55,13 +55,19 @@ from gprofiler.utils import (
     wait_event,
 )
 from gprofiler.utils.elf import get_mapped_dso_elf_id
-from gprofiler.utils.fs import safe_copy
+from gprofiler.utils.fs import is_rw_exec_dir, safe_copy
 from gprofiler.utils.perf import can_i_use_perf_events
 from gprofiler.utils.process import is_musl, process_comm
 
 logger = get_logger_adapter(__name__)
 
 libap_copy_lock = Lock()
+
+POSSIBLE_AP_DIRS = (
+    TEMPORARY_STORAGE_PATH,
+    f"/run/{GPROFILER_DIRECTORY_NAME}",
+    f"/opt/{GPROFILER_DIRECTORY_NAME}",
+)
 
 
 def frequency_to_ap_interval(frequency: int) -> int:
@@ -235,12 +241,11 @@ class AsyncProfiledProcess:
         # because storage_dir changes between runs.
         # we embed the async-profiler version in the path, so future gprofiler versions which use another version
         # of AP case use it (will be loaded as a different DSO)
-        self._ap_dir = os.path.join(
-            TEMPORARY_STORAGE_PATH,
+        self._ap_dir_host = os.path.join(
+            self._find_rw_exec_dir(POSSIBLE_AP_DIRS),
             f"async-profiler-{get_ap_version()}",
             "musl" if self._is_musl() else "glibc",
         )
-        self._ap_dir_host = resolve_proc_root_links(self._process_root, self._ap_dir)
 
         self._libap_path_host = os.path.join(self._ap_dir_host, "libasyncProfiler.so")
         self._libap_path_process = remove_prefix(self._libap_path_host, self._process_root)
@@ -259,6 +264,18 @@ class AsyncProfiledProcess:
         self._mode = mode
         self._ap_safemode = ap_safemode
         self._ap_args = ap_args
+
+    def _find_rw_exec_dir(self, available_dirs: Sequence[str]) -> str:
+        """
+        Find a rw & executable directory (in the context of the process) where we can place libasyncProfiler.so
+        and the target process will be able to load it.
+        """
+        for d in available_dirs:
+            full_dir = resolve_proc_root_links(self._process_root, d)
+            if is_rw_exec_dir(full_dir):
+                return full_dir
+        else:
+            raise NoRwExecDirectoryFoundError(f"Could not find a rw & exec directory out of {available_dirs}!")
 
     def __enter__(self: T) -> T:
         os.makedirs(self._ap_dir_host, 0o755, exist_ok=True)

--- a/gprofiler/utils/__init__.py
+++ b/gprofiler/utils/__init__.py
@@ -340,7 +340,7 @@ def touch_path(path: str, mode: int) -> None:
     os.chmod(path, mode)
 
 
-def remove_path(path: str, missing_ok: bool = False) -> None:
+def remove_path(path: Union[str, Path], missing_ok: bool = False) -> None:
     # backporting missing_ok, available only from 3.8
     try:
         Path(path).unlink()

--- a/gprofiler/utils/fs.py
+++ b/gprofiler/utils/fs.py
@@ -3,8 +3,11 @@
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
 
+import errno
 import os
 import shutil
+import subprocess
+from pathlib import Path
 
 
 def safe_copy(src: str, dst: str) -> None:
@@ -15,3 +18,31 @@ def safe_copy(src: str, dst: str) -> None:
     dst_tmp = f"{dst}.tmp"
     shutil.copy(src, dst_tmp)
     os.rename(dst_tmp, dst)
+
+
+def is_rw_exec_dir(path: str) -> bool:
+    """
+    Is 'path' rw and exec?
+    """
+    test_script = Path(path) / "t.sh"
+
+    # try creating & writing
+    try:
+        os.makedirs(path, 0o755, exist_ok=True)
+        test_script.write_text("#!/bin/sh\nexit 0")
+        test_script.chmod(0o755)
+    except OSError as e:
+        if e.errno == errno.EROFS:
+            # ro
+            return False
+
+    # try executing
+    try:
+        subprocess.run(str(test_script), check=True)
+    except PermissionError:
+        # noexec
+        return False
+    finally:
+        test_script.unlink()
+
+    return True

--- a/gprofiler/utils/fs.py
+++ b/gprofiler/utils/fs.py
@@ -9,6 +9,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
+from gprofiler.utils import remove_path
+
 
 def safe_copy(src: str, dst: str) -> None:
     """
@@ -35,6 +37,8 @@ def is_rw_exec_dir(path: str) -> bool:
         if e.errno == errno.EROFS:
             # ro
             return False
+        remove_path(test_script)
+        raise
 
     # try executing
     try:

--- a/gprofiler/utils/fs.py
+++ b/gprofiler/utils/fs.py
@@ -6,10 +6,9 @@
 import errno
 import os
 import shutil
-import subprocess
 from pathlib import Path
 
-from gprofiler.utils import remove_path
+from gprofiler.utils import remove_path, run_process
 
 
 def safe_copy(src: str, dst: str) -> None:
@@ -42,7 +41,7 @@ def is_rw_exec_dir(path: str) -> bool:
 
     # try executing
     try:
-        subprocess.run(str(test_script), check=True)
+        run_process([str(test_script)])
     except PermissionError:
         # noexec
         return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -243,10 +243,9 @@ def application_docker_mounts(
     mounts.extend(extra_application_docker_mounts)
 
     if application_docker_mount:
+        output_directory.mkdir(parents=True, exist_ok=True)
         mounts.append(
-            docker.types.Mount(
-                target=str(output_directory), type="volume", source=str(output_directory), read_only=False
-            )
+            docker.types.Mount(target=str(output_directory), type="bind", source=str(output_directory), read_only=False)
         )
 
     return mounts

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -234,7 +234,9 @@ def extra_application_docker_mounts() -> List[docker.types.Mount]:
 
 @fixture
 def application_docker_mounts(
-    application_docker_mount: bool, extra_application_docker_mounts: List[docker.types.Mount]
+    application_docker_mount: bool,
+    extra_application_docker_mounts: List[docker.types.Mount],
+    output_directory: Path,
 ) -> List[docker.types.Mount]:
     mounts = []
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -414,3 +414,19 @@ def python_version(in_container: bool, application_docker_container: Container) 
 
     # Output is expected to look like e.g. "Python 3.9.7"
     return cast(str, output.decode().strip().split()[-1])
+
+
+@fixture
+def noexec_tmp_dir(in_container: bool, tmp_path: Path) -> Iterator[str]:
+    if in_container:
+        # only needed for non-container tests
+        yield ""
+        return
+
+    tmpfs_path = tmp_path / "tmpfs"
+    tmpfs_path.mkdir(0o755, exist_ok=True)
+    try:
+        subprocess.run(["mount", "-t", "tmpfs", "-o", "noexec", "none", str(tmpfs_path)], check=True)
+        yield str(tmpfs_path)
+    finally:
+        subprocess.run(["umount", str(tmpfs_path)], check=True)

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -247,7 +247,9 @@ def test_already_loaded_async_profiler_profiling_failure(
     tmp_path: Path, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture, application_pid: int
 ) -> None:
     with monkeypatch.context() as m:
-        m.setattr("gprofiler.profilers.java.TEMPORARY_STORAGE_PATH", "/tmp/fake_gprofiler_tmp")
+        import gprofiler.profilers.java
+
+        m.setattr(gprofiler.profilers.java, "POSSIBLE_AP_DIRS", ("/tmp/fake_gprofiler_tmp",))
         with make_java_profiler(storage_dir=str(tmp_path)) as profiler:
             profiler.snapshot()
 

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -395,7 +395,7 @@ def test_java_noexec_dirs(
 ) -> None:
     """
     Tests that gProfiler is able to select a non-default directory for libasyncProfiler if the default one
-    is noexec/ro, both container and host.
+    is noexec, both container and host.
     """
     caplog.set_level(logging.DEBUG)
 


### PR DESCRIPTION
## Description
When run as a container, we use `/tmp` to place all of our binaries, and expect it to be executable.
When run as an executable, we give the user an opportunity to set a different directory to extract our executables, in case `/tmp` is not executable, to affect staticx & pyinstaller.

But async-profiler remains - as a DSO that is loaded to target profiled processes, and thus must reside on an executable filesystem in the context of a process.

This PR makes sure to find an executable (and writable) directory for each profiled process, and copy libasyncProfiler.so to that directory accordingly.