### PR TITLE
Set critical logs to "CRITICAL"

### DIFF
--- a/gprofiler/exceptions.py
+++ b/gprofiler/exceptions.py
@@ -64,7 +64,7 @@ class ThreadStopTimeoutError(Exception):
     pass
 
 
-class SystemProfilerInitFailure(Exception):
+class SystemProfilerStartFailure(Exception):
     pass
 
 

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -273,7 +273,7 @@ class GProfiler:
         except Exception:
             logger.critical(
                 "Running perf failed; consider running gProfiler with '--perf-mode disabled' to avoid using perf",
-                exc_info=True
+                exc_info=True,
             )
             raise
         metadata = (

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -27,7 +27,7 @@ from gprofiler import __version__
 from gprofiler.client import DEFAULT_UPLOAD_TIMEOUT, GRANULATE_SERVER_HOST, APIClient
 from gprofiler.containers_client import ContainerNamesClient
 from gprofiler.databricks_client import DatabricksClient
-from gprofiler.exceptions import APIError, NoProfilersEnabledError, SystemProfilerInitFailure
+from gprofiler.exceptions import APIError, NoProfilersEnabledError
 from gprofiler.gprofiler_types import ProcessToProfileData, UserArgs, positive_integer
 from gprofiler.log import RemoteLogsHandler, initial_root_logger_setup
 from gprofiler.merge import concatenate_profiles, merge_profiles

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -121,15 +121,11 @@ class GProfiler:
         # the latter can be root only. the former can not. we should do this separation so we don't expose
         # files unnecessarily.
         self._temp_storage_dir = TemporaryDirectoryWithMode(dir=TEMPORARY_STORAGE_PATH, mode=0o755)
-        try:
-            self.system_profiler, self.process_profilers = get_profilers(
-                user_args,
-                storage_dir=self._temp_storage_dir.name,
-                stop_event=self._stop_event,
-            )
-        except SystemProfilerInitFailure:
-            logger.exception("System profiler initialization has failed, exiting...")
-            sys.exit(1)
+        self.system_profiler, self.process_profilers = get_profilers(
+            user_args,
+            storage_dir=self._temp_storage_dir.name,
+            stop_event=self._stop_event,
+        )
         if self._enrichment_options.container_names:
             self._container_names_client: Optional[ContainerNamesClient] = ContainerNamesClient()
         else:

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -271,8 +271,9 @@ class GProfiler:
         try:
             system_result = system_future.result()
         except Exception:
-            logger.exception(
-                "Running perf failed; consider running gProfiler with '--perf-mode disabled' to avoid using perf"
+            logger.critical(
+                "Running perf failed; consider running gProfiler with '--perf-mode disabled' to avoid using perf",
+                exc_info=True
             )
             raise
         metadata = (

--- a/gprofiler/profilers/factory.py
+++ b/gprofiler/profilers/factory.py
@@ -42,7 +42,7 @@ def get_profilers(
         except Exception:
             if profiler_config.profiler_class is SystemProfiler:
                 raise SystemProfilerInitFailure("Could not create the system profiler")
-            logger.exception(f"Couldn't create the {profiler_name} profiler, continuing without it")
+            logger.critical(f"Couldn't create the {profiler_name} profiler, continuing without it", exc_info=True)
         else:
             if isinstance(profiler_instance, SystemProfiler):
                 system_profiler = profiler_instance

--- a/gprofiler/profilers/factory.py
+++ b/gprofiler/profilers/factory.py
@@ -1,7 +1,7 @@
 import sys
 from typing import TYPE_CHECKING, Any, List, Tuple, Union
 
-from gprofiler.exceptions import NoProfilersEnabledError, SystemProfilerInitFailure
+from gprofiler.exceptions import NoProfilersEnabledError
 from gprofiler.log import get_logger_adapter
 from gprofiler.metadata.system_metadata import get_arch
 from gprofiler.profilers.perf import SystemProfiler
@@ -41,7 +41,7 @@ def get_profilers(
         try:
             profiler_instance = profiler_config.profiler_class(**profiler_kwargs)
         except Exception:
-            logger.fatal(
+            logger.critical(
                 f"Couldn't create the {profiler_name} profiler, not continuing."
                 f" Run with --no-{profiler_name} to disable this profiler",
                 exc_info=True,

--- a/gprofiler/profilers/factory.py
+++ b/gprofiler/profilers/factory.py
@@ -43,7 +43,7 @@ def get_profilers(
         except Exception:
             logger.critical(
                 f"Couldn't create the {profiler_name} profiler, not continuing."
-                f" Run with --no-{profiler_name} to disable this profiler",
+                f" Run with --no-{profiler_name.lower()} to disable this profiler",
                 exc_info=True,
             )
             sys.exit(1)

--- a/gprofiler/profilers/factory.py
+++ b/gprofiler/profilers/factory.py
@@ -1,3 +1,4 @@
+import sys
 from typing import TYPE_CHECKING, Any, List, Tuple, Union
 
 from gprofiler.exceptions import NoProfilersEnabledError, SystemProfilerInitFailure
@@ -40,9 +41,12 @@ def get_profilers(
         try:
             profiler_instance = profiler_config.profiler_class(**profiler_kwargs)
         except Exception:
-            if profiler_config.profiler_class is SystemProfiler:
-                raise SystemProfilerInitFailure("Could not create the system profiler")
-            logger.critical(f"Couldn't create the {profiler_name} profiler, continuing without it", exc_info=True)
+            logger.fatal(
+                f"Couldn't create the {profiler_name} profiler, not continuing."
+                f" Run with --no-{profiler_name} to disable this profiler",
+                exc_info=True,
+            )
+            sys.exit(1)
         else:
             if isinstance(profiler_instance, SystemProfiler):
                 system_profiler = profiler_instance

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -80,7 +80,7 @@ class PerfProcess:
         except TimeoutError:
             process.kill()
             assert process.stdout is not None and process.stderr is not None
-            logger.error(f"perf failed to start. stdout {process.stdout.read()!r} stderr {process.stderr.read()!r}")
+            logger.critical(f"perf failed to start. stdout {process.stdout.read()!r} stderr {process.stderr.read()!r}")
             raise
         else:
             self._process = process
@@ -100,6 +100,13 @@ class PerfProcess:
     def wait_and_script(self) -> str:
         try:
             perf_data = wait_for_file_by_prefix(f"{self._output_path}.", self._dump_timeout_s, self._stop_event)
+        except Exception:
+            assert self._process is not None and self._process.stdout is not None and self._process.stderr is not None
+            logger.critical(
+                f"perf failed to dump output. stdout {self._process.stdout.read()!r}"
+                f" stderr {self._process.stderr.read()!r}"
+            )
+            raise
         finally:
             # always read its stderr
             # using read1() which performs just a single read() call and doesn't read until EOF


### PR DESCRIPTION
1. CRITICAL logs are bad errors that prevent the profiler from operating correctly
2. ERROR logs are stuff we don't expect to happen and might indicate a bug on our code
3. WARN logs are errors we are aware of and can happen

Currently marked 2 bad errors as CRITICAL, more will be added