### PR TITLE
Avoid using const multiple times for one variable in nodejs profiler

### DIFF
--- a/gprofiler/profilers/node.py
+++ b/gprofiler/profilers/node.py
@@ -145,7 +145,7 @@ def _change_dso_state(sock: WebSocket, module_path: str, action: str) -> None:
 
 
 def _validate_ns_node(sock: WebSocket, expected_ns_link_name: str) -> None:
-    command = 'const fs = process.mainModule.require("fs"); fs.readlinkSync("/proc/self/ns/pid")'
+    command = 'process.mainModule.require("fs").readlinkSync("/proc/self/ns/pid")'
     actual_ns_link_name = cast(str, _execute_js_command(sock, command))
     assert (
         actual_ns_link_name == expected_ns_link_name


### PR DESCRIPTION
## Description
Instead of assigning `process.mainModule.require("fs")` to a const, now we call `readlinkSync("/proc/self/ns/pid")` directly.

## Motivation and Context
This PR should fix problems with: 
`gprofiler.profilers.node: Could not create debug symbols for pid Reason: SyntaxError: Identifier 'fs' has already been declared` 
`Traceback (most recent call last):
  File "gprofiler/profilers/node.py", line 129, in _execute_js_command
KeyError: 'value'`
