### PR TITLE
java: Read and log AP log also upon successful operation

### DIFF
--- a/gprofiler/metadata/system_metadata.py
+++ b/gprofiler/metadata/system_metadata.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import Any, Dict, Optional, Tuple, cast
 
-import distro
+import distro  # type: ignore
 import psutil
 from granulate_utils.linux.ns import run_in_ns
 

--- a/gprofiler/metadata/system_metadata.py
+++ b/gprofiler/metadata/system_metadata.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import Any, Dict, Optional, Tuple, cast
 
-import distro  # type: ignore
+import distro
 import psutil
 from granulate_utils.linux.ns import run_in_ns
 

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -473,21 +473,24 @@ class AsyncProfiledProcess:
             + self._get_extra_ap_args()
         ]
 
+    def _read_ap_log(self) -> str:
+        if not os.path.exists(self._log_path_host):
+            return "(log file doesn't exist)"
+
+        log = Path(self._log_path_host)
+        ap_log = log.read_text()
+        # clean immediately so we don't mix log messages from multiple invocations.
+        # this is also what AP's profiler.sh does.
+        log.unlink()
+        self._recreate_log()
+        return ap_log
+
     def _run_async_profiler(self, cmd: List[str]) -> None:
         try:
             # kill jattach with SIGTERM if it hangs. it will go down
             run_process(cmd, stop_event=self._stop_event, timeout=self._jattach_timeout, kill_signal=signal.SIGTERM)
         except CalledProcessError as e:  # catches CalledProcessTimeoutError as well
-            if os.path.exists(self._log_path_host):
-                log = Path(self._log_path_host)
-                ap_log = log.read_text()
-                # clean immediately so we don't mix log messages from multiple invocations.
-                # this is also what AP's profiler.sh does.
-                log.unlink()
-                self._recreate_log()
-            else:
-                ap_log = "(log file doesn't exist)"
-
+            ap_log = self._read_ap_log()
             is_loaded = f" {self._libap_path_process}\n" in Path(f"/proc/{self.process.pid}/maps").read_text()
 
             args = e.returncode, e.cmd, e.stdout, e.stderr, self.process.pid, ap_log, is_loaded
@@ -498,6 +501,8 @@ class AsyncProfiledProcess:
                 raise JattachSocketMissingException(*args) from None
             else:
                 raise JattachException(*args) from None
+        else:
+            logger.debug("async-profiler log", jattach_cmd=cmd, ap_log=self._read_ap_log())
 
     def _run_fdtransfer(self) -> None:
         """

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -538,8 +538,7 @@ def test_java_attach_socket_missing(
         assert next(iter(profile.stacks.keys())) == "java;[Profiling error: exception JattachSocketMissingException]"
 
 
-# we're expected the debug symbols message, only in container because on the host
-# different Java may exist
+# we know what messages to expect when in container, not on the host Java
 @pytest.mark.parametrize("in_container", [True])
 def test_java_jattach_async_profiler_log_output(
     tmp_path: Path,
@@ -559,9 +558,6 @@ def test_java_jattach_async_profiler_log_output(
         log_records = list(filter(lambda r: r.message == "async-profiler log", caplog.records))
         assert len(log_records) == 2  # start,stop
         # start
-        assert (
-            log_records[0].gprofiler_adapter_extra["ap_log"]  # type: ignore
-            == "[WARN] Install JVM debug symbols to improve profile accuracy\n"
-        )
+        assert log_records[0].gprofiler_adapter_extra["ap_log"] == ""  # type: ignore
         # stop
         assert log_records[1].gprofiler_adapter_extra["ap_log"] == ""  # type: ignore

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -4,7 +4,6 @@
 #
 import logging
 import os
-import re
 import shutil
 import signal
 import threading
@@ -557,11 +556,12 @@ def test_java_jattach_async_profiler_log_output(
     ) as profiler:
         snapshot_one_profile(profiler)
 
+        log_records = list(filter(lambda r: r.message == "async-profiler log", caplog.records))
+        assert len(log_records) == 2  # start,stop
+        # start
         assert (
-            re.match(
-                # the "Install JVM debug symbols" is expected for the Java we test in container.
-                r"async-profiler log[^\n]ap_log=\[WARN\] Install JVM debug symbols to improve profile accuracy",
-                caplog.text,
-            )
-            is not None
+            log_records[0].gprofiler_adapter_extra["ap_log"]  # type: ignore
+            == "[WARN] Install JVM debug symbols to improve profile accuracy\n"
         )
+        # stop
+        assert log_records[1].gprofiler_adapter_extra["ap_log"] == ""  # type: ignore


### PR DESCRIPTION
For extra verbosity, we'd like to collect AP log at all times.
