### PR TITLE
Change java metadata['java_version'] to parsed JvmVersion

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -242,7 +242,7 @@ def get_java_version_logged(process: Process, stop_event: Event) -> str:
 class JavaMetadata(ApplicationMetadata):
     def make_application_metadata(self, process: Process) -> Dict[str, Any]:
         if is_java_basename(process):
-            version = get_java_version(process, self._stop_event)
+            version = parse_jvm_version(get_java_version(process, self._stop_event)).__repr__()
         else:
             version = "not /java"
         # libjvm elfid - we care only about libjvm, not about the java exe itself which is a just small program

--- a/tests/test_app_metadata.py
+++ b/tests/test_app_metadata.py
@@ -51,9 +51,7 @@ from tests.utils import run_gprofiler_in_container_for_one_session
             {
                 "exe": "/usr/local/openjdk-8/bin/java",
                 "execfn": "/usr/local/openjdk-8/bin/java",
-                "java_version": 'openjdk version "1.8.0_275"\n'
-                "OpenJDK Runtime Environment (build 1.8.0_275-b01)\n"
-                "OpenJDK 64-Bit Server VM (build 25.275-b01, mixed mode)",
+                "java_version": "JvmVersion(8.275, 1, 'OpenJDK 64-Bit Server VM')",
                 "libjvm_elfid": "buildid:0542486ff00153ca0bcf9f2daea9a36c428d6cde",
             },
         ),


### PR DESCRIPTION
Change java metadata['java_version'] to parsed JvmVersion

## Description
Change java metadata['java_version'] to parsed JvmVersion

## Related Issue
<!--- If there's an issue related, please link it here -->
<!--- If suggesting a new feature or a medium/big change, please discuss it in an issue first. -->
<!--- For small changes, it's okay to open a PR immediately. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What does it improve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your changes are tested by the CI, you can just write that.-->

## Screenshots
<!--- (if appropriate) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the relevant documentation.
- [x] I have added tests for new logic.
