### PR TITLE
Fix using attach_maps on NodeJS 14+

### DIFF
--- a/gprofiler/profilers/node.py
+++ b/gprofiler/profilers/node.py
@@ -39,7 +39,7 @@ class NodeDebuggerProcessUndefined(Exception):
     pass
 
 
-class ExpectedResult():
+class ExpectedResult:
     STRING = 1
     INTEGER = 2
     BOOLEAN = 3

--- a/gprofiler/profilers/node.py
+++ b/gprofiler/profilers/node.py
@@ -162,7 +162,6 @@ def _change_dso_state(sock: WebSocket, module_path: str, action: str) -> None:
     _evaluate_js_command(sock, command, ExpectedResult.BOOLEAN)
 
 
-@retry(NodeDebuggerProcessUndefined, 5, 0.5)
 def _close_debugger(sock: WebSocket) -> None:
     command = "process._debugEnd()"
     _evaluate_js_command(sock, command, ExpectedResult.NONE)

--- a/gprofiler/profilers/node.py
+++ b/gprofiler/profilers/node.py
@@ -10,7 +10,7 @@ import stat
 from functools import lru_cache
 from pathlib import Path
 from threading import Event
-from typing import Any, Dict, List, cast
+from typing import Any, List, cast
 
 import psutil
 import requests

--- a/gprofiler/profilers/node.py
+++ b/gprofiler/profilers/node.py
@@ -117,7 +117,6 @@ def _execute_js_command(sock: WebSocket, command: str) -> Any:
         "method": "Runtime.evaluate",
         "params": {
             "expression": command,
-            "replMode": True,
         },
     }
     sock.send(json.dumps(cdp_request))
@@ -156,6 +155,7 @@ def _close_debugger(sock: WebSocket) -> None:
     }
     sock.send(json.dumps(cdp_request))
     sock.recv()
+    sock.close()
 
 
 def _validate_ns_node(sock: WebSocket, expected_ns_link_name: str) -> None:

--- a/gprofiler/profilers/node.py
+++ b/gprofiler/profilers/node.py
@@ -107,7 +107,7 @@ def _get_debugger_url() -> str:
 
 
 @retry(NodeDebuggerProcessUndefined, 5, 0.5)
-def _evaluate_js_command(sock: WebSocket, command: str, expected_result: str) -> Any:
+def _evaluate_js_command(sock: WebSocket, command: str, expected_result: ResultType) -> Any:
     # Check if process or process.mainModule in command, and if it is, check if it is defined in js context
     if "process.mainModule" in command:
         command = f'typeof(process.mainModule) === "undefined" ? "process undefined" : {command}'

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -131,11 +131,6 @@ def test_nodejs_matrix(
     profiler_flags: List[str],
     application_image_tag: str,
 ) -> None:
-    node_version, libc = application_image_tag.split("-")
-    if node_version in ["14", "15", "16"] or (node_version == "12" and libc == "musl"):
-        pytest.xfail(
-            "This test fails with these nodejs versions, see https://github.com/Granulate/gprofiler/issues/550"
-        )
     with SystemProfiler(
         1000,
         6,


### PR DESCRIPTION
## Description
This PR removes experimental replMode (it is not needed in our case because we are not declaring any variables, and it seems to not work on NodeJS 14+). Also this PR adds closing socket after closing debugger.

## Related Issue
https://github.com/Granulate/gprofiler/issues/550

## How Has This Been Tested?
Run test_nodejs_matrix