### PR TITLE
java: Ensure fdtransfer lasts for as long as jattach timeout

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -525,7 +525,10 @@ class AsyncProfiledProcess:
         """
         assert self._fdtransfer_path is not None  # should be set if fdntransfer is invoked
         run_process(
-            [fdtransfer_path(), self._fdtransfer_path, str(self.process.pid)],
+            # run fdtransfer with accept timeout that's slightly greater than the jattach timeout - to make
+            # sure that fdtransfer is still around for the full duration of jattach, in case the application
+            # takes a while to accept & handle the connection.
+            [fdtransfer_path(), self._fdtransfer_path, str(self.process.pid), str(self._jattach_timeout + 5)],
             stop_event=self._stop_event,
             timeout=self._FDTRANSFER_TIMEOUT,
         )

--- a/scripts/async_profiler_build_shared.sh
+++ b/scripts/async_profiler_build_shared.sh
@@ -5,8 +5,8 @@
 #
 set -euo pipefail
 
-VERSION=v2.8.3g5
-GIT_REV="da08aab5cbd7f7bf174ac27f1e7bd6d6734ed4db"
+VERSION=v2.8.3g6
+GIT_REV="bbacc3c91e29709133edd4afc23916353343534e"
 
 git clone --depth 1 -b "$VERSION" https://github.com/Granulate/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
 # shellcheck disable=SC1090  # we pass it either async_profiler_build_glibc.sh or async_profiler_build_musl.sh


### PR DESCRIPTION
This PR & the accompanying AP change fix this scenario:
* Java app is taking time to handle the attach request
* fdtransfer had a timeout of 10 seconds while jattach has a higher one (by default 30 but configurable with `--java-jattach-timeout`)
* by the time the app starts to handle the attach request, fdtransfer is already exited and AP gets this error:
```
gprofiler.profilers.java.JattachException: Command '['/app/gprofiler/resources/java/jattach', '837867', 'load', '/tmp/gprofiler_tmp/async-profiler-v2.8.3g5/glibc/libasyncProfiler.so', 'true', 'start,event=cpu,file=/tmp/gprofiler_tmp/tmpq5dgrqc1/async-profiler-837867.output,collapsed,ann,sig,interval=90909090,log=/tmp/gprofiler_tmp/tmpq5dgrqc1/async-profiler-837867.log,fdtransfer=@async-profiler-837867-6eb885285f6505442f90,safemode=64,timeout=60']' returned non-zero exit status 200. 
stdout: b'Connected to remote JVM\nJVM response code = 0\nreturn code: 200\n\n'
stderr: b''
Java PID: 837867
async-profiler DSO was loaded
async-profiler log:
[WARN] FdTransferClient connect(): Connection refused
[ERROR] Failed to initialize FdTransferClient
```

(fdtransfer connection refused).

I reproduced this problem by running gprofiler with `--disable-application-identification` (so first jattach is with AP, not the `jcmd`). Then ran a Java app and `SIGSTOP`ed it. Then ran gProfiler and sent `SIGCONT` more than 10 seconds after the attach request started. Got this error. I don't get this error after my fix.