### PR TITLE
lint: Upgrade flake8

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 pytest==6.2.4
-flake8==3.9.2
+flake8==5.0.4
 black==22.3.0
 mypy==0.942
 isort==5.8.0


### PR DESCRIPTION
## Description

Trying to solve https://github.com/Granulate/gprofiler/actions/runs/3173626903/jobs/5220214768.

I searched online for the error and got to this one: https://stackoverflow.com/a/73932581/ which matches what I suggested [here](https://github.com/Granulate/gprofiler/pull/517#issuecomment-1270023442). By upgrading flake8 I now see in its downloaded dependencies that it adds the necessary constraint: `Collecting importlib-metadata<4.3,>=1.1.0`.
