### PR TITLE
Update perf version to v6.0g1

### DIFF
--- a/scripts/perf_build.sh
+++ b/scripts/perf_build.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # downloading the zip because the git is very large (this is also very large, but still smaller)
-curl -SL https://codeload.github.com/Granulate/linux/zip/37e33e68d0a02f31f46e089d4a33d9877ed79768 -o linux.zip
+curl -SL https://codeload.github.com/Granulate/linux/zip/fb51366232618f6f7bb9f7f1b36ddab79b7bd01c -o linux.zip
 unzip -qq linux.zip
 rm linux.zip
 cd linux-*/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update our perf version to include the latest version of the linux sources. This should resolve #493 thanks to the fix in https://github.com/Granulate/linux/commit/363afa3aef24f5e08df6a539f5dc3aae4cddcc1a

## Related Issue
<!--- If there's an issue related, please link it here -->
<!--- If suggesting a new feature or a medium/big change, please discuss it in an issue first. -->
<!--- For small changes, it's okay to open a PR immediately. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What does it improve? -->
This was mainly done in order to fix #493 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your changes are tested by the CI, you can just write that.-->
I ran a small program locally which reproduces the `[unknown]` frames in the graph by spawning threads until the tid becomes large enough to be alphabetically smaller (for example "100" < "70"). This reproduces the issue which is just incorrect thread initialization order in perf script. I then verified that with the mentioned fix the issue does not reproduce.

## Screenshots
<!--- (if appropriate) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
