### PR TITLE
tests: Turn command_line fixture lazy

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,9 +6,9 @@ import os
 import stat
 import subprocess
 from contextlib import _GeneratorContextManager, contextmanager
-from functools import partial
+from functools import lru_cache, partial
 from pathlib import Path
-from typing import Any, Callable, Dict, Generator, Iterable, Iterator, List, Mapping, Optional, cast
+from typing import Any, Callable, Dict, Generator, Iterable, Iterator, List, Mapping, Optional, Tuple, cast
 
 import docker
 import pytest
@@ -17,7 +17,7 @@ from docker import DockerClient
 from docker.models.containers import Container
 from docker.models.images import Image
 from psutil import Process
-from pytest import FixtureRequest, fixture
+from pytest import FixtureRequest, TempPathFactory, fixture
 
 from gprofiler.gprofiler_types import StackToSampleCount
 from gprofiler.metadata.application_identifiers import get_java_app_id, get_python_app_id, set_enrichment_options
@@ -64,24 +64,29 @@ def in_container(request: FixtureRequest) -> bool:
 
 
 @fixture
-def java_args() -> List[str]:
-    return []
+def java_args() -> Tuple[str]:
+    return cast(Tuple[str], ())
 
 
-@fixture
-def java_command_line(tmp_path: Path, java_args: List[str]) -> List[str]:
-    class_path = tmp_path / "java"
+@fixture(scope="session")
+def artifacts_dir(tmp_path_factory: TempPathFactory) -> Path:
+    return tmp_path_factory.mktemp("artifacts")
+
+
+@lru_cache(maxsize=None)
+def java_command_line(path: Path, java_args: Tuple[str]) -> List[str]:
+    class_path = path / "java"
     class_path.mkdir()
     # make all directories readable & executable by all.
     # Java fails with permissions errors: "Error: Could not find or load main class Fibonacci"
     chmod_path_parts(class_path, stat.S_IRGRP | stat.S_IROTH | stat.S_IXGRP | stat.S_IXOTH)
     subprocess.run(["javac", CONTAINERS_DIRECTORY / "java/Fibonacci.java", "-d", class_path])
-    return ["java"] + java_args + ["-cp", str(class_path), "Fibonacci"]
+    return ["java"] + list(java_args) + ["-cp", str(class_path), "Fibonacci"]
 
 
-@fixture
-def dotnet_command_line(tmp_path: Path) -> List[str]:
-    class_path = tmp_path / "dotnet" / "Fibonacci"
+@lru_cache(maxsize=None)
+def dotnet_command_line(path: Path) -> List[str]:
+    class_path = path / "dotnet" / "Fibonacci"
     class_path.mkdir(parents=True)
     chmod_path_parts(class_path, stat.S_IRGRP | stat.S_IROTH | stat.S_IXGRP | stat.S_IXOTH)
     subprocess.run(["cp", str(CONTAINERS_DIRECTORY / "dotnet/Fibonacci.cs"), class_path])
@@ -104,27 +109,32 @@ def dotnet_command_line(tmp_path: Path) -> List[str]:
 
 
 @fixture
-def command_line(runtime: str, java_command_line: List[str], dotnet_command_line: List[str]) -> List[str]:
-    # these do not have non-container application - so it will result in an error if the command
-    # line is used.
+def command_line(runtime: str, artifacts_dir: Path, java_args: Tuple[str]) -> List[str]:
     if runtime.startswith("native"):
+        # these do not have non-container application - so it will result in an error if the command
+        # line is used.
         return ["/bin/false"]
-
-    return {
-        "java": java_command_line,
+    elif runtime == "java":
+        return java_command_line(artifacts_dir, java_args)
+    elif runtime == "python":
         # note: here we run "python /path/to/lister.py" while in the container test we have
         # "CMD /path/to/lister.py", to test processes with non-python /proc/pid/comm
-        "python": ["python3", str(CONTAINERS_DIRECTORY / "python/lister.py")],
-        "php": ["php", str(CONTAINERS_DIRECTORY / "php/fibonacci.php")],
-        "ruby": ["ruby", str(CONTAINERS_DIRECTORY / "ruby/fibonacci.rb")],
-        "dotnet": dotnet_command_line,
-        "nodejs": [
+        return ["python3", str(CONTAINERS_DIRECTORY / "python/lister.py")]
+    elif runtime == "php":
+        return ["php", str(CONTAINERS_DIRECTORY / "php/fibonacci.php")]
+    elif runtime == "ruby":
+        return ["ruby", str(CONTAINERS_DIRECTORY / "ruby/fibonacci.rb")]
+    elif runtime == "dotnet":
+        return dotnet_command_line(artifacts_dir)
+    elif runtime == "nodejs":
+        return [
             "node",
             "--perf-prof",
             "--interpreted-frames-native-stack",
             str(CONTAINERS_DIRECTORY / "nodejs/fibonacci.js"),
-        ],
-    }[runtime]
+        ]
+    else:
+        raise NotImplementedError(runtime)
 
 
 @fixture

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -219,7 +219,7 @@ def test_java_safemode_build_number_check(
     "in_container,java_args,check_app_exited",
     [
         (False, [], False),  # default
-        (False, ["-XX:ErrorFile=/tmp/my_custom_error_file.log"], False),  # custom error file
+        (False, ("-XX:ErrorFile=/tmp/my_custom_error_file.log",), False),  # custom error file
         (True, [], False),  # containerized (other params are ignored)
     ],
 )

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -218,9 +218,9 @@ def test_java_safemode_build_number_check(
 @pytest.mark.parametrize(
     "in_container,java_args,check_app_exited",
     [
-        (False, [], False),  # default
+        (False, (), False),  # default
         (False, ("-XX:ErrorFile=/tmp/my_custom_error_file.log",), False),  # custom error file
-        (True, [], False),  # containerized (other params are ignored)
+        (True, (), False),  # containerized (other params are ignored)
     ],
 )
 def test_hotspot_error_file(

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -84,13 +84,16 @@ class AsyncProfiledProcessForTests(AsyncProfiledProcess):
 
 
 def test_async_profiler_already_running(
-    application_pid: int, assert_collapsed: AssertInCollapsed, tmp_path: Path, caplog: LogCaptureFixture
+    application_pid: int,
+    assert_collapsed: AssertInCollapsed,
+    tmp_path_world_accessible: Path,
+    caplog: LogCaptureFixture,
 ) -> None:
     """
     Test we're able to restart async-profiler in case it's already running in the process and get results normally.
     """
     caplog.set_level(logging.INFO)
-    with make_java_profiler(storage_dir=str(tmp_path)) as profiler:
+    with make_java_profiler(storage_dir=str(tmp_path_world_accessible)) as profiler:
         process = profiler._select_processes_to_profile()[0]
 
         with AsyncProfiledProcess(
@@ -287,14 +290,17 @@ def test_already_loaded_async_profiler_profiling_failure(
 @pytest.mark.parametrize("in_container", [False])
 @pytest.mark.parametrize("check_app_exited", [False])  # we're killing it, the exit check will raise.
 def test_async_profiler_output_written_upon_jvm_exit(
-    tmp_path: Path, application_pid: int, assert_collapsed: AssertInCollapsed, caplog: LogCaptureFixture
+    tmp_path_world_accessible: Path,
+    application_pid: int,
+    assert_collapsed: AssertInCollapsed,
+    caplog: LogCaptureFixture,
 ) -> None:
     """
     Make sure async-profiler writes output upon process exit (and we manage to read it correctly)
     """
     caplog.set_level(logging.DEBUG)
 
-    with make_java_profiler(storage_dir=str(tmp_path), duration=10) as profiler:
+    with make_java_profiler(storage_dir=str(tmp_path_world_accessible), duration=10) as profiler:
 
         def delayed_kill() -> None:
             time.sleep(3)
@@ -311,7 +317,10 @@ def test_async_profiler_output_written_upon_jvm_exit(
 # test only once
 @pytest.mark.parametrize("in_container", [False])
 def test_async_profiler_stops_after_given_timeout(
-    tmp_path: Path, application_pid: int, assert_collapsed: AssertInCollapsed, caplog: LogCaptureFixture
+    tmp_path_world_accessible: Path,
+    application_pid: int,
+    assert_collapsed: AssertInCollapsed,
+    caplog: LogCaptureFixture,
 ) -> None:
     caplog.set_level(logging.DEBUG)
 
@@ -319,7 +328,7 @@ def test_async_profiler_stops_after_given_timeout(
     timeout_s = 5
     with AsyncProfiledProcessForTests(
         process=process,
-        storage_dir=str(tmp_path),
+        storage_dir=str(tmp_path_world_accessible),
         stop_event=Event(),
         buildids=False,
         mode="itimer",
@@ -410,7 +419,7 @@ def test_java_async_profiler_buildids(
     ],
 )
 def test_java_noexec_dirs(
-    tmp_path: Path,
+    tmp_path_world_accessible: Path,
     application_pid: int,
     assert_collapsed: AssertInCollapsed,
     caplog: LogCaptureFixture,
@@ -434,7 +443,7 @@ def test_java_noexec_dirs(
         # mount because /tmp is not necessarily tmpfs; and that'll hide all current files in /tmp).
         monkeypatch.setattr(gprofiler.profilers.java, "POSSIBLE_AP_DIRS", (noexec_tmp_dir, run_dir))
 
-    with make_java_profiler(storage_dir=str(tmp_path)) as profiler:
+    with make_java_profiler(storage_dir=str(tmp_path_world_accessible)) as profiler:
         assert_collapsed(snapshot_one_collapsed(profiler))
 
     # should use this path instead of /tmp/gprofiler_tmp/...

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -37,14 +37,14 @@ from tests.utils import (
 
 @pytest.mark.parametrize("runtime", ["java"])
 def test_java_from_host(
-    tmp_path: Path,
+    tmp_path_world_accessible: Path,
     application_pid: int,
     assert_app_id: Callable,
     assert_collapsed: AssertInCollapsed,
 ) -> None:
     with make_java_profiler(
         frequency=99,
-        storage_dir=str(tmp_path),
+        storage_dir=str(tmp_path_world_accessible),
         java_async_profiler_mode="itimer",
     ) as profiler:
         _ = assert_app_id  # Required for mypy unused argument warning

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -144,8 +144,12 @@ def chmod_path_parts(path: Path, add_mode: int) -> None:
     """
     Adds 'add_mode' to all parts in 'path'.
     """
+    assert os.path.isabs(path), f"absolute path required: {path}"
     for i in range(1, len(path.parts)):
-        subpath = os.path.join(*path.parts[:i])
+        subpath = os.path.join(*path.parts[: i + 1])
+        if subpath == "/":
+            # skip chmodding /
+            continue
         os.chmod(subpath, os.stat(subpath).st_mode | add_mode)
 
 


### PR DESCRIPTION
dotnet_command_line & java_command_line are 2 fixtures that require java/dotnet to be installed, and if they're not installed, the fixture fails. By being eager - this fails the entire test suite. Now they're lazy so the lack of java/dotnet will fail only relevant tests.

Additionally, I made the fixture cached - to avoid re-compilation of the artifacts. This will be improved in the future by avoiding the build at all and copying the artifacts from the matching container.

Related: #481 