### PR TITLE
java: Upgrade async-profiler v2.8.3g1

### DIFF
--- a/scripts/async_profiler_build_shared.sh
+++ b/scripts/async_profiler_build_shared.sh
@@ -5,8 +5,8 @@
 #
 set -euo pipefail
 
-VERSION=v2.8.2g2
-GIT_REV="dd8c8e86c464c8a117c295418fa968fd310e3acb"
+VERSION=v2.8.3g1
+GIT_REV="6f38e459b212446d5126d6104278f41f55f29030"
 
 git clone --depth 1 -b "$VERSION" https://github.com/Granulate/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
 source "$1"


### PR DESCRIPTION
```
$ git range-diff v2.8.2..v2.8.2g2 v2.8.3..v2.8.3g1
 1:  9ec48d9 <  -:  ------- Could not recreate perf_event after the first failure
 2:  cc1682d <  -:  ------- Handle different versions of Zing properly
 3:  5ca36ed =  1:  f03014d Replace semicolon in method descriptors to vertical bar, since a semicolon is already used to separate between methods
 4:  cedaa2f =  2:  56daea2 Remove the "Profiling started" message
 5:  670f3f1 =  3:  e406f18 Remove the "Profiling stopped" message
 6:  60ed4cb =  4:  7a4312d Compile statically with libstdc++
 7:  7495121 =  5:  52692de Build jattach statically
 8:  dd89f6e =  6:  0edb237 Enocde buildid+offset of unknown symbols in the frame (#1)
 9:  944102d =  7:  0c51507 Build fdtransfer statically
10:  9e6b836 =  8:  114a86f Compile statically with libgcc
11:  e2f23a9 =  9:  dbc8e7e Force link with memcpy@GLIBC_2.2.5 on x86_64
12:  2d2b6c1 = 10:  86595ea Fix -static-* args passed only in non-MERGE case :(
13:  dd8c8e8 = 11:  6f38e45 Close standard streams after forking in fdtransfer
```