### PR TITLE
Add Ansible as an installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ sudo sh -c "setsid ./gprofiler -cu --token=\"<TOKEN>\" --service-name=\"<SERVICE
      ```
 
 ## Running via an Ansible playbook
-Download the [playbook](./deploy/dataproc/gprofiler_initialization_action.sh) and run it this way:
+Download the [playbook](./deploy/ansible/gprofiler_playbook.yml) and run it this way:
 ```
 ansible-playbook -i ... gprofiler_playbook.yml --extra-vars "gprofiler_token='<TOKEN>'" --extra-vars "gprofiler_service='<SERVICE NAME>'"
 ```

--- a/README.md
+++ b/README.md
@@ -326,6 +326,18 @@ sudo sh -c "setsid ./gprofiler -cu --token=\"<TOKEN>\" --service-name=\"<SERVICE
      aws emr create-cluster --name MY-Cluster ... --bootstrap-actions "Path=s3://my-s3-bucket/gprofiler-bootstrap.sh"
      ```
 
+## Running via an Ansible playbook
+Download the [playbook](./deploy/dataproc/gprofiler_initialization_action.sh) and run it this way:
+```
+ansible-playbook -i ... gprofiler_playbook.yml --extra-vars "gprofiler_token='<TOKEN>'" --extra-vars "gprofiler_service='<SERVICE NAME>'"
+```
+
+**Note** - the playbook defaults to `hosts: all`, make sure to modify the pattern to your liking before running.
+
+The playbook defines 2 more variables:
+* `gprofiler_path` - path to download gProfiler to, `/tmp/gprofiler` by default.
+* `gprofiler_args` - additional arguments to pass to gProfiler, empty by default. You can use it to pass, for example, `'--profiling-frequency 15'` to change the frequency.
+
 ## Running from source
 gProfiler requires Python 3.6+ to run.
 

--- a/deploy/ansible/gprofiler_playbook.yml
+++ b/deploy/ansible/gprofiler_playbook.yml
@@ -1,3 +1,7 @@
+#
+# Copyright (c) Granulate. All rights reserved.
+# Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
+#
 ---
 - name: Install gProfiler
   hosts: all

--- a/deploy/ansible/gprofiler_playbook.yml
+++ b/deploy/ansible/gprofiler_playbook.yml
@@ -1,0 +1,29 @@
+---
+- name: Install gProfiler
+  hosts: all
+  vars:
+    gprofiler_path: /tmp/gprofiler
+    # can be overriden to add extra arguments to gProfiler's execution, such as --no-perf.
+    gprofiler_args: ""
+  tasks:
+    - name: Check mandatory variables
+      assert:
+        that:
+          - gprofiler_path is defined
+          - gprofiler_token is defined
+          - gprofiler_service is defined
+          - gprofiler_args is defined
+    - name: Get remote machine architecture
+      shell: uname -m
+      register: machine
+    - name: Download latest gProfiler
+      ansible.builtin.get_url:
+        url: https://github.com/Granulate/gprofiler/releases/latest/download/gprofiler_{{machine.stdout}}
+        dest: "{{gprofiler_path}}"
+        mode: '0755'
+        owner: root
+        group: root
+      become: true
+    - name: Run gProfiler
+      shell: TMPDIR=$(dirname {{gprofiler_path}}) setsid {{gprofiler_path}} -cu --token="{{gprofiler_token | mandatory}}" --service-name="{{gprofiler_service | mandatory}}" {{gprofiler_args}} > /dev/null 2>&1 &
+      become: true


### PR DESCRIPTION
```
$ ansible-playbook -i XXX deploy/ansible/gprofiler_playbook.yml  --key-file ~/.ssh/mykey.pem -u ubuntu --extra-vars "gprofiler_token='MYTOKEN'" --extra-vars "gprofiler_service='MYSERVICE'"

PLAY [Install gProfiler] **********************************************************************************************************************************************************************************

TASK [Gathering Facts] ************************************************************************************************************************************************************************************
ok: [XXX]

TASK [Check mandatory variables] **************************************************************************************************************************************************************************
ok: [XXX] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [Get remote machine architecture] ********************************************************************************************************************************************************************
changed: [XXX]

TASK [Download latest gProfiler] **************************************************************************************************************************************************************************
ok: [XXX]

TASK [Run gProfiler] **************************************************************************************************************************************************************************************
changed: [XXX]

PLAY RECAP ************************************************************************************************************************************************************************************************
XXX              : ok=5    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```