### PR TITLE
tests: Print unexpected result in assert message

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -160,7 +160,7 @@ def assert_function_in_collapsed(function_name: str, collapsed: StackToSampleCou
 
 def snapshot_one_profile(profiler: ProfilerInterface) -> ProfileData:
     result = profiler.snapshot()
-    assert len(result) == 1
+    assert len(result) == 1, result
     return next(iter(result.values()))
 
 


### PR DESCRIPTION
pytest doesn't give enough information here.

This affects flaky tests, for example https://github.com/Granulate/gprofiler/runs/8290755032?check_suite_focus=true