### PR TITLE
deploy: ecs: Update task definition resources

### DIFF
--- a/deploy/ecs/gprofiler_task_definition.json
+++ b/deploy/ecs/gprofiler_task_definition.json
@@ -6,8 +6,9 @@
         {
             "name": "granulate-gprofiler",
             "image": "index.docker.io/granulate/gprofiler:latest",
-            "memory": "1000",
-            "cpu": "500",
+            "memory": "1024",
+            "memoryReservation": "256",
+            "cpu": "128",
             "essential": true,
             "command": [
                 "-cu",
@@ -18,8 +19,6 @@
             "privileged": true
         }
     ],
-    "cpu": "500",
-    "memory": "1000",
     "networkMode": null,
     "pidMode": "host",
     "ipcMode": "host",

--- a/deploy/ecs/gprofiler_task_definition.json
+++ b/deploy/ecs/gprofiler_task_definition.json
@@ -8,7 +8,7 @@
             "image": "index.docker.io/granulate/gprofiler:latest",
             "memory": "1024",
             "memoryReservation": "256",
-            "cpu": "128",
+            "cpu": "100",
             "essential": true,
             "command": [
                 "-cu",


### PR DESCRIPTION
After reading more on ECS task definitions, I understand the meaning of the values better.
* `cpu` is like k8s requests
* `memory` is like k8s limit
* `memoryReservation` is like k8s requests
* No need to specify both at task defintiion level and container level - I removed the task definition level.

The new values match the values we use for the k8s DaemonSet.

Some references:
* https://aws.amazon.com/blogs/containers/how-amazon-ecs-manages-cpu-and-memory-resources/
* https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definition_limits