### PR TITLE
dotnet: Add _[net] frame suffix to all frames from dotnet-trace

### DIFF
--- a/gprofiler/profilers/dotnet.py
+++ b/gprofiler/profilers/dotnet.py
@@ -57,6 +57,7 @@ class DotnetMetadata(ApplicationMetadata):
 class DotnetProfiler(ProcessProfilerBase):
     RESOURCE_PATH = "dotnet/tools/dotnet-trace"
     _EXTRA_TIMEOUT = 10
+    _DOTNET_FRAME_SUFFIX = "_[net]"
 
     def __init__(
         self,
@@ -121,7 +122,9 @@ class DotnetProfiler(ProcessProfilerBase):
             logger.info(f"Finished profiling process {process.pid} with dotnet")
             comm = process_comm(process)
             return ProfileData(
-                load_speedscope_as_collapsed(local_output_path, self._frequency, comm), appid, app_metadata
+                load_speedscope_as_collapsed(local_output_path, self._frequency, comm, self._DOTNET_FRAME_SUFFIX),
+                appid,
+                app_metadata,
             )
 
     def _select_processes_to_profile(self) -> List[Process]:

--- a/gprofiler/utils/speedscope.py
+++ b/gprofiler/utils/speedscope.py
@@ -23,7 +23,10 @@ def _speedscope_frame_name(speedscope: Dict[str, Any], frame: int) -> str:
 
 
 def load_speedscope_as_collapsed(
-    speedscope_path: str, frequncy_hz: int, add_comm: Optional[str] = None
+    speedscope_path: str,
+    frequncy_hz: int,
+    add_comm: Optional[str] = None,
+    frame_suffix: str = "",
 ) -> StackToSampleCount:
     interval = 1 / frequncy_hz
     interval_ms = interval * 1000
@@ -61,8 +64,8 @@ def load_speedscope_as_collapsed(
                 stacks.append(tuple(stack))
 
         for s in stacks:
-            if add_comm is not None:
-                result_stacks[f"{add_comm};" + ";".join(map(lambda f: _speedscope_frame_name(speedscope, f), s))] += 1
-            else:
-                result_stacks[";".join(map(lambda f: _speedscope_frame_name(speedscope, f), s))] += 1
+            result_stacks[
+                (f"{add_comm};" if add_comm is not None else "")
+                + ";".join(map(lambda f: _speedscope_frame_name(speedscope, f) + frame_suffix, s))
+            ] += 1
     return result_stacks


### PR DESCRIPTION
Here's how it looks:
```
1;loving_kilby;dotnet;Process64 Process(1) (1) Args: _[net];(Non-Activities)_[net];Threads_[net];Thread (1)_[net];Fibonacci!dotnet.Program.Main()_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net];Fibonacci!dotnet.Program.Fibonacci(int32)_[net] 38
```

Will let us identify & colorize dotnet frames in the backend.