### PR TITLE
Colaesce process basename checks & check argv[0] as well

### DIFF
--- a/gprofiler/profilers/dotnet.py
+++ b/gprofiler/profilers/dotnet.py
@@ -19,7 +19,7 @@ from gprofiler.metadata.application_metadata import ApplicationMetadata
 from gprofiler.profilers.profiler_base import ProcessProfilerBase
 from gprofiler.profilers.registry import register_profiler
 from gprofiler.utils import pgrep_maps, random_prefix, removed_path, resource_path, run_process
-from gprofiler.utils.process import is_process_basename, process_comm
+from gprofiler.utils.process import is_process_basename_matching, process_comm
 from gprofiler.utils.speedscope import load_speedscope_as_collapsed
 
 logger = get_logger_adapter(__name__)
@@ -30,7 +30,7 @@ class DotnetMetadata(ApplicationMetadata):
 
     @functools.lru_cache(4096)
     def _get_dotnet_version(self, process: Process) -> str:
-        if not is_process_basename(process, r"^dotnet"):  # startswith check
+        if not is_process_basename_matching(process, r"^dotnet"):  # startswith check
             raise NotImplementedError
         version = self.get_exe_version(process)  # not using cached version here since this wrapper is a cache
         return version

--- a/gprofiler/profilers/dotnet.py
+++ b/gprofiler/profilers/dotnet.py
@@ -10,7 +10,6 @@ from threading import Event
 from typing import Any, Dict, List, Optional
 
 from granulate_utils.linux.ns import get_process_nspid
-from granulate_utils.linux.process import process_exe
 from psutil import Process
 
 from gprofiler.exceptions import ProcessStoppedException, StopEventSetException
@@ -20,7 +19,7 @@ from gprofiler.metadata.application_metadata import ApplicationMetadata
 from gprofiler.profilers.profiler_base import ProcessProfilerBase
 from gprofiler.profilers.registry import register_profiler
 from gprofiler.utils import pgrep_maps, random_prefix, removed_path, resource_path, run_process
-from gprofiler.utils.process import process_comm
+from gprofiler.utils.process import is_process_basename, process_comm
 from gprofiler.utils.speedscope import load_speedscope_as_collapsed
 
 logger = get_logger_adapter(__name__)
@@ -31,7 +30,7 @@ class DotnetMetadata(ApplicationMetadata):
 
     @functools.lru_cache(4096)
     def _get_dotnet_version(self, process: Process) -> str:
-        if not os.path.basename(process_exe(process)).startswith("dotnet"):
+        if not is_process_basename(process, r"^dotnet"):  # startswith check
             raise NotImplementedError
         version = self.get_exe_version(process)  # not using cached version here since this wrapper is a cache
         return version

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -65,7 +65,7 @@ from gprofiler.utils import (
 )
 from gprofiler.utils.fs import is_rw_exec_dir, safe_copy
 from gprofiler.utils.perf import can_i_use_perf_events
-from gprofiler.utils.process import process_comm, read_proc_file
+from gprofiler.utils.process import is_process_basename, process_comm, read_proc_file
 
 logger = get_logger_adapter(__name__)
 
@@ -190,7 +190,7 @@ class JattachSocketMissingException(JattachExceptionBase):
 
 
 def is_java_basename(process: Process) -> bool:
-    return os.path.basename(process_exe(process)) == "java"
+    return is_process_basename(process, r"^java$")
 
 
 _JAVA_VERSION_TIMEOUT = 5

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -65,7 +65,7 @@ from gprofiler.utils import (
 )
 from gprofiler.utils.fs import is_rw_exec_dir, safe_copy
 from gprofiler.utils.perf import can_i_use_perf_events
-from gprofiler.utils.process import is_process_basename, process_comm, read_proc_file
+from gprofiler.utils.process import is_process_basename_matching, process_comm, read_proc_file
 
 logger = get_logger_adapter(__name__)
 
@@ -190,7 +190,7 @@ class JattachSocketMissingException(JattachExceptionBase):
 
 
 def is_java_basename(process: Process) -> bool:
-    return is_process_basename(process, r"^java$")
+    return is_process_basename_matching(process, r"^java$")
 
 
 _JAVA_VERSION_TIMEOUT = 5

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -805,7 +805,7 @@ class JavaProfiler(SpawningProcessProfilerBase):
             if java_version_output is None:  # we don't get the java version if the exe isn't "java"
                 logger.warning(
                     "Non-java basenamed process (cannot get Java version), skipping... (disable "
-                    f" --java-safemode={JavaSafemodeOptions.JAVA_EXTENDED_VERSION_CHECKS} to profile it anyway)",
+                    f"--java-safemode={JavaSafemodeOptions.JAVA_EXTENDED_VERSION_CHECKS} to profile it anyway)",
                     pid=process.pid,
                     exe=exe,
                 )
@@ -845,7 +845,7 @@ class JavaProfiler(SpawningProcessProfilerBase):
             if "libasyncProfiler.so" in mmap.path and f"/{GPROFILER_DIRECTORY_NAME}/" not in mmap.path:
                 logger.warning(
                     "Non-gProfiler async-profiler is already loaded to the target process."
-                    f" Disable --java-safemode={JavaSafemodeOptions.AP_LOADED_CHECK} to bypass this check.",
+                    f" (disable --java-safemode={JavaSafemodeOptions.AP_LOADED_CHECK} to bypass this check)",
                     pid=process.pid,
                     ap_path=mmap.path,
                 )

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -24,7 +24,7 @@ from gprofiler.profilers.profiler_base import ProfilerBase
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
 from gprofiler.utils import run_process, start_process, wait_event, wait_for_file_by_prefix
 from gprofiler.utils.perf import perf_path
-from gprofiler.utils.process import is_process_basename
+from gprofiler.utils.process import is_process_basename_matching
 
 logger = get_logger_adapter(__name__)
 
@@ -303,7 +303,7 @@ class GolangPerfMetadata(PerfMetadata):
 
 class NodePerfMetadata(PerfMetadata):
     def relevant_for_process(self, process: Process) -> bool:
-        return is_process_basename(process, r"^node$")
+        return is_process_basename_matching(process, r"^node$")
 
     def make_application_metadata(self, process: Process) -> Dict[str, Any]:
         metadata = {"node_version": self.get_exe_version_cached(process)}

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -12,7 +12,7 @@ from threading import Event
 from typing import Any, Dict, List, Optional
 
 from granulate_utils.linux.elf import is_statically_linked, read_elf_symbol, read_elf_va
-from granulate_utils.linux.process import is_musl, process_exe
+from granulate_utils.linux.process import is_musl
 from psutil import NoSuchProcess, Process
 
 from gprofiler import merge
@@ -24,6 +24,7 @@ from gprofiler.profilers.profiler_base import ProfilerBase
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
 from gprofiler.utils import run_process, start_process, wait_event, wait_for_file_by_prefix
 from gprofiler.utils.perf import perf_path
+from gprofiler.utils.process import is_process_basename
 
 logger = get_logger_adapter(__name__)
 
@@ -302,7 +303,7 @@ class GolangPerfMetadata(PerfMetadata):
 
 class NodePerfMetadata(PerfMetadata):
     def relevant_for_process(self, process: Process) -> bool:
-        return os.path.basename(process_exe(process)) == "node"
+        return is_process_basename(process, r"^node$")
 
     def make_application_metadata(self, process: Process) -> Dict[str, Any]:
         metadata = {"node_version": self.get_exe_version_cached(process)}

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -51,7 +51,7 @@ from gprofiler.utils import (
     wait_event,
     wait_for_file_by_prefix,
 )
-from gprofiler.utils.process import is_process_basename, process_comm, read_proc_file
+from gprofiler.utils.process import is_process_basename_matching, process_comm, read_proc_file
 
 logger = get_logger_adapter(__name__)
 
@@ -97,7 +97,7 @@ class PythonMetadata(ApplicationMetadata):
     _PYTHON_VERSION_TIMEOUT = 3
 
     def _run_process_python(self, process: Process, args: List[str]) -> Tuple[str, str]:
-        if not is_process_basename(process, application_identifiers._PYTHON_BIN_RE):
+        if not is_process_basename_matching(process, application_identifiers._PYTHON_BIN_RE):
             # TODO: for dynamic executables, find the python binary that works with the loaded libpython, and
             # check it instead. For static executables embedding libpython - :shrug:
             raise NotImplementedError

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -51,7 +51,7 @@ from gprofiler.utils import (
     wait_event,
     wait_for_file_by_prefix,
 )
-from gprofiler.utils.process import process_comm, read_proc_file
+from gprofiler.utils.process import is_process_basename, process_comm, read_proc_file
 
 logger = get_logger_adapter(__name__)
 
@@ -97,7 +97,7 @@ class PythonMetadata(ApplicationMetadata):
     _PYTHON_VERSION_TIMEOUT = 3
 
     def _run_process_python(self, process: Process, args: List[str]) -> Tuple[str, str]:
-        if not os.path.basename(process.exe()).startswith("python"):
+        if not is_process_basename(process, application_identifiers._PYTHON_BIN_RE):
             # TODO: for dynamic executables, find the python binary that works with the loaded libpython, and
             # check it instead. For static executables embedding libpython - :shrug:
             raise NotImplementedError

--- a/gprofiler/profilers/ruby.py
+++ b/gprofiler/profilers/ruby.py
@@ -12,7 +12,7 @@ from threading import Event
 from typing import Any, Dict, List, Optional
 
 from granulate_utils.linux.elf import get_elf_id
-from granulate_utils.linux.process import get_mapped_dso_elf_id, process_exe
+from granulate_utils.linux.process import get_mapped_dso_elf_id
 from psutil import Process
 
 from gprofiler import merge
@@ -23,7 +23,7 @@ from gprofiler.metadata.application_metadata import ApplicationMetadata
 from gprofiler.profilers.profiler_base import SpawningProcessProfilerBase
 from gprofiler.profilers.registry import register_profiler
 from gprofiler.utils import pgrep_maps, random_prefix, removed_path, resource_path, run_process
-from gprofiler.utils.process import process_comm, read_proc_file
+from gprofiler.utils.process import is_process_basename, process_comm, read_proc_file
 
 logger = get_logger_adapter(__name__)
 
@@ -33,7 +33,7 @@ class RubyMetadata(ApplicationMetadata):
 
     @functools.lru_cache(4096)
     def _get_ruby_version(self, process: Process) -> str:
-        if not os.path.basename(process_exe(process)).startswith("ruby"):
+        if is_process_basename(process, r"^ruby"):  # startswith match
             # TODO: for dynamic executables, find the ruby binary that works with the loaded libruby, and
             # check it instead. For static executables embedding libruby - :shrug:
             raise NotImplementedError

--- a/gprofiler/profilers/ruby.py
+++ b/gprofiler/profilers/ruby.py
@@ -23,7 +23,7 @@ from gprofiler.metadata.application_metadata import ApplicationMetadata
 from gprofiler.profilers.profiler_base import SpawningProcessProfilerBase
 from gprofiler.profilers.registry import register_profiler
 from gprofiler.utils import pgrep_maps, random_prefix, removed_path, resource_path, run_process
-from gprofiler.utils.process import is_process_basename, process_comm, read_proc_file
+from gprofiler.utils.process import is_process_basename_matching, process_comm, read_proc_file
 
 logger = get_logger_adapter(__name__)
 
@@ -33,7 +33,7 @@ class RubyMetadata(ApplicationMetadata):
 
     @functools.lru_cache(4096)
     def _get_ruby_version(self, process: Process) -> str:
-        if not is_process_basename(process, r"^ruby"):  # startswith match
+        if not is_process_basename_matching(process, r"^ruby"):  # startswith match
             # TODO: for dynamic executables, find the ruby binary that works with the loaded libruby, and
             # check it instead. For static executables embedding libruby - :shrug:
             raise NotImplementedError

--- a/gprofiler/profilers/ruby.py
+++ b/gprofiler/profilers/ruby.py
@@ -33,7 +33,7 @@ class RubyMetadata(ApplicationMetadata):
 
     @functools.lru_cache(4096)
     def _get_ruby_version(self, process: Process) -> str:
-        if is_process_basename(process, r"^ruby"):  # startswith match
+        if not is_process_basename(process, r"^ruby"):  # startswith match
             # TODO: for dynamic executables, find the ruby binary that works with the loaded libruby, and
             # check it instead. For static executables embedding libruby - :shrug:
             raise NotImplementedError

--- a/gprofiler/utils/process.py
+++ b/gprofiler/utils/process.py
@@ -3,9 +3,12 @@
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
 
+import os
+import re
+from functools import lru_cache
 from pathlib import Path
 
-from granulate_utils.linux.process import is_process_running
+from granulate_utils.linux.process import is_process_running, process_exe
 from psutil import NoSuchProcess, Process
 
 
@@ -30,3 +33,16 @@ def process_comm(process: Process) -> str:
     name_line = status.splitlines()[0]
     assert name_line.startswith("Name:\t")
     return name_line.split("\t", 1)[1]
+
+
+@lru_cache(maxsize=512)
+def is_process_basename(process: Process, basename_pattern: str) -> bool:
+    if re.match(basename_pattern, os.path.basename(process_exe(process))):
+        return True
+
+    # process was executed AS basename (but has different exe name)
+    cmd = process.cmdline()
+    if len(cmd) > 0 and re.match(basename_pattern, cmd[0]):
+        return True
+
+    return False

--- a/gprofiler/utils/process.py
+++ b/gprofiler/utils/process.py
@@ -36,7 +36,7 @@ def process_comm(process: Process) -> str:
 
 
 @lru_cache(maxsize=512)
-def is_process_basename(process: Process, basename_pattern: str) -> bool:
+def is_process_basename_matching(process: Process, basename_pattern: str) -> bool:
     if re.match(basename_pattern, os.path.basename(process_exe(process))):
         return True
 

--- a/tests/containers/java/Dockerfile
+++ b/tests/containers/java/Dockerfile
@@ -7,5 +7,7 @@ ADD Fibonacci.java /app
 ADD MANIFEST.MF /app
 RUN javac Fibonacci.java
 RUN jar cvmf MANIFEST.MF Fibonacci.jar *.class
+# create a java binary with different basename, see test_java_different_basename
+RUN cp `which java` `which java`-notjava
 
 CMD ["sh", "-c", "java -jar Fibonacci.jar; sleep 10000"]

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -18,7 +18,9 @@ from typing import Any, Optional
 import docker
 import psutil
 import pytest
+from docker import DockerClient
 from docker.models.containers import Container
+from docker.models.images import Image
 from granulate_utils.java import parse_jvm_version
 from granulate_utils.linux.elf import get_elf_buildid
 from granulate_utils.linux.ns import get_process_nspid
@@ -26,11 +28,24 @@ from granulate_utils.linux.process import is_musl
 from packaging.version import Version
 from pytest import LogCaptureFixture, MonkeyPatch
 
-from gprofiler.profilers.java import AsyncProfiledProcess, JavaProfiler, frequency_to_ap_interval, get_java_version
+from gprofiler.profilers.java import (
+    JAVA_SAFEMODE_ALL,
+    AsyncProfiledProcess,
+    JavaProfiler,
+    frequency_to_ap_interval,
+    get_java_version,
+)
 from gprofiler.utils import remove_prefix
 from tests.conftest import AssertInCollapsed
 from tests.type_utils import cast_away_optional
-from tests.utils import assert_function_in_collapsed, make_java_profiler, snapshot_one_collapsed, snapshot_one_profile
+from tests.utils import (
+    _application_docker_container,
+    assert_function_in_collapsed,
+    make_java_profiler,
+    snapshot_one_collapsed,
+    snapshot_one_profile,
+    snapshot_pid_profile,
+)
 
 
 def get_lib_path(application_pid: int, path: str) -> str:
@@ -564,3 +579,67 @@ def test_java_jattach_async_profiler_log_output(
         )
         # stop
         assert log_records[1].gprofiler_adapter_extra["ap_log"] == ""  # type: ignore
+
+
+@pytest.mark.parametrize(
+    "change_argv0", [pytest.param(True, id="argv0 is java"), pytest.param(False, id="argv0 is not java")]
+)
+def test_java_different_basename(
+    tmp_path: Path,
+    docker_client: DockerClient,
+    application_docker_image: Image,
+    assert_collapsed: AssertInCollapsed,
+    caplog: LogCaptureFixture,
+    change_argv0: bool,
+) -> None:
+    """
+    Tests that we can profile a Java app that runs with non-java "comm", by reading the argv0 instead.
+    """
+    java_notjava_basename = "java-notjava"
+
+    with make_java_profiler(
+        storage_dir=str(tmp_path),
+        duration=1,
+        java_safemode=JAVA_SAFEMODE_ALL,  # explicitly enable, for basename checks
+    ) as profiler:
+        with _application_docker_container(
+            docker_client,
+            application_docker_image,
+            [],
+            [],
+            application_docker_command=[
+                "bash",
+                "-c",
+                f"{'exec -a java ' if change_argv0 else ''}{java_notjava_basename} -jar Fibonacci.jar",
+            ],
+        ) as container:
+            application_pid = container.attrs["State"]["Pid"]
+            profile = snapshot_pid_profile(profiler, application_pid)
+            if change_argv0:
+                # we changed basename - we should run the profiler
+                assert profile.app_metadata is not None
+                assert (
+                    os.path.basename(profile.app_metadata["execfn"])
+                    == os.path.basename(profile.app_metadata["exe"])
+                    == java_notjava_basename
+                )
+                assert_function_in_collapsed(f"{java_notjava_basename};", profile.stacks)
+                assert_collapsed(profile.stacks)
+            else:
+                # we didn't change basename - we should not run the profiler due to a different basename.
+                assert profile.stacks == Counter(
+                    {f"{java_notjava_basename};[Profiling skipped: profiling this JVM is not supported]": 1}
+                )
+                log_records = list(
+                    filter(
+                        lambda r: r.message
+                        == "Non-java basenamed process (cannot get Java version), skipping... (disable"
+                        " --java-safemode=java-extended-version-checks to profile it anyway)",
+                        caplog.records,
+                    )
+                )
+                assert len(log_records) == 1
+                assert (
+                    os.path.basename(log_records[0].gprofiler_adapter_extra["exe"])  # type: ignore
+                    == java_notjava_basename
+                )

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -616,7 +616,7 @@ def test_java_different_basename(
             application_pid = container.attrs["State"]["Pid"]
             profile = snapshot_pid_profile(profiler, application_pid)
             if change_argv0:
-                # we changed basename - we should run the profiler
+                # we changed basename - we should have run the profiler
                 assert profile.app_metadata is not None
                 assert (
                     os.path.basename(profile.app_metadata["execfn"])
@@ -626,7 +626,7 @@ def test_java_different_basename(
                 assert_function_in_collapsed(f"{java_notjava_basename};", profile.stacks)
                 assert_collapsed(profile.stacks)
             else:
-                # we didn't change basename - we should not run the profiler due to a different basename.
+                # we didn't change basename - we should not have run the profiler due to a different basename.
                 assert profile.stacks == Counter(
                     {f"{java_notjava_basename};[Profiling skipped: profiling this JVM is not supported]": 1}
                 )

--- a/tests/test_libpython.py
+++ b/tests/test_libpython.py
@@ -36,8 +36,9 @@ def test_python_select_by_libpython(
     assert_collapsed: AssertInCollapsed,
 ) -> None:
     """
-    Tests that profiling of processes running Python, whose basename(readlink("/proc/pid/exe")) isn't "python".
-    (for example, uwsgi). We expect to select these because they have "libpython" in their "/proc/pid/maps".
+    Tests that profiling of processes running Python, whose basename(readlink("/proc/pid/exe")) isn't "python"
+    (and also their comm isn't "python", for example, uwsgi).
+    We expect to select these because they have "libpython" in their "/proc/pid/maps".
     This test runs a Python named "shmython".
     """
     with PythonProfiler(1000, 1, Event(), str(tmp_path), False, "pyspy", True, None) as profiler:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -162,8 +162,12 @@ def snapshot_one_collapsed(profiler: ProfilerInterface) -> StackToSampleCount:
     return snapshot_one_profile(profiler).stacks
 
 
+def snapshot_pid_profile(profiler: ProfilerInterface, pid: int) -> ProfileData:
+    return profiler.snapshot()[pid]
+
+
 def snapshot_pid_collapsed(profiler: ProfilerInterface, pid: int) -> StackToSampleCount:
-    return profiler.snapshot()[pid].stacks
+    return snapshot_pid_profile(profiler, pid).stacks
 
 
 def make_java_profiler(
@@ -304,6 +308,7 @@ def _application_docker_container(
     application_docker_image: Image,
     application_docker_mounts: List[Mount],
     application_docker_capabilities: List[str],
+    application_docker_command: Optional[List[str]] = None,
 ) -> Container:
     container: Container = docker_client.containers.run(
         application_docker_image,
@@ -311,6 +316,7 @@ def _application_docker_container(
         user="5555:6666",
         mounts=application_docker_mounts,
         cap_add=application_docker_capabilities,
+        command=application_docker_command,
     )
     while container.status != "running":
         if container.status == "exited":


### PR DESCRIPTION
I added a helper `is_process_basename` which checks both the comm & argv[0], then fixed all relevant sites to use it.

**EDIT**: manual tests described ahead, but I also added automatic tests for it.

To test, I applied this diff:
```
diff --git a/tests/containers/java/Dockerfile b/tests/containers/java/Dockerfile
index c2e6a74..e6c802f 100644
--- a/tests/containers/java/Dockerfile
+++ b/tests/containers/java/Dockerfile
@@ -7,5 +7,6 @@ ADD Fibonacci.java /app
 ADD MANIFEST.MF /app
 RUN javac Fibonacci.java
 RUN jar cvmf MANIFEST.MF Fibonacci.jar *.class
+RUN cp `which java` `which java`xxx
 
-CMD ["sh", "-c", "java -jar Fibonacci.jar; sleep 10000"]
+CMD ["bash", "-c", "exec -a java javaxxx -jar Fibonacci.jar; sleep 10000"]
```

Before this branch:
```
[2022-09-06 22:12:39,801] WARNING: gprofiler.profilers.java: Non-java basenamed process (cannot get Java version), skipping... (disable  --java-safemode=java-extended-version-checks to profile it anyway) (pid=1185956, exe=/usr/local/openjdk-8/bin/javaxxx)
```
After - process is profiled fine, and I get stacks like:
```
1;recursing_bell;javaxxx;appid: java: Fibonacci.jar;Fibonacci$1.run()V_[j];java/io/File.list()[Ljava/lang/String|_[j];java/io/UnixFileSystem.list(Ljava/io/File|)[Ljava/lang/String|_[j];[unknown];/lib/x86_64-linux-gnu/libc-2.28.so;entry_SYSCALL_64_after_hwframe_[k];do_syscall_64_[k];syscall_exit_to_user_mode_[k];exit_to_user_mode_prepare_[k];exit_to_user_mode_loop_[k];task_work_run_[k];____fput_[k];__fput_[k];security_file_free_[k];kmem_cache_free_[k];slab_free_freelist_hook.constprop.0_[k] 1
```

Along the way, this fixes at least one usage of `process.exe()` which is problematic (should use `process_exe()`).