### PR TITLE
java: Raise JattachSocketMissing if the attach socket is missing (HS only for now)

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -164,8 +164,16 @@ class JattachTimeout(JattachExceptionBase):
 
 class JattachSocketMissing(JattachExceptionBase):
     def __str__(self) -> str:
-        return super().__str__() + ("\nJVM attach socket is missing and jattach could not create it. It has most"
-            " likely been removed; the process has to be restarted for a new socket to be created.")
+        # the attach listener is initialized once, then it is marked as initialized:
+        # (https://github.com/openjdk/jdk/blob/3d07b3c7f01b60ff4dc38f62407c212b48883dbf/src/hotspot/share/services/attachListener.cpp#L388)
+        # and will not be initialized again:
+        # https://github.com/openjdk/jdk/blob/3d07b3c7f01b60ff4dc38f62407c212b48883dbf/src/hotspot/os/linux/attachListener_linux.cpp#L509
+        # since openjdk 2870c9d55efe, the attach socket will be recreated even when removed (and this exception
+        # won't happen).
+        return super().__str__() + (
+            "\nJVM attach socket is missing and jattach could not create it. It has most"
+            " likely been removed; the process has to be restarted for a new socket to be created."
+        )
 
 
 _JAVA_VERSION_TIMEOUT = 5

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -162,7 +162,7 @@ class JattachTimeout(JattachExceptionBase):
         )
 
 
-class JattachSocketMissing(JattachExceptionBase):
+class JattachSocketMissingException(JattachExceptionBase):
     def __str__(self) -> str:
         # the attach listener is initialized once, then it is marked as initialized:
         # (https://github.com/openjdk/jdk/blob/3d07b3c7f01b60ff4dc38f62407c212b48883dbf/src/hotspot/share/services/attachListener.cpp#L388)
@@ -459,7 +459,7 @@ class AsyncProfiledProcess:
                 raise JattachTimeout(*args, timeout=self._jattach_timeout) from None
             elif e.stderr == b"Could not start attach mechanism: No such file or directory\n":
                 # this is true for jattach_hotspot
-                raise JattachSocketMissing(*args) from None
+                raise JattachSocketMissingException(*args) from None
             else:
                 raise JattachException(*args) from None
 


### PR DESCRIPTION
Based on https://github.com/Granulate/gprofiler/pull/352

After removing `/tmp/.java_pidX`:
```
[2022-04-29 18:36:37,267] DEBUG: gprofiler.utils: (['/app/gprofiler/resources/java/jattach', '691779', 'load', '/tmp/gprofiler_tmp/async-profiler-v2.7g2/glibc/libasyncProfiler.so', 'true', 'start,event=cpu,file=/tmp/gprofiler_tmp/tmpk8bcej93/async-profiler-691779.output,collapsed,ann,sig,interval=10101010,log=/tmp/gprofiler_tmp/tmpk8bcej93/async-profiler-691779.log,fdtransfer,safemode=64,timeout=35']) stderr: 'Could not start attach mechanism: No such file or directory\n'
[2022-04-29 18:36:37,267] ERROR: gprofiler.profilers.profiler_base: JavaProfiler: failed to profile process 691779 (java)
Traceback (most recent call last):
  File "/app/gprofiler/profilers/profiler_base.py", line 139, in snapshot
    result = future.result()
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 437, in result
    return self.__get_result()
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 389, in __get_result
    raise self._exception
  File "/usr/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/app/gprofiler/profilers/java.py", line 854, in _profile_process
    return ProfileData(self._profile_process_stackcollapse(process), appid, app_metadata)
  File "/app/gprofiler/profilers/java.py", line 848, in _profile_process_stackcollapse
    return self._profile_ap_process(ap_proc, comm)
  File "/app/gprofiler/profilers/java.py", line 857, in _profile_ap_process
    started = ap_proc.start_async_profiler(self._interval, ap_timeout=self._ap_timeout)
  File "/app/gprofiler/profilers/java.py", line 479, in start_async_profiler
    self._run_async_profiler(start_cmd)
  File "/app/gprofiler/profilers/java.py", line 454, in _run_async_profiler
    raise JattachSocketMissing(*args) from None
gprofiler.profilers.java.JattachSocketMissing: Command '['/app/gprofiler/resources/java/jattach', '691779', 'load', '/tmp/gprofiler_tmp/async-profiler-v2.7g2/glibc/libasyncProfiler.so', 'true', 'start,event=cpu,file=/tmp/gprofiler_tmp/tmpk8bcej93/async-profiler-691779.output,collapsed,ann,sig,interval=10101010,log=/tmp/gprofiler_tmp/tmpk8bcej93/async-profiler-691779.log,fdtransfer,safemode=64,timeout=35']' returned non-zero exit status 1. 
stdout: b''
stderr: b'Could not start attach mechanism: No such file or directory\n'
Java PID: 691779
async-profiler DSO was loaded
async-profiler log:
(empty)
JVM attach socket is missing and jattach could not create it. It has most likely been removed; the process has to be restarted for a new socket to be created.
```
