### PR TITLE
java: Log all Java exits & the exiting Java version

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -186,6 +186,8 @@ class JattachSocketMissingException(JattachExceptionBase):
 _JAVA_VERSION_TIMEOUT = 5
 
 
+# process is hashable and the same process instance compares equal
+@functools.lru_cache(maxsize=1024)
 def get_java_version(process: Process, stop_event: Event) -> str:
     nspid = get_process_nspid(process.pid)
 

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -185,9 +185,11 @@ class JattachSocketMissingException(JattachExceptionBase):
 
 _JAVA_VERSION_TIMEOUT = 5
 
+_JAVA_VERSION_CACHE_MAX = 1024
+
 
 # process is hashable and the same process instance compares equal
-@functools.lru_cache(maxsize=1024)
+@functools.lru_cache(maxsize=_JAVA_VERSION_CACHE_MAX)
 def get_java_version(process: Process, stop_event: Event) -> str:
     nspid = get_process_nspid(process.pid)
 
@@ -219,7 +221,7 @@ def get_java_version(process: Process, stop_event: Event) -> str:
     return run_in_ns(["pid", "mnt"], _run_java_version, process.pid).stderr.decode().strip()
 
 
-def get_java_version_logged(process: Process, stop_event: Event) -> str:
+def try_get_java_version_logged(process: Process, stop_event: Event) -> str:
     java_version = get_java_version(process, stop_event)
     logger.debug("java -version output", java_version_output=java_version, pid=process.pid)
     return java_version
@@ -720,8 +722,10 @@ class JavaProfiler(ProcessProfilerBase):
         self._should_profile = True
         # if set, profiling is disabled due to this safemode reason.
         self._safemode_disable_reason: Optional[str] = None
+        self._want_to_profile_pids: Set[int] = set()
         self._profiled_pids: Set[int] = set()
         self._pids_to_remove: Set[int] = set()
+        self._pid_to_java_version: Dict[int, Optional[str]] = {}
         self._kernel_messages_provider = get_kernel_messages_provider()
         self._enabled_proc_events = False
         self._ap_timeout = self._duration + self._AP_EXTRA_TIMEOUT_S
@@ -813,7 +817,7 @@ class JavaProfiler(ProcessProfilerBase):
 
         return True
 
-    def _is_jvm_profiling_supported(self, process: Process) -> bool:
+    def _is_jvm_profiling_supported(self, process: Process, exe: str, java_version_output: Optional[str]) -> bool:
         """
         This is the core "version check" function.
         We have 3 modes of operation:
@@ -828,21 +832,16 @@ class JavaProfiler(ProcessProfilerBase):
            who pass the criteria enforced by the default mode ("simple checks") and additionally all checks
            performed by _check_jvm_supported_extended().
         """
-        exe = process_exe(process)
-        process_basename = os.path.basename(exe)
         if JavaSafemodeOptions.JAVA_EXTENDED_VERSION_CHECKS in self._java_safemode:
-            # TODO we can get the "java" binary by extracting the java home from the libjvm path,
-            # then check with that instead (if exe isn't java)
-            if process_basename != "java":
+            if java_version_output is None:  # we don't get the java version if the exe isn't "java"
                 logger.warning(
-                    "Non-java basenamed process, skipping... (disable "
+                    "Non-java basenamed process (cannot get Java version), skipping... (disable "
                     f" --java-safemode={JavaSafemodeOptions.JAVA_EXTENDED_VERSION_CHECKS} to profile it anyway)",
                     pid=process.pid,
                     exe=exe,
                 )
                 return False
 
-            java_version_output = get_java_version_logged(process, self._stop_event)
             jvm_version = parse_jvm_version(java_version_output)
             if not self._check_jvm_supported_simple(process, java_version_output, jvm_version):
                 return False
@@ -857,8 +856,7 @@ class JavaProfiler(ProcessProfilerBase):
                 )
                 return False
         else:
-            if self._simple_version_check and process_basename == "java":
-                java_version_output = get_java_version_logged(process, self._stop_event)
+            if self._simple_version_check and java_version_output is not None:
                 jvm_version = parse_jvm_version(java_version_output)
                 if not self._check_jvm_supported_simple(process, java_version_output, jvm_version):
                     return False
@@ -888,11 +886,30 @@ class JavaProfiler(ProcessProfilerBase):
 
     def _profile_process_stackcollapse(self, process: Process) -> StackToSampleCount:
         comm = process_comm(process)
+        exe = process_exe(process)
+        process_basename = os.path.basename(exe)
+        # TODO we can get the "java" binary by extracting the java home from the libjvm path,
+        # then check with that instead (if exe isn't java)
+        if process_basename == "java":
+            java_version_output: Optional[str] = try_get_java_version_logged(process, self._stop_event)
+            # This Java version might be used in _proc_exit_callback
+            if self._enabled_proc_events:
+                # there's no reliable way to get the underlying cache of get_java_version, otherwise
+                # I'd just use it.
+                if len(self._pid_to_java_version) > _JAVA_VERSION_CACHE_MAX:
+                    self._pid_to_java_version.clear()
+
+                self._pid_to_java_version[process.pid] = java_version_output
+        else:
+            java_version_output = None
+
+        if self._enabled_proc_events:
+            self._want_to_profile_pids.add(process.pid)
 
         if self._safemode_disable_reason is not None:
             return self._profiling_skipped_stack(f"disabled due to {self._safemode_disable_reason}", comm)
 
-        if not self._is_jvm_profiling_supported(process):
+        if not self._is_jvm_profiling_supported(process, exe, java_version_output):
             return self._profiling_skipped_stack("profiling this JVM is not supported", comm)
 
         if self._check_async_profiler_loaded(process):
@@ -1019,18 +1036,33 @@ class JavaProfiler(ProcessProfilerBase):
     def _proc_exit_callback(self, tid: int, pid: int, exit_code: int) -> None:
         # Notice that we only check the exit code of the main thread here.
         # It's assumed that an error in any of the Java threads will be reflected in the exit code of the main thread.
-        if tid in self._profiled_pids:
+        if tid in self._want_to_profile_pids:
             self._pids_to_remove.add(tid)
+            java_version_output = self._pid_to_java_version.get(tid)
 
             signo = java_exit_code_to_signo(exit_code)
             if signo is None:
                 # not a signal, do not report
                 return
 
-            logger.warning("async-profiled Java process exited with signal", pid=tid, signal=signo)
+            if tid in self._profiled_pids:
+                logger.warning(
+                    "async-profiled Java process exited with signal",
+                    pid=tid,
+                    signal=signo,
+                    java_version_output=java_version_output,
+                )
 
-            if is_java_fatal_signal(signo):
-                self._disable_profiling(JavaSafemodeOptions.PROFILED_SIGNALED)
+                if is_java_fatal_signal(signo):
+                    self._disable_profiling(JavaSafemodeOptions.PROFILED_SIGNALED)
+            else:
+                # this is a process that we wanted to profile, but didn't profile due to safemode.
+                logger.debug(
+                    "Non-profiled Java process exited with signal",
+                    pid=tid,
+                    signal=signo,
+                    java_version_output=java_version_output,
+                )
 
     def _handle_kernel_messages(self, messages: List[KernelMessage]) -> None:
         for message in messages:
@@ -1073,4 +1105,5 @@ class JavaProfiler(ProcessProfilerBase):
         finally:
             self._handle_new_kernel_messages()
             self._profiled_pids -= self._pids_to_remove
+            self._want_to_profile_pids -= self._pids_to_remove
             self._pids_to_remove.clear()


### PR DESCRIPTION
1. Cache java versions retrievals (a simple cache on `get_java_version` which is the core function)
2. Maintain pid-to-java-version mapping to be able to attach the exiting Java version to an exiting PID
3. Log exiting PID & Java version also for non-profiled processes (processes we would have profiled had the pre-checks passed)