### PR TITLE
scripts: build_x86_64_container.sh: Tag image to the name expected by tests

### DIFF
--- a/.github/workflows/build-container-and-test.yml
+++ b/.github/workflows/build-container-and-test.yml
@@ -42,7 +42,7 @@ jobs:
     # the tests need the gprofiler image built (from Dockerfile). I run it separately here, because "docker build" prints the build logs
     # more nicely. the tests will then be able to use the built image.
     - name: Build gProfiler image
-      run: ./scripts/build_x86_64_container.sh -t gprofiler
+      run: ./scripts/build_x86_64_container.sh
 
     - name: Export gProfiler image
       run: mkdir -p output && docker image save gprofiler > output/gprofiler.img

--- a/scripts/build_x86_64_container.sh
+++ b/scripts/build_x86_64_container.sh
@@ -5,4 +5,4 @@
 #
 set -euo pipefail
 
-DOCKER_BUILDKIT=1 docker build . "$@"
+DOCKER_BUILDKIT=1 docker build . -t gprofiler "$@"


### PR DESCRIPTION
This is done by default now, to avoid confusion when running tests. Instead of requiring the user to pass this manually.

Closes: #492
