### PR TITLE
Log arguments

### DIFF
--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -698,7 +698,8 @@ def main() -> None:
     usage_logger = CgroupsUsageLogger(logger, "/") if args.log_usage else NoopUsageLogger()
 
     try:
-        logger.info(f"Running gprofiler (version {__version__}), commandline: {' '.join(sys.argv[1:])!r}")
+        logger.info(f"Running gProfiler (version {__version__}), commandline: {' '.join(sys.argv[1:])!r}")
+        logger.info(f"gProfiler arguments: {args!r}")
 
         if args.controller_pid is not None:
             try:


### PR DESCRIPTION
Add a log message with the values of the final parsed arguments. For example:

```
[22:23:19] gProfiler arguments: Namespace(app_id_args_filters=[], application_metadata=True, collect_metadata=True, collect_metrics=True, config='config.ini', container_names=True, continuous=False, controller_pid=None, duration=60, flamegraph=True, frequency=11, identify_applications=True, java_async_profiler_args=None, java_async_profiler_buildids=False, java_async_profiler_mode='auto', java_async_profiler_safemode=64, java_mode='ap', java_safemode='true', java_version_check=True, log_file='/var/log/gprofiler/gprofiler.log', log_rotate_backup_count=1, log_rotate_max_size=5242880, log_to_server=True, log_usage=False, nodejs_mode='disabled', output_dir='/tmp', perf_dwarf_stack_size=8192, perf_inject=False, perf_mode='fp', php_mode='disabled', php_process_filter='php-fpm', pid_ns_check=True, profile_api_version=None, python_add_versions=True, python_mode='auto', python_pyperf_user_stacks_pages=None, rotating_output=False, ruby_mode='rbspy', server_host='https://profiler.granulate.io', server_token=None, server_upload_timeout=120, service_name=None, upload_results=False, verbose=False)
```

## Motivation and Context
When using `--config` the arguments come from the config file, but their values are not logged, only the cmdline is (which is not helpful in that case).

## How Has This Been Tested?
Local build and run on Ubuntu 18.04.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
