### PR TITLE
Collect CPU model name & flags

### DIFF
--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -684,6 +684,7 @@ def setup_signals() -> None:
 
 def log_system_info() -> None:
     system_info = get_static_system_info()
+    logger.info(f"CPU stuff: {system_info.cpu_model_name} {system_info.cpu_flags}")  # TODO remove, only debug
     logger.info(f"gProfiler Python version: {system_info.python_version}")
     logger.info(f"gProfiler deployment mode: {system_info.run_mode}")
     logger.info(f"Kernel uname release: {system_info.kernel_release}")

--- a/gprofiler/metadata/system_metadata.py
+++ b/gprofiler/metadata/system_metadata.py
@@ -20,6 +20,8 @@ from granulate_utils.linux.ns import run_in_ns
 from gprofiler.log import get_logger_adapter
 from gprofiler.utils import is_pyinstaller, run_process
 
+UNKNOWN_VALUE = "unknown"
+
 logger = get_logger_adapter(__name__)
 hostname: Optional[str] = None
 RUN_MODE_TO_DEPLOYMENT_TYPE: Dict[str, str] = {
@@ -57,7 +59,7 @@ def get_libc_version() -> Tuple[str, str]:
     if m is not None:
         return "musl", decode_libc_version(m.group(1))
 
-    return "unknown", decode_libc_version(ldd_version)
+    return UNKNOWN_VALUE, decode_libc_version(ldd_version)
 
 
 def is_container() -> bool:
@@ -76,7 +78,7 @@ def get_run_mode() -> str:
 
 
 def get_deployment_type(run_mode: str) -> str:
-    return RUN_MODE_TO_DEPLOYMENT_TYPE.get(run_mode, "unknown")
+    return RUN_MODE_TO_DEPLOYMENT_TYPE.get(run_mode, UNKNOWN_VALUE)
 
 
 def get_local_ip() -> str:
@@ -87,7 +89,7 @@ def get_local_ip() -> str:
         s.connect(("8.8.8.8", 53))
         return cast(str, s.getsockname()[0])
     except socket.error:
-        return "unknown"
+        return UNKNOWN_VALUE
     finally:
         s.close()
 
@@ -132,7 +134,7 @@ def get_mac_address() -> str:
         address = ":".join(["%02X" % i for i in mac])
         return address
 
-    return "unknown"
+    return UNKNOWN_VALUE
 
 
 @dataclass
@@ -205,11 +207,11 @@ def get_hostname() -> str:
 def _initialize_system_info() -> Any:
     # initialized first
     global hostname
-    hostname = "<unknown>"
-    distribution = ("unknown", "unknown", "unknown")
-    libc_version = ("unknown", "unknown")
-    mac_address = "unknown"
-    local_ip = "unknown"
+    hostname = f"<{UNKNOWN_VALUE}>"  # < > are added to further distinct it from a legit hostname
+    distribution = (UNKNOWN_VALUE, UNKNOWN_VALUE, UNKNOWN_VALUE)
+    libc_version = (UNKNOWN_VALUE, UNKNOWN_VALUE)
+    mac_address = UNKNOWN_VALUE
+    local_ip = UNKNOWN_VALUE
 
     # move to host mount NS for distro & ldd.
     # now, distro will read the files on host.


### PR DESCRIPTION
## Description
This data can be useful for analysis.

Here's how the debug print looks like on my box:
```
[2022-07-19 23:20:42,976] INFO: gprofiler: CPU stuff: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp md_clear flush_l1d arch_capabilities
```