### PR TITLE
Increase duration of gprofiler container in test_from_container_spawned_process test

### DIFF
--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -203,7 +203,7 @@ def test_from_container_spawned_process(
     profiler_flags: List[str],
     application_factory: Callable[[], _GeneratorContextManager],
 ) -> None:
-    profiler_flags.extend(["-d", "10", "--profile-spawned-processes"])
+    profiler_flags.extend(["-d", "30", "--profile-spawned-processes"])
     container = start_gprofiler_in_container_for_one_session(
         docker_client,
         gprofiler_docker_image,


### PR DESCRIPTION
## Description
Increasing duration of gprofiler container should avoid container stopping before application fibonacci starts.

## Related Issue
https://github.com/Granulate/gprofiler/issues/513

## How Has This Been Tested?
I added artificial delay to `_application_process` function by using `time.wait(10)` and then I ran the test_sanity.py.
