### PR TITLE
tests: Add perf tests on changing comms

### DIFF
--- a/tests/containers/native/change_comm.Dockerfile
+++ b/tests/containers/native/change_comm.Dockerfile
@@ -1,0 +1,7 @@
+FROM gcc:8
+
+COPY native.c .
+
+RUN gcc -DCHANGE_COMM -pthread native.c -o native
+
+CMD ["./native"]

--- a/tests/containers/native/native.c
+++ b/tests/containers/native/native.c
@@ -1,5 +1,9 @@
 // This one isn't fibonacci like the others, because it's used in tests for perf smart mode,
 // which require consistent stacktraces (and fibonacci is not consistent; these stacks are)
+#define _GNU_SOURCE
+#include <pthread.h>
+#include <stdlib.h>
+
 static void recursive(unsigned int n) {
     if (n > 0) {
         recursive(n - 1);
@@ -8,7 +12,45 @@ static void recursive(unsigned int n) {
     while (1) ;
 }
 
+#if defined(CHANGE_COMM) || defined(THREAD_COMM)
+static void change_my_comm(void) {
+    char name[16];  // 16 -> TASK_COMM_LEN
+    if (pthread_getname_np(pthread_self(), name, sizeof(name))) {
+        exit(1);
+    }
+    name[0]++; // get the name changed
+    if (pthread_setname_np(pthread_self(), name)) {
+        exit(1);
+    }
+}
+#endif
+
+#if defined(CHANGE_COMM) && defined(THREAD_COMM)
+#error not both
+#endif
+
+#if defined(CHANGE_COMM)
+int main(void) {
+    change_my_comm();
+    recursive(10);
+    return 0;
+}
+#elif defined(THREAD_COMM)
+static void *thread(void *_) {
+    change_my_comm();
+    recursive(10);
+}
+
+int main(void) {
+    change_my_comm();  // change first time in main thread
+    pthread_t t;
+    pthread_create(&t, NULL, thread, NULL);
+    pthread_join(t, NULL);
+    return 0;
+}
+#else
 int main(void) {
     recursive(10);
     return 0;
 }
+#endif

--- a/tests/containers/native/thread_comm.Dockerfile
+++ b/tests/containers/native/thread_comm.Dockerfile
@@ -1,0 +1,7 @@
+FROM gcc:8
+
+COPY native.c .
+
+RUN gcc -DTHREAD_COMM -pthread native.c -o native
+
+CMD ["./native"]

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -65,12 +65,17 @@ def _restart_app_container(application_docker_container: Container) -> int:
 
 def _assert_comm_in_profile(profiler: SystemProfiler, application_pid: int, exec_comm: bool) -> None:
     collapsed = snapshot_pid_collapsed(profiler, application_pid)
+    # native is the original comm
+    # oative is the changed comm of the main thread
+    # pative is the changed comm of other threads
     if exec_comm:
-        assert not is_function_in_collapsed("oative;", collapsed)
         assert is_function_in_collapsed("native;", collapsed)
+        assert not is_function_in_collapsed("oative;", collapsed)
+        assert not is_function_in_collapsed("pative;", collapsed)
     else:
-        assert is_function_in_collapsed("oative;", collapsed)
         assert not is_function_in_collapsed("native;", collapsed)
+        assert is_function_in_collapsed("oative;", collapsed)
+        assert not is_function_in_collapsed("pative;", collapsed)
 
 
 @pytest.mark.parametrize("runtime", ["native_change_comm"])

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -7,31 +7,36 @@ from pathlib import Path
 from threading import Event
 
 import pytest
+from docker.models.containers import Container
 
 from gprofiler.profilers.perf import DEFAULT_PERF_DWARF_STACK_SIZE, SystemProfiler
 from tests.utils import assert_function_in_collapsed, is_function_in_collapsed, snapshot_pid_collapsed
 
 
-@pytest.mark.parametrize("runtime", ["native_fp", "native_dwarf"])
-@pytest.mark.parametrize("perf_mode", ["fp", "dwarf", "smart"])
-@pytest.mark.parametrize("in_container", [True])  # native app is built only for container
-def test_perf(
-    tmp_path: Path,
-    application_pid: int,
-    runtime: str,
-    perf_mode: str,
-) -> None:
-    """ """
-    with SystemProfiler(
+@pytest.fixture
+def system_profiler(tmp_path: Path, perf_mode: str) -> SystemProfiler:
+    return SystemProfiler(
         99,
-        3,
+        1,
         Event(),
         str(tmp_path),
         False,
         perf_mode=perf_mode,
         perf_inject=False,
         perf_dwarf_stack_size=DEFAULT_PERF_DWARF_STACK_SIZE,
-    ) as profiler:
+    )
+
+
+@pytest.mark.parametrize("runtime", ["native_fp", "native_dwarf"])
+@pytest.mark.parametrize("perf_mode", ["fp", "dwarf", "smart"])
+@pytest.mark.parametrize("in_container", [True])  # native app is built only for container
+def test_perf_fp_dwarf_smart(
+    system_profiler: SystemProfiler,
+    application_pid: int,
+    runtime: str,
+    perf_mode: str,
+) -> None:
+    with system_profiler as profiler:
         process_collapsed = snapshot_pid_collapsed(profiler, application_pid)
 
         if runtime == "native_dwarf":
@@ -49,3 +54,97 @@ def test_perf(
         assert is_function_in_collapsed(";_start;__libc_start_main;main;", process_collapsed) ^ bool(
             perf_mode not in ("dwarf", "smart")
         )
+
+
+@pytest.mark.parametrize("runtime", ["native_change_comm"])
+@pytest.mark.parametrize("perf_mode", ["fp"])  # only fp is enough
+@pytest.mark.parametrize("in_container", [True])  # native app is built only for container
+def test_perf_comm_change(
+    system_profiler: SystemProfiler,
+    application_pid: int,
+    application_docker_container: Container,
+    perf_mode: str,
+) -> None:
+    """
+    Runs a program that changes its comm (i.e comm of the main thread).
+    The stack output by perf should use the original name, not the changed one.
+
+    This tests our modification to perf here:
+    https://github.com/Granulate/linux/commit/40a7823cf90a7e69ce8af88d224dfdd7e371de2d
+
+    perf records "comm" events - changes of task comms. Samples printed for a thread will use the current comm
+    perf understands that it has. Our modification makes it select a PERF_RECORD_COMM event that has the "exec"
+    flag. Below are 2 events from the native program - the first is the name it was executed with, then
+    the rename. If perf has started before the app, we expect to see the exec name and not the current name.
+
+        native 1901079 [010] 984807.648525: PERF_RECORD_COMM exec: native:1901079/1901079
+        oative 1901079 [010] 984807.648792: PERF_RECORD_COMM: oative:1901079/1901079
+
+    If perf started after the app, we will see the changed name (although I'd prefer to see the original name, but
+    I'm not sure it can be done, i.e is this info even kept anywhere).
+    """
+    with system_profiler as profiler:
+        collapsed = snapshot_pid_collapsed(profiler, application_pid)
+        # first run - we get the changed name, because the app started before perf began recording.
+        assert is_function_in_collapsed("oative;", collapsed)
+        assert not is_function_in_collapsed("native;", collapsed)
+
+        # now, while perf is still running & recording, we restart the app
+        application_docker_container.restart(timeout=0)
+        application_docker_container.reload()  # post restart
+        application_pid = application_docker_container.attrs["State"]["Pid"]
+
+        # second run - we get the original name, because the app started after perf began recording.
+        collapsed = snapshot_pid_collapsed(profiler, application_pid)
+        assert not is_function_in_collapsed("oative;", collapsed)
+        assert is_function_in_collapsed("native;", collapsed)
+
+
+@pytest.mark.xfail(reason="https://github.com/Granulate/gprofiler/issues/431")
+@pytest.mark.parametrize("runtime", ["native_thread_comm"])
+@pytest.mark.parametrize("perf_mode", ["fp"])  # only fp is enough
+@pytest.mark.parametrize("in_container", [True])  # native app is built only for container
+def test_perf_thread_comm_is_process_comm(
+    system_profiler: SystemProfiler,
+    application_pid: int,
+    application_docker_container: Container,
+    perf_mode: str,
+) -> None:
+    """
+    Runs a program that changes its comm (i.e comm of the main thread), then starts a thread that
+    changes its comm.
+    The stack output by perf should use the comm of the process (i.e the main thread), and when the process
+    starts after perf, the exec comm of the process should be used (see test_perf_comm_change)
+
+    This test currently fails but describes the desired behavior.
+    """
+    with system_profiler as profiler:
+        # running perf & script now with --show-task-events would show:
+        #   pative 1925947 [010] 987095.272656: PERF_RECORD_COMM: pative:1925904/1925947
+        # our perf will prefer to use the exec comm, OR oldest comm available if exec
+        # one is not present; see logic in thread__exec_comm().
+
+        collapsed = snapshot_pid_collapsed(profiler, application_pid)
+        # first run - we get the changed name, because the app started before perf began recording.
+        # note that we still pick the process name and not thread name! (thread native is 'pative')
+        assert is_function_in_collapsed("oative;", collapsed)
+        assert not is_function_in_collapsed("native;", collapsed)
+
+        # now, while perf is still running & recording, we restart the app
+        application_docker_container.restart(timeout=0)
+        application_docker_container.reload()  # post restart
+        application_pid = application_docker_container.attrs["State"]["Pid"]
+
+        # for clarity, these are the COMM events that happen here:
+        #   native 1925904 [006] 987095.271786: PERF_RECORD_COMM exec: native:1925904/1925904
+        #   oative 1925904 [006] 987095.272430: PERF_RECORD_COMM: oative:1925904/1925904
+        #   oative 1925904 [006] 987095.272545: PERF_RECORD_FORK(1925904:1925947):(1925904:1925904)
+        #   pative 1925947 [010] 987095.272656: PERF_RECORD_COMM: pative:1925904/1925947
+        # we take the exec comm for all threads so we remain with the first, "native".
+
+        collapsed = snapshot_pid_collapsed(profiler, application_pid)
+        # this fails - because in thread__fork(), perf takes only the current comm of the forking thread
+        # and attaches it to the forked one. thus the exec comm (which is not current, but last) is lost.
+        # the fix can be to copy all comms in thread__fork().
+        assert not is_function_in_collapsed("oative;", collapsed)
+        assert is_function_in_collapsed("native;", collapsed)


### PR DESCRIPTION
I liked writing them because they helped me grasp the current state of affairs.

An unrelated change - we no longer delete the application docker images, it's a
waste of time.
