### PR TITLE
java: Add app metadata in gProfiler log for profile-api-version v1

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -56,6 +56,7 @@ from gprofiler.kernel_messages import get_kernel_messages_provider
 from gprofiler.log import get_logger_adapter
 from gprofiler.metadata import application_identifiers
 from gprofiler.metadata.application_metadata import ApplicationMetadata
+from gprofiler.metadata.base_application_identifier import _ApplicationIdentifier
 from gprofiler.profilers.profiler_base import SpawningProcessProfilerBase
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
 from gprofiler.utils import (
@@ -898,6 +899,14 @@ class JavaProfiler(SpawningProcessProfilerBase):
         logger.info(f"Profiling{' spawned' if spawned else ''} process {process.pid} with async-profiler")
         app_metadata = self._metadata.get_metadata(process)
         appid = application_identifiers.get_java_app_id(process, self._collect_spark_app_name)
+
+        if (
+            _ApplicationIdentifier.enrichment_options is not None
+            and _ApplicationIdentifier.enrichment_options.profile_api_version == "v1"
+        ):
+            execfn = (app_metadata or {}).get("execfn")
+            logger.info("Process paths", pid=process.pid, execfn=execfn, exe=exe)
+            logger.info("Process maps", pid=process.pid, maps=Path(f"/proc/{process.pid}/maps").read_text())
 
         with AsyncProfiledProcess(
             process,


### PR DESCRIPTION
This data is not included when running the profiler in protocol v1, and we want it to, so for now the logs are a solution.