### PR TITLE
Fix skip folders in lint script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,4 @@ gprofiler/resources/*
 
 # IDEs
 .idea
+.vscode

--- a/lint.sh
+++ b/lint.sh
@@ -15,7 +15,7 @@ if [[ "$1" = "--ci" ]]; then
     isort_extra_args="--check-only"
 fi
 
-isort --settings-path .isort.cfg $isort_extra_args --skip granulate-utils .
-black --line-length 120 $black_extra_args --exclude "granulate-utils|\.venv" .
+isort --settings-path .isort.cfg $isort_extra_args .
+black --line-length 120 $black_extra_args --exclude "granulate-utils|venv" .
 flake8 --config .flake8 .
 mypy .


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Passing `--skip` to `isort` overrides the configuration from `.isort.cfg`. Also changing the excluded dirs for `black` to `venv` instead of `.venv` since that's apparently the convention for this project (see a few lines up in `lint.sh`).
