### PR TITLE
java: Get stdout/stderr from fdtransfer

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -507,7 +507,6 @@ class AsyncProfiledProcess:
             [fdtransfer_path(), str(self.process.pid)],
             stop_event=self._stop_event,
             timeout=self._FDTRANSFER_TIMEOUT,
-            communicate=False,
         )
 
     def start_async_profiler(self, interval: int, second_try: bool = False, ap_timeout: int = 0) -> bool:

--- a/scripts/async_profiler_build_shared.sh
+++ b/scripts/async_profiler_build_shared.sh
@@ -5,8 +5,8 @@
 #
 set -euo pipefail
 
-VERSION=v2.8.1g1
-GIT_REV="a54f956ad4f9ee7601fcfce1a968abdca9921a6d"
+VERSION=v2.8.1g2
+GIT_REV="83fd51841ab368b0c89e20320a6d45e31a1bec5d"
 
 git clone --depth 1 -b "$VERSION" https://github.com/Granulate/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
 source "$1"


### PR DESCRIPTION
fdtransfer works by fork()ing, returning control to its parent while the child process waits until
async-profiler connects. The child inherits the standard stream fds, preventing subprocess's communicate
from returning when the process exits. I added close() calls and now it works.

The rationale - I'm seeing errors in `_run_fdtransfer` but I'm unable to debug because all I get is:
```
Traceback (most recent call last):
  File "/app/gprofiler/profilers/profiler_base.py", line 139, in snapshot
    result = future.result()
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 437, in result
    return self.__get_result()
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 389, in __get_result
    raise self._exception
  File "/usr/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/app/gprofiler/profilers/java.py", line 953, in _profile_process
    stackcollapse = self._profile_ap_process(ap_proc, comm)
  File "/app/gprofiler/profilers/java.py", line 958, in _profile_ap_process
    started = ap_proc.start_async_profiler(self._interval, ap_timeout=self._ap_timeout)
  File "/app/gprofiler/profilers/java.py", line 519, in start_async_profiler
    self._run_fdtransfer()
  File "/app/gprofiler/profilers/java.py", line 506, in _run_fdtransfer
    run_process(
  File "/app/gprofiler/utils/__init__.py", line 265, in run_process
    raise CalledProcessError(retcode, process.args, output=stdout, stderr=stderr)
gprofiler.exceptions.CalledProcessError: Command '['/app/gprofiler/resources/java/fdtransfer', '54327']' returned non-zero exit status 1. 
stdout: None
stderr: None
```

with this PR, and this small patch on fdtransfer:
```
diff --git a/src/fdtransfer/fdtransferServer.cpp b/src/fdtransfer/fdtransferServer.cpp
index fad31b6..bf5a7b5 100644
--- a/src/fdtransfer/fdtransferServer.cpp
+++ b/src/fdtransfer/fdtransferServer.cpp
@@ -53,7 +53,7 @@ int FdTransferServer::_peer;
 
 bool FdTransferServer::bindServer(struct sockaddr_un *sun, socklen_t addrlen, int accept_timeout) {
     _server = socket(AF_UNIX, SOCK_SEQPACKET, 0);
-    if (_server == -1) {
+    if (_server == -1 || 1) {
         perror("FdTransfer socket()");
         return false;
```

I'm now getting:
```
Traceback (most recent call last):
  File "/app/gprofiler/profilers/profiler_base.py", line 119, in _wait_for_profiles
    result = future.result()
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 437, in result
    return self.__get_result()
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 389, in __get_result
    raise self._exception
  File "/usr/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/app/gprofiler/profilers/java.py", line 953, in _profile_process
    stackcollapse = self._profile_ap_process(ap_proc, comm, duration)
  File "/app/gprofiler/profilers/java.py", line 958, in _profile_ap_process
    started = ap_proc.start_async_profiler(self._interval, ap_timeout=self._ap_timeout)
  File "/app/gprofiler/profilers/java.py", line 518, in start_async_profiler
    self._run_fdtransfer()
  File "/app/gprofiler/profilers/java.py", line 506, in _run_fdtransfer
    run_process(
  File "/app/gprofiler/utils/__init__.py", line 265, in run_process
    raise CalledProcessError(retcode, process.args, output=stdout, stderr=stderr)
gprofiler.exceptions.CalledProcessError: Command '['/app/gprofiler/resources/java/fdtransfer', '2580351']' returned non-zero exit status 1. 
stdout: b''
stderr: b'FdTransfer socket(): Success\n'
```

so I will be able to debug real problems later on.

See commit https://github.com/Granulate/async-profiler/commit/83fd51841ab368b0c89e20320a6d45e31a1bec5d.