### PR TITLE
Fix flaky NodeJS tests

### DIFF
--- a/gprofiler/profilers/node.py
+++ b/gprofiler/profilers/node.py
@@ -159,7 +159,7 @@ def _validate_pid(expected_pid: int, sock: WebSocket) -> None:
 
 def create_debugger_socket(nspid: int, ns_link_name: str) -> WebSocket:
     debugger_url = _get_debugger_url()
-    sock = create_connection(debugger_url)
+    sock = create_connection(url=debugger_url, timeout=15.0)
     sock.settimeout(10)
     _validate_ns_node(sock, ns_link_name)
     _validate_pid(nspid, sock)

--- a/gprofiler/profilers/node.py
+++ b/gprofiler/profilers/node.py
@@ -10,6 +10,7 @@ import stat
 from functools import lru_cache
 from pathlib import Path
 from threading import Event
+from time import sleep
 from typing import Any, Dict, List, cast
 
 import psutil
@@ -61,6 +62,7 @@ def _get_dest_inside_container(musl: bool, node_version: str) -> str:
 def _start_debugger(pid: int) -> None:
     # for windows: in shell node -e "process._debugProcess(PID)"
     os.kill(pid, signal.SIGUSR1)
+    sleep(2)
 
 
 @retry(NodeDebuggerUrlNotFound, 5, 1)

--- a/gprofiler/profilers/node.py
+++ b/gprofiler/profilers/node.py
@@ -10,7 +10,6 @@ import stat
 from functools import lru_cache
 from pathlib import Path
 from threading import Event
-from time import sleep
 from typing import Any, Dict, List, cast
 
 import psutil
@@ -62,10 +61,10 @@ def _get_dest_inside_container(musl: bool, node_version: str) -> str:
 def _start_debugger(pid: int) -> None:
     # for windows: in shell node -e "process._debugProcess(PID)"
     os.kill(pid, signal.SIGUSR1)
-    sleep(2)
 
 
 @retry(NodeDebuggerUrlNotFound, 5, 1)
+@retry(requests.exceptions.ConnectionError, 5, 1)
 def _get_debugger_url() -> str:
     # when killing process with SIGUSR1 it will open new debugger session on port 9229,
     # so it will always the same. When another debugger is opened in same NS it will not open new one.

--- a/tests/containers/nodejs/fibonacci.js
+++ b/tests/containers/nodejs/fibonacci.js
@@ -6,6 +6,8 @@ function fibonacci(n) {
     return n <= 1 ? n : fibonacci(n - 1) + fibonacci(n - 2);
 }
 
+const {execSync} = require('child_process');
 while (true) {
     fibonacci(30);
+    execSync('sleep 0.01');
 }


### PR DESCRIPTION
## Description
This PR:
- increases timeout to creating connection with debugger socket in NodeJS profiler.
- adds sleep in fibonacci.js application to lower CPU usage

## Related Issue
https://github.com/Granulate/gprofiler/issues/538

## Motivation and Context
NodeJS Tests are flaky. 
