### PR TITLE
java: Upgrade to AP v2.8.2

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -507,7 +507,6 @@ class AsyncProfiledProcess:
             [fdtransfer_path(), str(self.process.pid)],
             stop_event=self._stop_event,
             timeout=self._FDTRANSFER_TIMEOUT,
-            communicate=False,
         )
 
     def start_async_profiler(self, interval: int, second_try: bool = False, ap_timeout: int = 0) -> bool:

--- a/scripts/async_profiler_build_shared.sh
+++ b/scripts/async_profiler_build_shared.sh
@@ -5,8 +5,8 @@
 #
 set -euo pipefail
 
-VERSION=v2.8.1g1
-GIT_REV="a54f956ad4f9ee7601fcfce1a968abdca9921a6d"
+VERSION=v2.8.1g2
+GIT_REV="83fd51841ab368b0c89e20320a6d45e31a1bec5d"
 
 git clone --depth 1 -b "$VERSION" https://github.com/Granulate/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
 source "$1"

--- a/scripts/async_profiler_build_shared.sh
+++ b/scripts/async_profiler_build_shared.sh
@@ -5,8 +5,8 @@
 #
 set -euo pipefail
 
-VERSION=v2.8.2g1
-GIT_REV="edd7a931fd645591bf8784b8383aeaecaa1fc556"
+VERSION=v2.8.2g2
+GIT_REV="dd8c8e86c464c8a117c295418fa968fd310e3acb"
 
 git clone --depth 1 -b "$VERSION" https://github.com/Granulate/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
 source "$1"

--- a/scripts/async_profiler_build_shared.sh
+++ b/scripts/async_profiler_build_shared.sh
@@ -5,8 +5,8 @@
 #
 set -euo pipefail
 
-VERSION=v2.8.1g2
-GIT_REV="83fd51841ab368b0c89e20320a6d45e31a1bec5d"
+VERSION=v2.8.2g1
+GIT_REV="edd7a931fd645591bf8784b8383aeaecaa1fc556"
 
 git clone --depth 1 -b "$VERSION" https://github.com/Granulate/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
 source "$1"


### PR DESCRIPTION
Upgrade to AP v2.8.2.
Based on https://github.com/Granulate/gprofiler/pull/402

```
$ git range-diff v2.8.1..v2.8.1g2 v2.8.2..v2.8.2g1
 1:  0d8b07a =  1:  b2b8710 Replace semicolon in method descriptors to vertical bar, since a semicolon is already used to separate between methods
 2:  93e4b5d =  2:  f72c806 Remove the "Profiling started" message
 3:  51bb684 =  3:  3e9bf32 Remove the "Profiling stopped" message
 4:  4fd3a44 =  4:  902a2e6 Compile statically with libstdc++
 5:  700ba3b =  5:  0a9883d Build jattach statically
 6:  e898d0f !  6:  027c1cd Enocde buildid+offset of unknown symbols in the frame (#1)
    @@ src/codeCache.h: class CodeCache {
      
     
      ## src/profiler.cpp ##
    -@@ src/profiler.cpp: CodeCache* Profiler::findNativeLibrary(const void* address) {
    +@@ src/profiler.cpp: CodeCache* Profiler::findLibraryByAddress(const void* address) {
      
      const char* Profiler::findNativeMethod(const void* address) {
    -     CodeCache* lib = findNativeLibrary(address);
    +     CodeCache* lib = findLibraryByAddress(address);
     -    return lib == NULL ? NULL : lib->binarySearch(address);
     +    return lib == NULL ? NULL : lib->binarySearch(address, _call_trace_storage.get_allocator(), _add_build_ids);
      }
 7:  19e3d0d =  7:  f91464f Build fdtransfer statically
 8:  a652602 =  8:  cbc1591 Compile statically with libgcc
 9:  cf07c9e =  9:  0fe9396 Force link with memcpy@GLIBC_2.2.5 on x86_64
10:  a54f956 = 10:  4033ee0 Fix -static-* args passed only in non-MERGE case :(
11:  83fd518 = 11:  edd7a93 Close standard streams after forking in fdtransfer

```