### PR TITLE
Use read_proc_file helper from granulate-utils

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -65,7 +65,7 @@ from gprofiler.utils import (
 )
 from gprofiler.utils.fs import is_rw_exec_dir, safe_copy
 from gprofiler.utils.perf import can_i_use_perf_events
-from gprofiler.utils.process import is_process_basename_matching, process_comm, read_proc_file
+from gprofiler.utils.process import is_process_basename_matching, process_comm, search_proc_maps
 
 logger = get_logger_adapter(__name__)
 
@@ -980,7 +980,7 @@ class JavaProfiler(SpawningProcessProfilerBase):
         return pgrep_maps(DETECTED_JAVA_PROCESSES_REGEX)
 
     def _should_profile_process(self, process: Process) -> bool:
-        return re.search(DETECTED_JAVA_PROCESSES_REGEX, read_proc_file(process, "maps"), re.MULTILINE) is not None
+        return search_proc_maps(process, DETECTED_JAVA_PROCESSES_REGEX) is not None
 
     def start(self) -> None:
         super().start()

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -258,8 +258,9 @@ class PySpyProfiler(SpawningProcessProfilerBase):
         return filtered_procs
 
     def _should_profile_process(self, process: Process) -> bool:
-        return (search_proc_maps(process, DETECTED_PYTHON_PROCESSES_REGEX) is not None
-                and not self._should_skip_process(process))
+        return search_proc_maps(process, DETECTED_PYTHON_PROCESSES_REGEX) is not None and not self._should_skip_process(
+            process
+        )
 
     def _should_skip_process(self, process: Process) -> bool:
         if process.pid == os.getpid():

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -51,7 +51,7 @@ from gprofiler.utils import (
     wait_event,
     wait_for_file_by_prefix,
 )
-from gprofiler.utils.process import is_process_basename_matching, process_comm, read_proc_file
+from gprofiler.utils.process import is_process_basename_matching, process_comm, search_proc_maps
 
 logger = get_logger_adapter(__name__)
 
@@ -258,8 +258,8 @@ class PySpyProfiler(SpawningProcessProfilerBase):
         return filtered_procs
 
     def _should_profile_process(self, process: Process) -> bool:
-        match = re.search(DETECTED_PYTHON_PROCESSES_REGEX, read_proc_file(process, "maps"), re.MULTILINE) is not None
-        return match and not self._should_skip_process(process)
+        return (search_proc_maps(process, DETECTED_PYTHON_PROCESSES_REGEX) is not None
+                and not self._should_skip_process(process))
 
     def _should_skip_process(self, process: Process) -> bool:
         if process.pid == os.getpid():

--- a/gprofiler/profilers/ruby.py
+++ b/gprofiler/profilers/ruby.py
@@ -5,7 +5,6 @@
 
 import functools
 import os
-import re
 import signal
 from pathlib import Path
 from threading import Event
@@ -23,7 +22,7 @@ from gprofiler.metadata.application_metadata import ApplicationMetadata
 from gprofiler.profilers.profiler_base import SpawningProcessProfilerBase
 from gprofiler.profilers.registry import register_profiler
 from gprofiler.utils import pgrep_maps, random_prefix, removed_path, resource_path, run_process
-from gprofiler.utils.process import is_process_basename_matching, process_comm, read_proc_file
+from gprofiler.utils.process import is_process_basename_matching, process_comm, search_proc_maps
 
 logger = get_logger_adapter(__name__)
 
@@ -128,4 +127,4 @@ class RbSpyProfiler(SpawningProcessProfilerBase):
         return pgrep_maps(self.DETECTED_RUBY_PROCESSES_REGEX)
 
     def _should_profile_process(self, process: Process) -> bool:
-        return re.search(self.DETECTED_RUBY_PROCESSES_REGEX, read_proc_file(process, "maps"), re.MULTILINE) is not None
+        return search_proc_maps(process, self.DETECTED_RUBY_PROCESSES_REGEX) is not None

--- a/gprofiler/utils/process.py
+++ b/gprofiler/utils/process.py
@@ -6,13 +6,14 @@
 import os
 import re
 from functools import lru_cache
+from typing import Match, Optional
 
 from granulate_utils.linux.process import process_exe, read_proc_file
 from psutil import Process
 
 
-def search_proc_maps(process: Process, pattern: str):
-    return re.search(pattern, read_proc_file(process, 'maps').decode(), re.MULTILINE)
+def search_proc_maps(process: Process, pattern: str) -> Optional[Match[str]]:
+    return re.search(pattern, read_proc_file(process, "maps").decode(), re.MULTILINE)
 
 
 def process_comm(process: Process) -> str:

--- a/gprofiler/utils/process.py
+++ b/gprofiler/utils/process.py
@@ -6,30 +6,17 @@
 import os
 import re
 from functools import lru_cache
-from pathlib import Path
 
-from granulate_utils.linux.process import is_process_running, process_exe
-from psutil import NoSuchProcess, Process
-
-
-def ensure_running(process: Process) -> None:
-    if not is_process_running(process, allow_zombie=True):
-        raise NoSuchProcess(process.pid)
+from granulate_utils.linux.process import process_exe, read_proc_file
+from psutil import Process
 
 
-def read_proc_file(process: Process, file: str) -> str:
-    try:
-        data = Path(f"/proc/{process.pid}/{file}").read_text()
-    except FileNotFoundError as e:
-        raise NoSuchProcess(process.pid) from e
-    else:
-        # ensures we read the right file (i.e PID was not reused)
-        ensure_running(process)
-    return data
+def search_proc_maps(process: Process, pattern: str):
+    return re.search(pattern, read_proc_file(process, 'maps').decode(), re.MULTILINE)
 
 
 def process_comm(process: Process) -> str:
-    status = read_proc_file(process, "status")
+    status = read_proc_file(process, "status").decode()
     name_line = status.splitlines()[0]
     assert name_line.startswith("Name:\t")
     return name_line.split("\t", 1)[1]


### PR DESCRIPTION
Java, Python, and Ruby profilers rely on searching /proc/PID/maps the same way, so refactored that to a function and replaced read_proc_file with the function from granulate-utils.