### PR TITLE
Move jvm version parsing to granulate-utils

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -9,7 +9,6 @@ import re
 import secrets
 import signal
 from enum import Enum
-from itertools import dropwhile
 from pathlib import Path
 from subprocess import CompletedProcess
 from threading import Event, Lock
@@ -23,9 +22,11 @@ from granulate_utils.java import (
     NATIVE_FRAMES_REGEX,
     SIGINFO_REGEX,
     VM_INFO_REGEX,
+    JvmVersion,
     is_java_fatal_signal,
     java_exit_code_to_signo,
     locate_hotspot_error_file,
+    parse_jvm_version,
 )
 from granulate_utils.linux import proc_events
 from granulate_utils.linux.kernel_messages import KernelMessage
@@ -549,77 +550,6 @@ class AsyncProfiledProcess:
             if not is_process_running(self.process):
                 return None
             raise
-
-
-class JvmVersion:
-    def __init__(self, version: Version, build: int, name: str):
-        self.version = version
-        self.build = build
-        self.name = name
-
-    def __repr__(self) -> str:
-        return f"JvmVersion({self.version}, {self.build!r}, {self.name!r})"
-
-
-# Parse java version information from "java -version" output
-def parse_jvm_version(version_string: str) -> JvmVersion:
-    # Example java -version output:
-    #   openjdk version "1.8.0_265"
-    #   OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_265-b01)
-    #   OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.265-b01, mixed mode)
-    # We are taking the version from the first line, and the build number and vm name from the last line
-
-    lines = version_string.splitlines()
-
-    # the version always starts with "openjdk version" or "java version". strip all lines
-    # before that.
-    lines = list(dropwhile(lambda l: not ("openjdk version" in l or "java version" in l), lines))
-
-    # version is always in quotes
-    _, version_str, _ = lines[0].split('"')
-    # matches the build string from e.g (build 25.212-b04, mixed mode) -> "25.212-b04"
-    m = re.search(r"\(build ([^,)]+?)(?:,|\))", version_string)
-    assert m is not None, f"did not find build_str in {version_string!r}"
-    build_str = m.group(1)
-
-    if any(version_str.endswith(suffix) for suffix in ("-internal", "-ea", "-ojdkbuild")):
-        # strip those suffixes to keep the rest of the parsing logic clean
-        version_str = version_str.rsplit("-")[0]
-
-    version_list = version_str.split(".")
-    if version_list[0] == "1":
-        # For java 8 and prior, versioning looks like
-        # 1.<major>.0_<minor>-b<build_number>
-        # For example 1.8.0_242-b12 means 8.242 with build number 12
-        assert len(version_list) == 3, f"Unexpected number of elements for old-style java version: {version_list!r}"
-        assert "_" in version_list[-1], f"Did not find expected underscore in old-style java version: {version_list!r}"
-        major = version_list[1]
-        minor = version_list[-1].split("_")[-1]
-        version = Version(f"{major}.{minor}")
-        # find the -b or -ojdkbuild-
-        if "-b" in build_str:
-            build_split = build_str.split("-b")
-            # it can appear multiple times, e.g "(build 1.8.0_282-8u282-b08-0ubuntu1~16.04-b08)"
-            assert len(build_split) >= 2, f"Unexpected number of occurrences of '-b' in {build_str!r}"
-        else:
-            build_split = build_str.split("-ojdkbuild-")
-            assert len(build_split) == 2, f"Unexpected number of occurrences of '-ojdkbuild-' in {build_str!r}"
-        build = int(build_split[-1])
-    else:
-        # Since java 9 versioning became more normal, and looks like
-        # <version>+<build_number>
-        # For example, 11.0.11+9
-        version = Version(version_str)
-        assert "+" in build_str, f"Did not find expected build number prefix in new-style java version: {build_str!r}"
-        # The goal of the regex here is to read the build number until a non-digit character is encountered,
-        # since additional information can be appended after it, such as the platform name
-        matched = re.match(r"\d+", build_str[build_str.find("+") + 1 :])
-        assert matched, f"Unexpected build number format in new-style java version: {build_str!r}"
-        build = int(matched[0])
-
-    # There is no real format here, just use the entire description string
-    vm_name = lines[2].split("(build")[0].strip()
-    return JvmVersion(version, build, vm_name)
 
 
 @register_profiler(

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -19,19 +19,14 @@ import docker
 import psutil
 import pytest
 from docker.models.containers import Container
+from granulate_utils.java import parse_jvm_version
 from granulate_utils.linux.elf import get_elf_buildid
 from granulate_utils.linux.ns import get_process_nspid
 from granulate_utils.linux.process import is_musl
 from packaging.version import Version
 from pytest import LogCaptureFixture, MonkeyPatch
 
-from gprofiler.profilers.java import (
-    AsyncProfiledProcess,
-    JavaProfiler,
-    frequency_to_ap_interval,
-    get_java_version,
-    parse_jvm_version,
-)
+from gprofiler.profilers.java import AsyncProfiledProcess, JavaProfiler, frequency_to_ap_interval, get_java_version
 from gprofiler.utils import remove_prefix
 from tests.conftest import AssertInCollapsed
 from tests.type_utils import cast_away_optional


### PR DESCRIPTION
Move jvm version parsing to granulate-utils.

## Description
JvmVersion class and parse_jvm_version method are now moved to granulate-utils submodule.

## Related Issue
<!--- If there's an issue related, please link it here -->
<!--- If suggesting a new feature or a medium/big change, please discuss it in an issue first. -->
<!--- For small changes, it's okay to open a PR immediately. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What does it improve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your changes are tested by the CI, you can just write that.-->

## Screenshots
<!--- (if appropriate) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
