### PR TITLE
Write output collapsed files & flamegraphs in utf-8

### DIFF
--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -180,11 +180,7 @@ class GProfiler:
         base_filename = os.path.join(self._output_dir, "profile_{}".format(end_ts))
 
         collapsed_path = base_filename + ".col"
-        try:
-            Path(collapsed_path).write_text(collapsed_data)
-        except UnicodeDecodeError:
-            print(collapsed_data)
-            raise
+        Path(collapsed_path).write_text(collapsed_data, encoding="utf-8")
         stripped_collapsed_data = self._strip_extra_data(collapsed_data)
 
         # point last_profile.col at the new file; and possibly, delete the previous one.

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -180,7 +180,7 @@ class GProfiler:
         base_filename = os.path.join(self._output_dir, "profile_{}".format(end_ts))
 
         collapsed_path = base_filename + ".col"
-        Path(collapsed_path).write_text(collapsed_data, encoding="utf-8")
+        Path(collapsed_path).write_text(collapsed_data)
         stripped_collapsed_data = self._strip_extra_data(collapsed_data)
 
         # point last_profile.col at the new file; and possibly, delete the previous one.
@@ -191,21 +191,21 @@ class GProfiler:
             flamegraph_path = base_filename + ".html"
             flamegraph_data = (
                 Path(resource_path("flamegraph/flamegraph_template.html"))
-                .read_text()
+                .read_bytes()
                 .replace(
-                    "{{{JSON_DATA}}}",
+                    b"{{{JSON_DATA}}}",
                     run_process(
                         [resource_path("burn"), "convert", "--type=folded"],
                         suppress_log=True,
                         stdin=stripped_collapsed_data.encode(),
                         stop_event=self._stop_event,
                         timeout=10,
-                    ).stdout.decode(),
+                    ).stdout,
                 )
-                .replace("{{{START_TIME}}}", start_ts)
-                .replace("{{{END_TIME}}}", end_ts)
+                .replace(b"{{{START_TIME}}}", start_ts.encode())
+                .replace(b"{{{END_TIME}}}", end_ts.encode())
             )
-            Path(flamegraph_path).write_text(flamegraph_data)
+            Path(flamegraph_path).write_bytes(flamegraph_data)
 
             # point last_flamegraph.html at the new file; and possibly, delete the previous one.
             self._update_last_output("last_flamegraph.html", flamegraph_path)

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -180,7 +180,7 @@ class GProfiler:
         base_filename = os.path.join(self._output_dir, "profile_{}".format(end_ts))
 
         collapsed_path = base_filename + ".col"
-        Path(collapsed_path).write_text(collapsed_data)
+        Path(collapsed_path).write_text(collapsed_data, encoding="utf-8")
         stripped_collapsed_data = self._strip_extra_data(collapsed_data)
 
         # point last_profile.col at the new file; and possibly, delete the previous one.

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -180,7 +180,11 @@ class GProfiler:
         base_filename = os.path.join(self._output_dir, "profile_{}".format(end_ts))
 
         collapsed_path = base_filename + ".col"
-        Path(collapsed_path).write_text(collapsed_data)
+        try:
+            Path(collapsed_path).write_text(collapsed_data)
+        except UnicodeDecodeError:
+            print(collapsed_data)
+            raise
         stripped_collapsed_data = self._strip_extra_data(collapsed_data)
 
         # point last_profile.col at the new file; and possibly, delete the previous one.


### PR DESCRIPTION
This combats failures I've seen in the tests: https://github.com/Granulate/gprofiler/runs/6954306861?check_suite_focus=true

Anyway it makes sense to write in utf-8 because symbols may have non-ascii letters.

This is extracted from https://github.com/Granulate/gprofiler/pull/380