### PR TITLE
appids: Rework --app-id-args-filter

### DIFF
--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -545,12 +545,14 @@ def parse_cmd_args() -> configargparse.Namespace:
         help="Disable identification of applications by heuristics",
     )
 
+    # this is specific for java, but placed here because it's used in this file and not
+    # in JavaProfiler
     parser.add_argument(
-        "--app-id-args-filter",
+        "--java-app-id-args-filter",
         action="append",
         default=list(),
-        dest="app_id_args_filters",
-        help="A regex based filter for adding relevant arguments to the app id",
+        dest="java_app_id_args_filters",
+        help="A regex based filter for adding relevant arguments to the Java app id",
     )
 
     parser.add_argument(
@@ -754,7 +756,7 @@ def main() -> None:
             profile_api_version=args.profile_api_version,
             container_names=args.container_names,
             application_identifiers=args.identify_applications,
-            application_identifier_args_filters=args.app_id_args_filters,
+            application_identifier_java_args_filters=args.java_app_id_args_filters,
             application_metadata=args.application_metadata,
         )
 

--- a/gprofiler/metadata/application_identifiers.py
+++ b/gprofiler/metadata/application_identifiers.py
@@ -260,6 +260,22 @@ class _PythonModuleApplicationIdentifier(_ApplicationIdentifier):
 
 
 class _JavaJarApplicationIdentifier(_ApplicationIdentifier):
+    def _add_from_args(self, args_line: str) -> List[str]:
+        # we don't split the line by spaces (to get individual arguments) because the JVM spits them unquoted
+        # so we can't really differentiate between arguments containing spaces and individual arguments.
+        # instead we'll just search the entire line, to allow a single expression to match on arguments
+        # like "--my-arg=5" as one argument, and "--my-arg", "5" as two arguments.
+        args = []
+        for flag_filter in (
+            self.enrichment_options.application_identifier_java_args_filters
+            if self.enrichment_options is not None
+            else []
+        ):
+            m = re.search(flag_filter, args_line)
+            if m is not None:
+                args.append(m.group())
+        return args
+
     def get_app_id(self, process: Process) -> Optional[str]:
         try:
             java_properties = run_process([jattach_path(), str(process.pid), "jcmd", "VM.command_line"]).stdout.decode()
@@ -267,18 +283,15 @@ class _JavaJarApplicationIdentifier(_ApplicationIdentifier):
             java_args = []
             for line in java_properties.splitlines():
                 if line.startswith("jvm_args:"):
-                    if (
-                        self.enrichment_options is not None
-                        and self.enrichment_options.application_identifier_args_filters
-                    ):
-                        for arg in line[line.find(":") + 1 :].strip().split(" "):
-                            if any(
-                                re.search(flag_filter, arg)
-                                for flag_filter in self.enrichment_options.application_identifier_args_filters
-                            ):
-                                java_args.append(arg)
+                    # jvm_args contains all arguments passed to the JVM
+                    java_args.extend(self._add_from_args(line[len("jvm_args:") :].strip()))
+
                 if line.startswith("java_command:"):
-                    java_command = line[line.find(":") + 1 :].strip().split(" ", 1)[0]
+                    java_command_line = line[len("java_command") :].strip()
+                    java_command = java_command_line.split(" ", 1)[0]
+                    # java_command contains all arguments passed to the Java application.
+                    java_args.extend(self._add_from_args(java_command_line))
+
             if java_command:
                 return f"java: {java_command}{' (' + ' '.join(java_args) + ')' if java_args else ''}"
         except CalledProcessError as e:

--- a/gprofiler/metadata/enrichment.py
+++ b/gprofiler/metadata/enrichment.py
@@ -13,5 +13,7 @@ class EnrichmentOptions:
     profile_api_version: Optional[str]
     container_names: bool  # Include container names for each stack in result profile
     application_identifiers: bool  # Attempt to produce & include appid frames for each stack in result profile
-    application_identifier_args_filters: List[str]  # A list of regex filters to add cmdline arguments to the app id
+    application_identifier_java_args_filters: List[
+        str
+    ]  # A list of regex filters to add from cmdline arguments of Java to the app id
     application_metadata: bool  # Include specialized metadata per application, e.g for Python - the Python version

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -402,7 +402,7 @@ def _set_enrichment_options() -> None:
             profile_api_version=None,
             container_names=True,
             application_identifiers=True,
-            application_identifier_args_filters=[],
+            application_identifier_java_args_filters=[],
             application_metadata=True,
         )
     )


### PR DESCRIPTION
It will now:
* Search the entire arguments line (instead of individual arguments)
* Search arguments passed to Java as well (i.e from java_command)

Also, renamed it in the code to make it clear that it refers to Java only.

@liorgorb - the new scheme will work for your use case, lmk if you think anything else should be changed.

I will test after you approve this approach.