### PR TITLE
Log HTTP proxy upon connection error

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ gProfiler uses the Python `requests` package, which works with standard HTTP pro
 If running gProfiler as an executable and using `sudo`, make sure to run `sudo -E` if you have the environment variable defined (otherwise, `sudo` will forget it). Alternatively, you can run `sudo https_proxy=my-proxy /path/to/gprofiler ...`.
 If running gProfiler as a Docker container, make sure to add `-e https_proxy=my-proxy` to the `docker run` command line (the spawned container does not inherit your set of environment variables, you have to pass it manually).
 
+If you still get connection errors, make sure the proxy is indeed used by the profiler - in the `Failed to connect to server` error message you'll see the proxy used by the profiler (under `Proxy used:`).
+
 ### Sending logs to server
 **By default, gProfiler sends logs to Granulate Performance Studio** (when using `--upload-results`/`-u` flag)
 This behavior can be disabled by passing `--dont-send-logs` or the setting environment variable `GPROFILER_DONT_SEND_LOGS=1`.

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -801,10 +801,12 @@ def main() -> None:
             logger.error(f"Server error: {e}")
             sys.exit(1)
         except RequestException as e:
+            proxy = get_https_proxy()
+            proxy_str = repr(proxy) if proxy is not None else "none"
             logger.error(
                 "Failed to connect to server. It might be blocked by your security rules / firewall,"
                 " or you might require a proxy to access it from your environment?"
-                f" Proxy used: {repr(get_https_proxy()) or 'none'}. Error: {e}"
+                f" Proxy used: {proxy_str}. Error: {e}"
             )
             sys.exit(1)
 

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -53,6 +53,7 @@ from gprofiler.utils import (
     resource_path,
     run_process,
 )
+from gprofiler.utils.proxy import get_https_proxy
 
 logger: logging.LoggerAdapter
 
@@ -802,7 +803,8 @@ def main() -> None:
         except RequestException as e:
             logger.error(
                 "Failed to connect to server. It might be blocked by your security rules / firewall,"
-                f" or you might require a proxy to access it from your environment? {e}"
+                " or you might require a proxy to access it from your environment?"
+                f" Proxy used: {get_https_proxy() or 'none'!r}. Error: {e}"
             )
             sys.exit(1)
 

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -804,7 +804,7 @@ def main() -> None:
             logger.error(
                 "Failed to connect to server. It might be blocked by your security rules / firewall,"
                 " or you might require a proxy to access it from your environment?"
-                f" Proxy used: {get_https_proxy() or 'none'!r}. Error: {e}"
+                f" Proxy used: {repr(get_https_proxy()) or 'none'}. Error: {e}"
             )
             sys.exit(1)
 

--- a/gprofiler/utils/proxy.py
+++ b/gprofiler/utils/proxy.py
@@ -1,0 +1,14 @@
+#
+# Copyright (c) Granulate. All rights reserved.
+# Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
+#
+
+import urllib.request
+from typing import Optional, cast
+
+
+def get_https_proxy() -> Optional[str]:
+    """
+    We follow what requests uses.
+    """
+    return cast(Optional[str], urllib.request.getproxies_environment().get("https"))

--- a/gprofiler/utils/proxy.py
+++ b/gprofiler/utils/proxy.py
@@ -3,12 +3,12 @@
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
 
-import urllib.request
 from typing import Optional, cast
+from urllib.request import getproxies_environment  # type: ignore  # incorrectly yells at it
 
 
 def get_https_proxy() -> Optional[str]:
     """
     We follow what requests uses.
     """
-    return cast(Optional[str], urllib.request.getproxies_environment().get("https"))
+    return cast(Optional[str], getproxies_environment().get("https"))


### PR DESCRIPTION
Continues https://github.com/Granulate/gprofiler/pull/369 to provide more information for the users upon a connection error.

We use the same logic as `urllib` uses to extract the proxy.