### PR TITLE
utils: perf: Catch another case of perf permissions error

### DIFF
--- a/gprofiler/utils/perf.py
+++ b/gprofiler/utils/perf.py
@@ -22,6 +22,7 @@ def can_i_use_perf_events() -> bool:
         if e.returncode == 255 and (
             b"Access to performance monitoring and observability operations is limited" in e.stderr
             or b"perf_event_open(..., PERF_FLAG_FD_CLOEXEC) failed with unexpected error" in e.stderr
+            or b"Permission error mapping pages.\n" in e.stderr
         ):
             return False
         raise


### PR DESCRIPTION
	[17:21:12] Couldn't create the Java profiler, continuing without it
	Traceback (most recent call last):
	  File "gprofiler/profilers/factory.py", line 41, in get_profilers
	  File "gprofiler/profilers/java.py", line 637, in __init__
	  File "gprofiler/profilers/java.py", line 654, in _init_ap_mode
	  File "gprofiler/utils/perf.py", line 19, in can_i_use_perf_events
	  File "gprofiler/utils/__init__.py", line 265, in run_process
	gprofiler.exceptions.CalledProcessError: Command '['/tmp/_MEIYxgsVy/gprofiler/resources/perf', 'record', '-o', '/dev/null', '--', '/bin/true']' returned non-zero exit status 255.
	stdout: b''
	stderr: b'Permission error mapping pages.\nConsider increasing /proc/sys/kernel/perf_event_mlock_kb,\nor try again with a smaller value of -m/--mmap_pages.\n(current value: 4294967295,0)\n'


I don't know, maybe it's just best to catch all errors and treat them as "False" instead of failing the `JavaProfiler` completely. On the other hand, that might hide real errors. Well, keeping it this way for now.