### PR TITLE
java: Increase jattach timeout & make it configurable

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -38,7 +38,7 @@ from psutil import Process
 
 from gprofiler import merge
 from gprofiler.exceptions import CalledProcessError, NoRwExecDirectoryFoundError
-from gprofiler.gprofiler_types import ProcessToProfileData, ProfileData, StackToSampleCount
+from gprofiler.gprofiler_types import ProcessToProfileData, ProfileData, StackToSampleCount, positive_integer
 from gprofiler.kernel_messages import get_kernel_messages_provider
 from gprofiler.log import get_logger_adapter
 from gprofiler.metadata import application_identifiers
@@ -210,7 +210,7 @@ class AsyncProfiledProcess:
 
     # timeouts in seconds
     _FDTRANSFER_TIMEOUT = 10
-    _JATTACH_TIMEOUT = 10  # higher than jattach's timeout
+    _JATTACH_TIMEOUT = 30  # higher than jattach's timeout
 
     def __init__(
         self,
@@ -221,6 +221,7 @@ class AsyncProfiledProcess:
         mode: str,
         ap_safemode: int,
         ap_args: str,
+        jattach_timeout: int = _JATTACH_TIMEOUT,
     ):
         self.process = process
         self._stop_event = stop_event
@@ -266,6 +267,7 @@ class AsyncProfiledProcess:
         self._mode = mode
         self._ap_safemode = ap_safemode
         self._ap_args = ap_args
+        self._jattach_timeout = jattach_timeout
 
     def _find_rw_exec_dir(self, available_dirs: Sequence[str]) -> str:
         """
@@ -396,7 +398,7 @@ class AsyncProfiledProcess:
     def _run_async_profiler(self, cmd: List[str]) -> None:
         try:
             # kill jattach with SIGTERM if it hangs. it will go down
-            run_process(cmd, stop_event=self._stop_event, timeout=self._JATTACH_TIMEOUT, kill_signal=signal.SIGTERM)
+            run_process(cmd, stop_event=self._stop_event, timeout=self._jattach_timeout, kill_signal=signal.SIGTERM)
         except CalledProcessError as e:  # catches timeouts as well
             if os.path.exists(self._log_path_host):
                 log = Path(self._log_path_host)
@@ -580,6 +582,13 @@ def parse_jvm_version(version_string: str) -> JvmVersion:
             default=",".join(JAVA_SAFEMODE_DEFAULT_OPTIONS),
             help="Sets the Java profiler safemode options. Default is: %(default)s.",
         ),
+        ProfilerArgument(
+            "--java-jattach-timeout",
+            dest="java_jattach_timeout",
+            type=positive_integer,
+            default=AsyncProfiledProcess._JATTACH_TIMEOUT,
+            help="Timeout for jattach operations (start/stop AP, etc)",
+        ),
     ],
 )
 class JavaProfiler(ProcessProfilerBase):
@@ -613,6 +622,7 @@ class JavaProfiler(ProcessProfilerBase):
         java_async_profiler_safemode: int,
         java_async_profiler_args: str,
         java_safemode: str,
+        java_jattach_timeout: int,
         java_mode: str,
     ):
         assert java_mode == "ap", "Java profiler should not be initialized, wrong java_mode value given"
@@ -627,6 +637,7 @@ class JavaProfiler(ProcessProfilerBase):
         self._init_ap_mode(java_async_profiler_mode)
         self._ap_safemode = java_async_profiler_safemode
         self._ap_args = java_async_profiler_args
+        self._jattach_timeout = java_jattach_timeout
         self._init_java_safemode(java_safemode)
         self._should_profile = True
         # if set, profiling is disabled due to this safemode reason.
@@ -785,7 +796,14 @@ class JavaProfiler(ProcessProfilerBase):
         logger.info(f"Profiling process {process.pid} with async-profiler")
 
         with AsyncProfiledProcess(
-            process, self._storage_dir, self._stop_event, self._buildids, self._mode, self._ap_safemode, self._ap_args
+            process,
+            self._storage_dir,
+            self._stop_event,
+            self._buildids,
+            self._mode,
+            self._ap_safemode,
+            self._ap_args,
+            self._jattach_timeout,
         ) as ap_proc:
             return self._profile_ap_process(ap_proc, comm)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,7 +9,12 @@ from docker.models.containers import Container
 from docker.models.images import Image
 
 from gprofiler.gprofiler_types import ProfileData, StackToSampleCount
-from gprofiler.profilers.java import JAVA_ASYNC_PROFILER_DEFAULT_SAFEMODE, JAVA_SAFEMODE_ALL, JavaProfiler
+from gprofiler.profilers.java import (
+    JAVA_ASYNC_PROFILER_DEFAULT_SAFEMODE,
+    JAVA_SAFEMODE_ALL,
+    AsyncProfiledProcess,
+    JavaProfiler,
+)
 from gprofiler.profilers.profiler_base import ProfilerInterface
 from gprofiler.utils import remove_path
 
@@ -131,6 +136,7 @@ def make_java_profiler(
     java_async_profiler_safemode: int = JAVA_ASYNC_PROFILER_DEFAULT_SAFEMODE,
     java_async_profiler_args: str = "",
     java_safemode: str = JAVA_SAFEMODE_ALL,
+    java_jattach_timeout: int = AsyncProfiledProcess._JATTACH_TIMEOUT,
     java_mode: str = "ap",
 ) -> JavaProfiler:
     assert storage_dir is not None
@@ -145,6 +151,7 @@ def make_java_profiler(
         java_async_profiler_safemode=java_async_profiler_safemode,
         java_async_profiler_args=java_async_profiler_args,
         java_safemode=java_safemode,
+        java_jattach_timeout=java_jattach_timeout,
         java_mode=java_mode,
     )
 


### PR DESCRIPTION
In some cases it might be to use a higher timeout, even higher than the new 30s, e.g if process is very
loaded and AP takes a long while to dump the traces.

Also - make it configurable as an argument, for next times.