### PR TITLE
Pass --token, --service-name with = everywhere

### DIFF
--- a/deploy/dataproc/gprofiler_initialization_action.sh
+++ b/deploy/dataproc/gprofiler_initialization_action.sh
@@ -21,5 +21,5 @@ fi
 
 wget --no-verbose https://github.com/Granulate/gprofiler/releases/latest/download/gprofiler_$(uname -m) -O gprofiler
 sudo chmod +x gprofiler
-sudo sh -c "setsid ./gprofiler -cu --token '$GPROFILER_TOKEN' --service-name '$GPROFILER_SERVICE' $OUTPUT_REDIRECTION &"
+sudo sh -c "setsid ./gprofiler -cu --token='$GPROFILER_TOKEN' --service-name='$GPROFILER_SERVICE' $OUTPUT_REDIRECTION &"
 echo "gProfiler installed successfully."

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -8,4 +8,4 @@ services:
     pid: "host"
     userns_mode: "host"
     privileged: true
-    command: '-cu --token "<TOKEN>" --service-name "<SERVICE NAME>"'
+    command: '-cu --token="<TOKEN>" --service-name="<SERVICE NAME>"'

--- a/deploy/ecs/gprofiler_task_definition.json
+++ b/deploy/ecs/gprofiler_task_definition.json
@@ -11,10 +11,8 @@
             "essential": true,
             "command": [
                 "-cu",
-                "--token",
-                "<TOKEN>",
-                "--service-name",
-                "<SERVICE NAME>"
+                "--token=<TOKEN>",
+                "--service-name=<SERVICE NAME>"
             ],
             "user": "0:0",
             "privileged": true

--- a/deploy/k8s/gprofiler.yaml
+++ b/deploy/k8s/gprofiler.yaml
@@ -39,10 +39,8 @@ spec:
           imagePullPolicy: Always
           args:
             - -cu
-            - --token
-            - $(GPROFILER_TOKEN)
-            - --service-name
-            - $(GPROFILER_SERVICE)
+            - --token=$(GPROFILER_TOKEN)
+            - --service-name=$(GPROFILER_SERVICE)
           env:
             - name: GPROFILER_TOKEN
               value: @insert your token here@

--- a/deploy/k8s/helm-charts/templates/daemonset.yaml
+++ b/deploy/k8s/helm-charts/templates/daemonset.yaml
@@ -17,10 +17,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - -cu
-          - --token
-          - $(GPROFILER_TOKEN)
-          - --service-name
-          - $(GPROFILER_SERVICE)
+          - --token=$(GPROFILER_TOKEN)
+          - --service-name=$(GPROFILER_SERVICE)
           {{  range .Values.gprofiler.extraArguments }}
           - {{ . }}
           {{ end }}

--- a/deploy/systemd/granulate-gprofiler.service.template
+++ b/deploy/systemd/granulate-gprofiler.service.template
@@ -17,7 +17,7 @@ WorkingDirectory=/opt/granulate/gprofiler
 ExecStartPre=/bin/bash -c 'if [ -z "${GPROFILER_TOKEN}" ]; then echo "missing GPROFILER_TOKEN!"; exit 1; fi'
 ExecStartPre=/bin/bash -c 'if [ -z "${GPROFILER_SERVICE}" ]; then echo "missing GPROFILER_SERVICE!"; exit 1; fi'
 ExecStartPre=/bin/bash -c 'wget --no-verbose https://github.com/Granulate/gprofiler/releases/latest/download/gprofiler_$(uname -m) -O gprofiler && chmod +x gprofiler'
-ExecStart=/opt/granulate/gprofiler/gprofiler -cu --token '${GPROFILER_TOKEN}' --service-name '${GPROFILER_SERVICE}'
+ExecStart=/opt/granulate/gprofiler/gprofiler -cu --token='${GPROFILER_TOKEN}' --service-name='${GPROFILER_SERVICE}'
 TimeoutStopSec=10
 
 KillMode=process


### PR DESCRIPTION
PR #325 did it partially. Finish the job here.

Fixes the issue from https://github.com/Granulate/gprofiler/issues/417.

I manually tested the new k8s DaemonSet and it works fine.

The pattern `--token[^=]` doesn't have any other matches :)