### PR TITLE
tests: Use openjdk images repository instead of java

### DIFF
--- a/tests/containers/java/musl.Dockerfile
+++ b/tests/containers/java/musl.Dockerfile
@@ -1,5 +1,5 @@
 # see test_java_async_profiler_musl_and_cpu
-FROM openjdk:alpine
+FROM openjdk@sha256:d49bf8c44670834d3dade17f8b84d709e7db47f1887f671a0e098bafa9bae49f
 
 WORKDIR /app
 ADD Fibonacci.java /app

--- a/tests/containers/java/musl.Dockerfile
+++ b/tests/containers/java/musl.Dockerfile
@@ -1,5 +1,5 @@
 # see test_java_async_profiler_musl_and_cpu
-FROM java:alpine
+FROM openjdk:alpine
 
 WORKDIR /app
 ADD Fibonacci.java /app


### PR DESCRIPTION
It seems like "java" was removed, I get:
"Error response from daemon: manifest for java:latest not found: manifest unknown: manifest unknown"

Also, heading to https://hub.docker.com/_/java redirects you to https://hub.docker.com/_/openjdk so I suppose that's the official successor.