### PR TITLE
Enable phpspy for Aarch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ The runtime stacks are then merged into the data collected by `perf`, substituti
 | Python (py-spy)            | :heavy_check_mark: | :heavy_check_mark: |
 | Python (PyPerf eBPF)       | :heavy_check_mark: | :x:                |
 | Ruby (rbspy)               | :heavy_check_mark: | :heavy_check_mark: |
-| PHP (phpspy)               | :heavy_check_mark: | :x:                |
+| PHP (phpspy)               | :heavy_check_mark: | :heavy_check_mark: |
 | NodeJS (perf)              | :heavy_check_mark: | :heavy_check_mark: |
 
 ## perf-less mode

--- a/README.md
+++ b/README.md
@@ -359,15 +359,15 @@ The runtime stacks are then merged into the data collected by `perf`, substituti
 
 ## Architecture support
 
-| Runtime                    | x86_64             | Aarch64            |
-|----------------------------|--------------------|--------------------|
-| perf (native, Golang, ...) | :heavy_check_mark: | :heavy_check_mark: |
-| Java (async-profiler)      | :heavy_check_mark: | :heavy_check_mark: |
-| Python (py-spy)            | :heavy_check_mark: | :heavy_check_mark: |
-| Python (PyPerf eBPF)       | :heavy_check_mark: | :x:                |
-| Ruby (rbspy)               | :heavy_check_mark: | :heavy_check_mark: |
-| PHP (phpspy)               | :heavy_check_mark: | :heavy_check_mark: |
-| NodeJS (perf)              | :heavy_check_mark: | :heavy_check_mark: |
+| Runtime                    | x86_64             | Aarch64                           |
+|----------------------------|--------------------|-----------------------------------|
+| perf (native, Golang, ...) | :heavy_check_mark: | :heavy_check_mark:                |
+| Java (async-profiler)      | :heavy_check_mark: | :heavy_check_mark:                |
+| Python (py-spy)            | :heavy_check_mark: | :heavy_check_mark:                |
+| Python (PyPerf eBPF)       | :heavy_check_mark: | :x:                               |
+| Ruby (rbspy)               | :heavy_check_mark: | :heavy_check_mark:                |
+| PHP (phpspy)               | :heavy_check_mark: | :heavy_check_mark: (experimental) |
+| NodeJS (perf)              | :heavy_check_mark: | :heavy_check_mark:                |
 
 ## perf-less mode
 

--- a/gprofiler/profilers/php.py
+++ b/gprofiler/profilers/php.py
@@ -29,7 +29,7 @@ DEFAULT_PROCESS_FILTER = "php-fpm"
 @register_profiler(
     "PHP",
     possible_modes=["phpspy", "disabled"],
-    supported_archs=["x86_64"],  # we don't build phpspy for others yet
+    supported_archs=["x86_64", "aarch64"],
     default_mode="disabled",
     profiler_arguments=[
         ProfilerArgument(

--- a/scripts/phpspy_build.sh
+++ b/scripts/phpspy_build.sh
@@ -5,16 +5,6 @@
 #
 set -euo pipefail
 
-# TODO support aarch64
-if [ "$(uname -m)" != "x86_64" ]; then
-    mkdir -p /tmp/phpspy
-    touch /tmp/phpspy/phpspy
-    mkdir -p /tmp/binutils/binutils-2.25/bin/bin/
-    touch /tmp/binutils/binutils-2.25/bin/bin/objdump
-    touch /tmp/binutils/binutils-2.25/bin/bin/strings
-    exit 0
-fi
-
 # First build phpspy
 pushd /tmp
 git clone --depth=1 -b v0.6.0-g4 --recursive https://github.com/Granulate/phpspy.git && git -C phpspy reset --hard af1d74ebd4f9c27486e82397eafde1c450f06510

--- a/scripts/phpspy_env.sh
+++ b/scripts/phpspy_env.sh
@@ -5,9 +5,6 @@
 #
 set -euo pipefail
 
-if [ "$(uname -m)" = "aarch64" ]; then
-  exit 0
-fi
 apt-get update
 apt-get install -y --no-install-recommends \
   git \


### PR DESCRIPTION
phpspy test results (on our branch):
```
TEST tests/test_varpeek.sh
process_vm_readv: No such process
  OK   varpeek
process_vm_readv: No such process
  OK   varpeek

TEST tests/test_pgrep_time_limit.sh
main_pgrep finished gracefully
  ERR  frame_1
expected=^1 <main> <internal>:-1$

actual=


TEST tests/test_pgrep_trace_limit.sh
main_pgrep finished gracefully
  ERR  exit_code=124

TEST tests/test_time_limit.sh
  OK   include_sleep

TEST tests/test_child.sh
  OK   req_uri
  ERR  req_ts
expected=^# ts = \d+\.\d+$

actual=
0 usleep <internal>:-1
1 <main> <internal>:-1
# uri = -
# path = Standard input code
# qstring = -
# cookie = -
# ts = -nan

TEST tests/test_verbose.sh
  OK   verbose_pid
  OK   frame_1
  OK   verbose_ts
  OK   frame_0

TEST tests/test_mem.sh   
  SKIP alloc_globals symbol not found

TEST tests/test_flamegraph.sh
  OK   flamegraph

TEST tests/test_filter.sh
process_vm_readv: No such process
  OK   include_nanosleep
  OK   exclude_usleep
process_vm_readv: No such process
  OK   negate_include_nanosleep
  OK   negate_exclude_usleep

TEST tests/test_glopeek.sh
process_vm_readv: No such process
  OK   glopeek_server_new
  OK   glopeek_server_mod
  OK   glopeek_globals
  OK   glopeek_server
process_vm_readv: No such process
  OK   glopeek1
  OK   glopeek2

TEST tests/test_varpeek_range.sh
process_vm_readv: No such process
  OK   varpeek_range_a_3
  OK   varpeek_range_a_1
  OK   varpeek_range_b_4
  OK   varpeek_range_b_2

TEST tests/test_pid.sh
  OK   frame_1
  OK   frame_0

TEST tests/test_pgrep.sh
main_pgrep finished gracefully
  ERR  frame_1
expected=^1 <main> <internal>:-1$

actual=


TEST tests/test_buffer_full.sh
event_handler_fout_snprintf: Not enough space in buffer; truncating
  OK   frame_0
  OK   no_frame_1
event_handler_fout_snprintf: Not enough space in buffer; truncating
  OK   nothing

Passed 10 out of 14 tests
```

Not all pass but it's enough to try this experimental support.

Resolves: https://github.com/Granulate/gprofiler/issues/429