### PR TITLE
Use staticx for Aarch64 exe builds

### DIFF
--- a/exe-requirements.txt
+++ b/exe-requirements.txt
@@ -4,4 +4,10 @@ pyinstaller==4.0; platform.machine == "x86_64"
 # see https://github.com/pyinstaller/pyinstaller/issues/5540
 pyinstaller==4.10; platform.machine == "aarch64"
 # for aarch64 we build a slightly patched version
-staticx==0.13.6; platform.machine == "x86_64"
+# I tried upgrading to 0.13.6 but it crashes when the botoloader is run as non-root :/
+# I got this error in gdb:
+# (gdb) run
+# Starting program: /path/to/build/x86_64/gprofiler
+# During startup program terminated with signal SIGSEGV, Segmentation fault.
+# staying with 0.12.1 for the mean time...
+staticx==0.12.1; platform.machine == "x86_64"

--- a/exe-requirements.txt
+++ b/exe-requirements.txt
@@ -3,4 +3,4 @@ pyinstaller==4.0; platform.machine == "x86_64"
 # aarch64 requires a later version due to the use of a newer centos version.
 # see https://github.com/pyinstaller/pyinstaller/issues/5540
 pyinstaller==4.10; platform.machine == "aarch64"
-staticx==0.12.1
+staticx==0.13.6

--- a/exe-requirements.txt
+++ b/exe-requirements.txt
@@ -3,4 +3,5 @@ pyinstaller==4.0; platform.machine == "x86_64"
 # aarch64 requires a later version due to the use of a newer centos version.
 # see https://github.com/pyinstaller/pyinstaller/issues/5540
 pyinstaller==4.10; platform.machine == "aarch64"
-staticx==0.13.6
+# for aarch64 we build a slightly patched version
+staticx==0.13.6; platform.machine == "x86_64"

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -219,8 +219,7 @@ COPY ./scripts/list_needed_libs.sh ./scripts/list_needed_libs.sh
 # we use list_needed_libs.sh to list the dynamic dependencies of *all* of our resources,
 # and make staticx pack them as well.
 # using scl here to get the proper LD_LIBRARY_PATH set
-# TODO: use staticx for aarch64 as well; currently it doesn't generate correct binaries when run over Docker emulation.
-RUN if [ $(uname -m) != "aarch64" ]; then source scl_source enable devtoolset-8 llvm-toolset-7 && libs=$(./scripts/list_needed_libs.sh) && staticx $libs dist/gprofiler dist/gprofiler; fi
+RUN if [ $(uname -m) != "aarch64" ]; then source scl_source enable devtoolset-8 llvm-toolset-7 ; fi; libs=$(./scripts/list_needed_libs.sh) && staticx $libs dist/gprofiler dist/gprofiler
 
 FROM scratch AS export-stage
 

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -211,7 +211,7 @@ RUN if [ $(uname -m) = "aarch64" ]; then \
         git clone -b v0.13.6 https://github.com/JonathonReinhart/staticx.git && \
         cd staticx && \
         git reset --hard 819d8eafecbaab3646f70dfb1e3e19f6bbc017f8 && \
-        git apply staticx_patch.diff && \
+        git apply ../staticx_patch.diff && \
         python3 -m pip install . ; \
     fi
 

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -204,6 +204,15 @@ RUN pyinstaller pyinstaller.spec \
     && test -f build/pyinstaller/warn-pyinstaller.txt \
     && if grep 'gprofiler\.' build/pyinstaller/warn-pyinstaller.txt ; then echo 'PyInstaller failed to pack gProfiler code! See lines above. Make sure to check for SyntaxError as this is often the reason.'; exit 1; fi;
 
+COPY scripts/staticx_patch.diff staticx_patch.diff
+RUN if [ $(uname -m) = "aarch64" ]; then \
+        git clone -b v0.13.6 https://github.com/JonathonReinhart/staticx.git && \
+        cd staticx && \
+        git reset --hard 819d8eafecbaab3646f70dfb1e3e19f6bbc017f8 && \
+        git apply staticx_patch.diff && \
+        python3 -m pip install . ; \
+    fi
+
 COPY ./scripts/list_needed_libs.sh ./scripts/list_needed_libs.sh
 # staticx packs dynamically linked app with all of their dependencies, it tries to figure out which dynamic libraries are need for its execution
 # in some cases, when the application is lazily loading some DSOs, staticx doesn't handle it.

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -204,6 +204,8 @@ RUN pyinstaller pyinstaller.spec \
     && test -f build/pyinstaller/warn-pyinstaller.txt \
     && if grep 'gprofiler\.' build/pyinstaller/warn-pyinstaller.txt ; then echo 'PyInstaller failed to pack gProfiler code! See lines above. Make sure to check for SyntaxError as this is often the reason.'; exit 1; fi;
 
+# for aarch64 - build a patched version of staticx 0.13.6. we remove calls to getpwnam and getgrnam, for these end up doing dlopen()s which
+# crash the staticx bootloader. we don't need them anyway (all files in our staticx tar are uid 0 and we don't need the names translation)
 COPY scripts/staticx_patch.diff staticx_patch.diff
 RUN if [ $(uname -m) = "aarch64" ]; then \
         git clone -b v0.13.6 https://github.com/JonathonReinhart/staticx.git && \

--- a/scripts/list_needed_libs.sh
+++ b/scripts/list_needed_libs.sh
@@ -1,9 +1,10 @@
+
 #!/usr/bin/env bash
 #
 # Copyright (c) Granulate. All rights reserved.
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
-set -e
+set -euo pipefail
 
 # this file lists all dynamic dependenices of executables in gprofiler/resources.
 # we use it to let staticx know which libraries it should pack inside.
@@ -40,7 +41,11 @@ for f in $BINS ; do
     fi
 done
 
+printed=
 for l in $libs ; do
-    >&2 echo "found needed lib: $l"
-    echo -n " -l $l"
+    if ! echo "$printed" | grep -q "$l"; then
+        >&2 echo "found needed lib: $l"
+        echo -n " -l $l"
+        printed="$printed $l"
+    fi
 done

--- a/scripts/staticx_patch.diff
+++ b/scripts/staticx_patch.diff
@@ -1,30 +1,28 @@
 diff --git a/libtar/decode.c b/libtar/decode.c
-index b34b1d9..5105cb0 100644
+index b34b1d9..d221c3a 100644
 --- a/libtar/decode.c
 +++ b/libtar/decode.c
-@@ -46,9 +46,9 @@ th_get_uid(const TAR *t)
-        int uid;
-        struct passwd *pw;
+@@ -44,11 +44,6 @@ uid_t
+ th_get_uid(const TAR *t)
+ {
+ 	int uid;
+-	struct passwd *pw;
+-
+-	pw = getpwnam(t->th_buf.uname);
+-	if (pw != NULL)
+-		return pw->pw_uid;
  
--       pw = getpwnam(t->th_buf.uname);
--       if (pw != NULL)
--               return pw->pw_uid;
-+       // pw = getpwnam(t->th_buf.uname);
-+       // if (pw != NULL)
-+       //      return pw->pw_uid;
+ 	/* if the password entry doesn't exist */
+ 	sscanf(t->th_buf.uid, "%o", &uid);
+@@ -60,11 +55,6 @@ gid_t
+ th_get_gid(const TAR *t)
+ {
+ 	int gid;
+-	struct group *gr;
+-
+-	gr = getgrnam(t->th_buf.gname);
+-	if (gr != NULL)
+-		return gr->gr_gid;
  
-        /* if the password entry doesn't exist */
-        sscanf(t->th_buf.uid, "%o", &uid);
-@@ -62,9 +62,9 @@ th_get_gid(const TAR *t)
-        int gid;
-        struct group *gr;
- 
--       gr = getgrnam(t->th_buf.gname);
--       if (gr != NULL)
--               return gr->gr_gid;
-+       // gr = getgrnam(t->th_buf.gname);
-+       // if (gr != NULL)
-+       //      return gr->gr_gid;
- 
-        /* if the group entry doesn't exist */
-        sscanf(t->th_buf.gid, "%o", &gid);
+ 	/* if the group entry doesn't exist */
+ 	sscanf(t->th_buf.gid, "%o", &gid);

--- a/scripts/staticx_patch.diff
+++ b/scripts/staticx_patch.diff
@@ -1,0 +1,30 @@
+diff --git a/libtar/decode.c b/libtar/decode.c
+index b34b1d9..5105cb0 100644
+--- a/libtar/decode.c
++++ b/libtar/decode.c
+@@ -46,9 +46,9 @@ th_get_uid(const TAR *t)
+        int uid;
+        struct passwd *pw;
+ 
+-       pw = getpwnam(t->th_buf.uname);
+-       if (pw != NULL)
+-               return pw->pw_uid;
++       // pw = getpwnam(t->th_buf.uname);
++       // if (pw != NULL)
++       //      return pw->pw_uid;
+ 
+        /* if the password entry doesn't exist */
+        sscanf(t->th_buf.uid, "%o", &uid);
+@@ -62,9 +62,9 @@ th_get_gid(const TAR *t)
+        int gid;
+        struct group *gr;
+ 
+-       gr = getgrnam(t->th_buf.gname);
+-       if (gr != NULL)
+-               return gr->gr_gid;
++       // gr = getgrnam(t->th_buf.gname);
++       // if (gr != NULL)
++       //      return gr->gr_gid;
+ 
+        /* if the group entry doesn't exist */
+        sscanf(t->th_buf.gid, "%o", &gid);


### PR DESCRIPTION
Closes: https://github.com/Granulate/gprofiler/issues/342

## Description
The problem starts with #342  - we needed to solve the glibc issue after upgrading the base image to CentOS 8.

staticx is the easiest solution because that's what we already do for x86_64. However, simply enabling staticx with this patch:
```
diff --git a/pyi.Dockerfile b/pyi.Dockerfile
index 8f855fe..952226b 100644
--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -211,7 +211,7 @@ COPY ./scripts/list_needed_libs.sh ./scripts/list_needed_libs.sh
 # and make staticx pack them as well.
 # using scl here to get the proper LD_LIBRARY_PATH set
 # TODO: use staticx for aarch64 as well; currently it doesn't generate correct binaries when run over Docker emulation.
-RUN if [ $(uname -m) != "aarch64" ]; then source scl_source enable devtoolset-8 llvm-toolset-7 && libs=$(./scripts/list_needed_libs.sh) && staticx $libs dist/gprofiler dist/gprofiler; fi
+RUN libs=$(./scripts/list_needed_libs.sh) && staticx $libs dist/gprofiler dist/gprofiler
 
 FROM scratch AS export-stage
```
Results in this binary:
```
ubuntu@ip-172-31-21-72:~/gprofiler$ ./build/aarch64/gprofiler  --version
gprofiler: dl-call-libc-early-init.c:37: _dl_call_libc_early_init: Assertion `sym != NULL' failed.
Aborted (core dumped)
```

Not good.

gdb shows this trace:
```
gprofiler: dl-call-libc-early-init.c:37: _dl_call_libc_early_init: Assertion `sym != NULL' failed.

Program received signal SIGABRT, Aborted.
0x000000000040917c in raise ()
(gdb) bt
#0  0x000000000040917c in raise ()
#1  0x0000000000400380 in abort ()
#2  0x0000000000404f28 in __assert_fail_base ()
#3  0x0000000000404f90 in __assert_fail ()
#4  0x000000000045b9e0 in _dl_call_libc_early_init ()
#5  0x0000000000459b34 in dl_open_worker ()
#6  0x00000000004346c4 in _dl_catch_exception ()
#7  0x00000000004594c0 in _dl_open ()
#8  0x0000000000433e7c in do_dlopen ()
#9  0x00000000004346c4 in _dl_catch_exception ()
#10 0x0000000000434790 in _dl_catch_error ()
#11 0x0000000000433ecc in dlerror_run ()
#12 0x0000000000434368 in __libc_dlopen_mode ()
#13 0x00000000004305cc in __nss_lookup_function ()
#14 0x0000000000430664 in __nss_lookup ()
#15 0x000000000042b0fc in getpwnam_r ()
#16 0x000000000042adb4 in getpwnam ()
#17 0x00000000004027ac in th_get_uid ()
#18 0x00000000004019ec in tar_extract_file ()
#19 0x0000000000401d00 in tar_extract_all ()
#20 0x0000000000400f90 in extract_archive ()
#21 0x0000000000400510 in main ()
(gdb) 
```

Tar extraction calling into `getpwnam` which ends up loading DSOs... sigh.
We don't need this functionality.

So, this PR:
1. Adds a patch for latest staticx version that disables using `getpwnam` and `getgrnam`.
2. Builds staticx from source with the patch for Aarch64
3. Runs staticx also for Aarch64.

## Known issues
The exe build doesn't pass on x86_64 anymore.
```
 => ERROR [build-stage 53/53] RUN if [ $(uname -m) != "aarch64" ]; then source scl_source enable devtoolset-8 llvm-toolset-7 ; fi; libs=$(./scripts/list_needed_libs.sh) && staticx $libs dist/gprof  0.7s
------
 > [build-stage 53/53] RUN if [ $(uname -m) != "aarch64" ]; then source scl_source enable devtoolset-8 llvm-toolset-7 ; fi; libs=$(./scripts/list_needed_libs.sh) && staticx $libs dist/gprofiler dist/gprofiler:
#106 0.690 ldd failed: ldd: exited with unknown exit code (139)
```

I suspect this to be a bug with the QEMU that emulates the usermode environment for Aarch64 binaries. It doesn't set up a correct environment for `ldd`.

Before we merge this PR, I plan to inspect if now after https://github.com/Granulate/gprofiler/pull/350 I can provision an Aarch64 runner and separate the Aarch64 build steps to run on it instead. This will also make the build faster :) but mostly it will not crash haha.
Alternatively we need to fix the build when running on x86_64. Maybe upgrade QEMU? We all run `multiarch/qemu-user-static:latest` so IDK....

## How Has This Been Tested?
All current binaries used in Aarch64 builds of gProfiler are static - only PyPerf is dynamically built, hence this PR is also in preparation for https://github.com/Granulate/gprofiler/pull/287 which finally uses PyPerf in Aarch64.
For the mean time, the only thing "tested" here is that gProfiler's Python starts - staticx provides us with libc. So the tests I have performed for Aarch64 are just `gprofiler --version`. For x86_64, I tested PyPerf on appropriate kernel versions as well, and not just `gprofiler --version`.

* [x] Aarch64 new glibc - > 2.28
* [x] Aarch64 old glibc - < 2.28
* [ ] x86_64 very old (CentOS 6)
* [ ] x86_64 gprofiler & PyPerf  