### PR TITLE
ci: Install self-hosted requirements & run on dirty environment

### DIFF
--- a/.github/workflows/build-container-and-deploy.yml
+++ b/.github/workflows/build-container-and-deploy.yml
@@ -14,6 +14,10 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
+
+      - name: Set up requirements
+        run: scripts/setup_runner_requirements.sh
+
       - name: Get and verify tag value
         run: |
           echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV

--- a/.github/workflows/build-container-and-deploy.yml
+++ b/.github/workflows/build-container-and-deploy.yml
@@ -47,7 +47,7 @@ jobs:
 
           # build & push Aarch64
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-          docker buildx create --name multiarch --driver docker-container --use
+          docker buildx create --name multiarch --driver docker-container --use --node multiarch0
           ./scripts/build_aarch64_container.sh -t "$AARCH64_IMAGE" --push
 
           # build & push x86_64

--- a/.github/workflows/build-executable-test-deploy.yml
+++ b/.github/workflows/build-executable-test-deploy.yml
@@ -117,7 +117,7 @@ jobs:
      - name: Build gProfiler executable
        run: |
          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-         docker buildx create --name multiarch --driver docker-container --use
+         docker buildx create --name multiarch --driver docker-container --use --node multiarch0
 
          mkdir -p output
          ./scripts/build_aarch64_executable.sh

--- a/.github/workflows/build-executable-test-deploy.yml
+++ b/.github/workflows/build-executable-test-deploy.yml
@@ -109,6 +109,10 @@ jobs:
        with:
          fetch-depth: 0
          submodules: true
+
+     - name: Set up requirements
+       run: scripts/setup_runner_requirements.sh
+
      - name: Get and verify tag value
        run: |
          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV

--- a/cmp_tags.sh
+++ b/cmp_tags.sh
@@ -5,7 +5,7 @@ set -ue
 # Copyright (c) Granulate. All rights reserved.
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
-# Used in CI and checks that last pushed tag is grater that last existing tag.
+# Used in CI and checks that last pushed tag is greater that last existing tag.
 # Using python package 'cmp_version' to do the compare work
 
 pip install cmp_version

--- a/scripts/setup_runner_requirements.sh
+++ b/scripts/setup_runner_requirements.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) Granulate. All rights reserved.
+# Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
+#
+set -euo pipefail
+
+# this file installs requirements on a blank Ubuntu server (those are typically installed
+# on GH runners, this is used for our self-hosted runners)
+
+sudo apt install -y docker.io python3-pip python-is-python3 build-essential
+sudo chmod o+rw /var/run/docker.sock


### PR DESCRIPTION
2 types of fixes:
1. Upon each run, install the necessary requirements (that come preinstalled on gh hosted runners but not on self-hosted obv)
2. Fix things that expect to run on clean env

Those all I fixed manually when I released 1.2.22, making sure that it works fine next release.