### PR TITLE
Upgrade libunwind to latest stable version (v1.5.0 -> v1.6.2)

### DIFF
--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -194,6 +194,7 @@ COPY ./scripts/libunwind_build.sh .
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
         exit 0; \
     fi && \
+    source scl_source enable devtoolset-8 && \
     ./libunwind_build.sh
 
 COPY ./scripts/pyperf_build.sh .

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -191,6 +191,7 @@ RUN if [ "$(uname -m)" = "aarch64" ]; \
     yum clean all
 
 COPY ./scripts/libunwind_build.sh .
+# hadolint ignore=SC1091
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
         exit 0; \
     fi && \

--- a/scripts/libunwind_build.sh
+++ b/scripts/libunwind_build.sh
@@ -5,12 +5,9 @@
 #
 set -euo pipefail
 
-curl -L https://download.savannah.nongnu.org/releases/libunwind/libunwind-1.5.0.tar.gz -o libunwind-1.5.0.tar.gz
-tar -xf libunwind-1.5.0.tar.gz
-# Add containers support in libunwind
-curl https://github.com/libunwind/libunwind/commit/831459ee961e7d673bbd83e40d0823227c66db33.patch | sed s/unw_ltoa/ltoa/g > libunwind-container-support.patch
-pushd libunwind-1.5.0
-patch -p1 < ../libunwind-container-support.patch
+curl -L https://download.savannah.nongnu.org/releases/libunwind/libunwind-1.6.2.tar.gz -o libunwind-1.6.2.tar.gz
+tar -xf libunwind-1.6.2.tar.gz
+pushd libunwind-1.6.2
 
 if [ "$(uname -m)" = "aarch64" ]; then
     # higher value for make -j kills the GH runner (build gets OOM)
@@ -21,5 +18,5 @@ fi
 
 ./configure --prefix=/usr --disable-tests --disable-documentation && make install -j "$nproc"
 popd
-rm -r libunwind-1.5.0
-rm libunwind-1.5.0.tar.gz
+rm -r libunwind-1.6.2
+rm libunwind-1.6.2.tar.gz

--- a/scripts/prepare_machine-unknown-linux-musl.sh
+++ b/scripts/prepare_machine-unknown-linux-musl.sh
@@ -21,15 +21,15 @@ apt-get update && apt-get install -y musl-dev musl-tools
 
 mkdir builds && cd builds
 
-wget https://github.com/libunwind/libunwind/releases/download/v1.5/libunwind-1.5.0.tar.gz
-tar -xf libunwind-1.5.0.tar.gz
-pushd libunwind-1.5.0
+wget https://github.com/libunwind/libunwind/releases/download/v1.6.2/libunwind-1.6.2.tar.gz
+tar -xf libunwind-1.6.2.tar.gz
+pushd libunwind-1.6.2
 CC=musl-gcc ./configure --disable-minidebuginfo --enable-ptrace --disable-tests --disable-documentation
 make
 make install
 popd
-rm -r libunwind-1.5.0
-rm libunwind-1.5.0.tar.gz
+rm -r libunwind-1.6.2
+rm libunwind-1.6.2.tar.gz
 
 ZLIB_VERSION=1.2.12
 ZLIB_FILE="zlib-$ZLIB_VERSION.tar.xz"


### PR DESCRIPTION
Switch to libunwind-1.6.2

## Description
 - Upgraded libunwind-1.5.0 (Nov 2020) to latest stable libunwind-1.6.2 (Dec, 2021)
    - Replaced libunwind-1.5.0 with libunwind-1.6.2
     - Removed patching with 831459ee96 commit due to the commit is already included in v1.6.2. 
     - Enabled devtools-8 to use gcc 8.3.1 in Centos GProfiler Builder

## Related Issue
None

## Motivation and Context
To operate on the latest stable libunwind release 

## How Has This Been Tested?
 - Successful `./scripts/build_x86_64_container.sh` execution
 - Successful `./scripts/build_x86_64_executable.sh` execution
 - Shall be checked in CI pipeline. Please trigger testing suite


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [N/A]  I have updated the relevant documentation. 
- [N/A] I have added tests for new logic. 
