### PR TITLE
java: Upgrade async-profiler (regression in build scripts, not using -static-* flags)

### DIFF
--- a/scripts/async_profiler_build_shared.sh
+++ b/scripts/async_profiler_build_shared.sh
@@ -5,8 +5,8 @@
 #
 set -euo pipefail
 
-VERSION=v2.7g1
-GIT_REV="3d5777b3705c7ef58950e99232a3691916d90df6"
+VERSION=v2.7g2
+GIT_REV="6541b573294c3c9e8efb633bc830440a6f2e13d0"
 
 git clone --depth 1 -b "$VERSION" https://github.com/Granulate/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
 source "$1"

--- a/tests/containers/java/musl.Dockerfile
+++ b/tests/containers/java/musl.Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:8-alpine
+# see test_java_async_profiler_musl_and_cpu
+FROM java:alpine
 
 WORKDIR /app
 ADD Fibonacci.java /app

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -147,6 +147,12 @@ def test_java_async_profiler_musl_and_cpu(
         assert_collapsed(process_collapsed)
         assert_function_in_collapsed("do_syscall_64_[k]", process_collapsed)  # ensure kernels stacks exist
 
+        # make sure libstdc++ and libgcc are not loaded - the running Java does not require them,
+        # and neither should our async-profiler build.
+        maps = Path(f"/proc/{application_pid}/maps").read_text()
+        assert "/libstdc++.so" not in maps
+        assert "/libgcc_s.so" not in maps
+
 
 def test_java_safemode_parameters(tmp_path: Path) -> None:
     with pytest.raises(AssertionError) as excinfo:


### PR DESCRIPTION
Before:
```
root@3994adfa7dcf:/app# for f in  gprofiler/resources/java/*/libasyncProfiler.so ; do echo $f; ldd $f; done
gprofiler/resources/java/glibc/libasyncProfiler.so
	linux-vdso.so.1 (0x00007ffe815cf000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f078b380000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f078b35d000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f078b352000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f078b170000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f078b021000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f078b006000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f078ae12000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f078b5c6000)
gprofiler/resources/java/musl/libasyncProfiler.so
	linux-vdso.so.1 (0x00007ffcfdb7f000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007ffa12677000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007ffa1265c000)
	libc.musl-x86_64.so.1 => not found
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007ffa1250d000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007ffa1231b000)
	/lib64/ld-linux-x86-64.so.2 (0x00007ffa128a4000)
```

After:
```
root@2fffbd329bd9:/app# for f in  gprofiler/resources/java/*/libasyncProfiler.so ; do echo $f; ldd $f; done
gprofiler/resources/java/glibc/libasyncProfiler.so
	linux-vdso.so.1 (0x00007ffdc8f15000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fda6810e000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fda680eb000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007fda680e0000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fda67f91000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fda67d9f000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fda684ac000)
gprofiler/resources/java/musl/libasyncProfiler.so
	linux-vdso.so.1 (0x00007ffcd2df8000)
	libc.musl-x86_64.so.1 => not found
```

async-profiler v2.6 added `MERGE` and our `-static-*` flags were passed in the not-executed-anymore line.

Fixing commit: https://github.com/Granulate/async-profiler/commit/6541b573294c3c9e8efb633bc830440a6f2e13d0