### PR TITLE
metadata: get_cpu_flags(): Fix it on Aarch64

### DIFF
--- a/gprofiler/metadata/system_metadata.py
+++ b/gprofiler/metadata/system_metadata.py
@@ -146,22 +146,23 @@ def get_cpu_info() -> Tuple[str, str]:
             model_names = []
             flags = []
             for line in f:
-                m = re.match(r"^((?:model name)|(?:flags))[ \t]*: (.*)$", line)
+                m = re.match(r"^((?:model name)|(?:flags)|(?:Features))[ \t]*: (.*)$", line)
                 if m is not None:
                     field, value = m.groups()
                     if field == "model name":
                         model_names.append(value)
                     else:
-                        assert field == "flags", f"unexpected field: {field!r}"
+                        # flags in x86_64, Features in aarch64
+                        assert field in ("flags", "Features"), f"unexpected field: {field!r}"
                         flags.append(value)
 
-        if len(set(model_names)) != 1:
+        if len(set(model_names)) > 1:
             logger.warning(f"CPU model names differ between cores, reporting only the first: {model_names}")
 
-        if len(set(flags)) != 1:
+        if len(set(flags)) > 1:
             logger.warning(f"CPU flags differ between cores, reporting only the first: {model_names}")
 
-        return model_names[0], flags[0]
+        return model_names[0] if len(model_names) else UNKNOWN_VALUE, flags[0] if len(flags) else UNKNOWN_VALUE
     except Exception:
         logger.exception("Failed to get CPU model name & flags, reporting unknown")
         return UNKNOWN_VALUE, UNKNOWN_VALUE


### PR DESCRIPTION
Sample output on a Graviton server:
```
ubuntu@ip-xxx:~$ cat /proc/cpuinfo 
processor	: 0
BogoMIPS	: 166.66
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd08
CPU revision	: 3

processor	: 1
BogoMIPS	: 166.66
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd08
CPU revision	: 3

processor	: 2
BogoMIPS	: 166.66
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd08
CPU revision	: 3

processor	: 3
BogoMIPS	: 166.66
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd08
CPU revision	: 3

processor	: 4
BogoMIPS	: 166.66
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd08
CPU revision	: 3

processor	: 5
BogoMIPS	: 166.66
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd08
CPU revision	: 3

processor	: 6
BogoMIPS	: 166.66
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd08
CPU revision	: 3

processor	: 7
BogoMIPS	: 166.66
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd08
CPU revision	: 3
```

Seems to be no "CPU model name" here, so we'll get "unknown" instead.

Tested it against that output ^^ works fine.