### PR TITLE
bugfix/stdout-logs-utc

### DIFF
--- a/gprofiler/log.py
+++ b/gprofiler/log.py
@@ -176,7 +176,7 @@ class RemoteLogsHandler(logging.Handler):
             self._logs[:logs_count] = []
 
 
-class ExtraFormatter(logging.Formatter):
+class _ExtraFormatter(logging.Formatter):
     FILTERED_EXTRA_KEYS = [CYCLE_ID_KEY, RUN_ID_KEY, NO_SERVER_LOG_KEY, NO_SERVER_EXTRA_KEY, GPROFILER_VERSION_KEY]
 
     def format(self, record: LogRecord) -> str:
@@ -190,10 +190,14 @@ class ExtraFormatter(logging.Formatter):
         return formatted
 
 
-class GProfilerFormatter(ExtraFormatter):
+class _UTCFormatter(logging.Formatter):
     # Patch formatTime to be GMT (UTC) for all formatters,
     # see https://docs.python.org/3/library/logging.html?highlight=formattime#logging.Formatter.formatTime
     converter = time.gmtime
+
+
+class GProfilerFormatter(_ExtraFormatter, _UTCFormatter):
+    pass
 
 
 def initial_root_logger_setup(

--- a/gprofiler/log.py
+++ b/gprofiler/log.py
@@ -9,6 +9,7 @@ import logging.handlers
 import os
 import re
 import sys
+import time
 from logging import Logger, LogRecord
 from typing import TYPE_CHECKING, Any, Dict, List, MutableMapping, Optional, Tuple
 
@@ -198,6 +199,10 @@ def initial_root_logger_setup(
 ) -> logging.LoggerAdapter:
     logger_adapter = get_logger_adapter("gprofiler")
     logger_adapter.setLevel(logging.DEBUG)
+
+    # Patch formatTime to be GMT (UTC) for all formatters,
+    # see https://docs.python.org/3/library/logging.html?highlight=formattime#logging.Formatter.formatTime
+    logging.Formatter.converter = time.gmtime
 
     stream_handler = logging.StreamHandler(stream=sys.stdout)
     stream_handler.setLevel(stream_level)

--- a/gprofiler/log.py
+++ b/gprofiler/log.py
@@ -190,6 +190,12 @@ class ExtraFormatter(logging.Formatter):
         return formatted
 
 
+class GProfilerFormatter(ExtraFormatter):
+    # Patch formatTime to be GMT (UTC) for all formatters,
+    # see https://docs.python.org/3/library/logging.html?highlight=formattime#logging.Formatter.formatTime
+    converter = time.gmtime
+
+
 def initial_root_logger_setup(
     stream_level: int,
     log_file_path: str,
@@ -200,16 +206,12 @@ def initial_root_logger_setup(
     logger_adapter = get_logger_adapter("gprofiler")
     logger_adapter.setLevel(logging.DEBUG)
 
-    # Patch formatTime to be GMT (UTC) for all formatters,
-    # see https://docs.python.org/3/library/logging.html?highlight=formattime#logging.Formatter.formatTime
-    logging.Formatter.converter = time.gmtime
-
     stream_handler = logging.StreamHandler(stream=sys.stdout)
     stream_handler.setLevel(stream_level)
     if stream_level < logging.INFO:
-        stream_handler.setFormatter(ExtraFormatter("[%(asctime)s] %(levelname)s: %(name)s: %(message)s"))
+        stream_handler.setFormatter(GProfilerFormatter("[%(asctime)s] %(levelname)s: %(name)s: %(message)s"))
     else:
-        stream_handler.setFormatter(ExtraFormatter("[%(asctime)s] %(message)s", "%H:%M:%S"))
+        stream_handler.setFormatter(GProfilerFormatter("[%(asctime)s] %(message)s", "%H:%M:%S"))
     logger_adapter.logger.addHandler(stream_handler)
 
     os.makedirs(os.path.dirname(log_file_path), exist_ok=True)
@@ -219,7 +221,7 @@ def initial_root_logger_setup(
         backupCount=rotate_backup_count,
     )
     file_handler.setLevel(logging.DEBUG)
-    file_handler.setFormatter(ExtraFormatter("[%(asctime)s] %(levelname)s: %(name)s: %(message)s"))
+    file_handler.setFormatter(GProfilerFormatter("[%(asctime)s] %(levelname)s: %(name)s: %(message)s"))
     logger_adapter.logger.addHandler(file_handler)
 
     if remote_logs_handler is not None:


### PR DESCRIPTION

## Description
Currently, logs that are written to stdout are affected from the gProfiler instance environment timezone, this PR fixes it and changes the log records to be recorded in UTC time.


## Related Issue
Closes: https://github.com/Granulate/gprofiler/issues/595

## How Has This Been Tested?
```
docker run -it --env TZ=America/Los_Angeles --entrypoint /bin/bash --rm --userns=host --privileged --pid=host gprofiler
root@7eafc7ec4618:/app# date
Thu Nov 17 09:05:29 PST 2022
root@7eafc7ec4618:/app# python3 -m gprofiler -o /tmp -c
[17:05:42] Running gProfiler (version 1.11.0), commandline: '-o /tmp -c'
[17:05:42] gProfiler arguments: Namespace(alloc_interval=None, app_id_args_filters=[], application_metadata=True, collect_metadata=True, collect_metrics=True, config=None, container_names=True, continuous=True, controller_pid=None, curlify_requests=False, databricks_job_name_as_service_name=False, dotnet_mode='dotnet-trace', duration=60, flamegraph=True, frequency=11, identify_applications=True, insert_dso_name=False, java_async_profiler_args=None, java_async_profiler_mcache=30, java_async_profiler_mode='auto', java_async_profiler_safemode=64, java_collect_spark_app_name_as_appid=False, java_jattach_timeout=30, java_mode='ap', java_safemode='profiled-oom,profiled-signaled,hserr', java_version_check=True, log_file='/var/log/gprofiler/gprofiler.log', log_rotate_backup_count=1, log_rotate_max_size=5242880, log_to_server=True, log_usage=False, nodejs_mode='disabled', output_dir='/tmp', perf_dwarf_stack_size=8192, perf_inject=False, perf_mode='smart', perf_node_attach=False, php_mode='disabled', php_process_filter='php-fpm', pid_file='/var/run/gprofiler.pid', pid_ns_check=True, profile_api_version=None, profile_spawned_processes=False, profiling_mode='cpu', python_add_versions=True, python_mode='auto', python_pyperf_user_stacks_pages=None, rotating_output=False, ruby_mode='rbspy', server_host='https://profiler.granulate.io', server_token=None, server_upload_timeout=120, service_name=None, subcommand=None, upload_results=False, verbose=False)
[17:05:42] gProfiler Python version: 3.8.10 (default, Jun 22 2022, 20:18:18)
[GCC 9.4.0]
```