### PR TITLE
perf: Parse new event family names

### DIFF
--- a/gprofiler/merge.py
+++ b/gprofiler/merge.py
@@ -28,7 +28,7 @@ logger = get_logger_adapter(__name__)
 
 SAMPLE_REGEX = re.compile(
     r"\s*(?P<comm>.+?)\s+(?P<pid>[\d-]+)/(?P<tid>[\d-]+)(?:\s+\[(?P<cpu>\d+)])?\s+(?P<time>\d+\.\d+):\s+"
-    r"(?:(?P<freq>\d+)\s+)?(?P<event_family>[\w-]+):(?:(?P<event>[\w-]+):)?(?P<suffix>[^\n]*)(?:\n(?P<stack>.*))?",
+    r"(?:(?P<freq>\d+)\s+)?(?P<event_family>[\w\-_/]+):(?:(?P<event>[\w-]+):)?(?P<suffix>[^\n]*)(?:\n(?P<stack>.*))?",
     re.MULTILINE | re.DOTALL,
 )
 


### PR DESCRIPTION
This field used to be "cpu-clock:", with the new perf (and on a recent kernel) I get "cpu_core/cycles/",
so add _ and / to the pattern.

It's probably for the better to remove this complex regex and remain only with parsing the stack itself. I didn't want to make a larger change at this point, given that this already works, and that we don't have good tests coverage here.