### PR TITLE
Use self-hosted runner for heavy builds & gProfiler 1.2.22

### DIFF
--- a/.github/workflows/build-container-and-deploy.yml
+++ b/.github/workflows/build-container-and-deploy.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-docker:
-    runs-on: ubuntu-20.04
+    runs-on: self-hosted
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/.github/workflows/build-container-and-test.yml
+++ b/.github/workflows/build-container-and-test.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0]
 
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build-container-and-test.yml
+++ b/.github/workflows/build-container-and-test.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0]
 
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build-executable-test-deploy.yml
+++ b/.github/workflows/build-executable-test-deploy.yml
@@ -41,6 +41,7 @@ jobs:
 
   test-executable:
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-20.04
     needs: build-executable
     strategy:
       fail-fast: false
@@ -63,7 +64,6 @@ jobs:
           - debian:8
           - debian:9
           - debian:10
-    runs-on: ubuntu-20.04
     steps:
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
@@ -102,7 +102,7 @@ jobs:
 
   build-executable-aarch64:
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-20.04
+    runs-on: self-hosted
     steps:
      - name: Checkout Code
        uses: actions/checkout@v2
@@ -132,10 +132,10 @@ jobs:
 
   deploy-executable:
     if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-20.04
     needs:
       - build-executable
       - build-executable-aarch64
-    runs-on: ubuntu-20.04
 
     steps:
       - name: Download executables from the previous job

--- a/gprofiler/__init__.py
+++ b/gprofiler/__init__.py
@@ -2,4 +2,4 @@
 # Copyright (c) Granulate. All rights reserved.
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
-__version__ = "1.2.21"
+__version__ = "1.2.22"


### PR DESCRIPTION
GitHub actions machines are 2 cores 7 GB RAM. This is not enough for our cross build (Aarch64). CICD for release doesn't complete, see e.g https://github.com/Granulate/gprofiler/actions/runs/2228001665:
```
The hosted runner: GitHub Actions 6 lost communication with the server. Anything in your workflow that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error.
```

I added a self-hosted runner that's c4.4xlarge, 8 cores 15 GB RAM, hopefully that'll suffice.