### PR TITLE
perf: Restart perf every 60 minutes if perf used memory exceeds 512 MB

### DIFF
--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -84,7 +84,7 @@ class PerfProcess:
     def check_if_restart(self) -> None:
         if (
             time.monotonic() - self.start_time >= self._restart_after_s
-            and Process(self._process.pid).memory_info().rss >= self._perf_memory_usage_treshhold # type: ignore
+            and Process(self._process.pid).memory_info().rss >= self._perf_memory_usage_treshhold  # type: ignore
         ):
             self.stop()
             self.start()

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -170,9 +170,9 @@ class PerfProcess:
         ProfilerArgument(
             "--perf-no-restart",
             help="Disable checking if perf used memory exceeds threshold and restarting perf",
-            action='store_true',
+            action="store_true",
             dest="perf_no_restart",
-        )
+        ),
     ],
     disablement_help="Disable the global perf of processes,"
     " and instead only concatenate runtime-specific profilers results",

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -84,7 +84,7 @@ class PerfProcess:
     def check_if_restart(self) -> None:
         if (
             time.monotonic() - self.start_time >= self._restart_after_s
-            and Process(self._process.pid).memory_info().rss >= self._perf_memory_usage_treshhold
+            and Process(self._process.pid).memory_info().rss >= self._perf_memory_usage_treshhold # type: ignore
         ):
             self.stop()
             self.start()

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -170,8 +170,8 @@ class PerfProcess:
         ProfilerArgument(
             "--perf-no-restart",
             help="Disable checking if perf used memory exceeds threshold and restarting perf",
-            action="store_true",
-            dest="perf_no_restart",
+            action="store_false",
+            dest="perf_restart",
         ),
     ],
     disablement_help="Disable the global perf of processes,"
@@ -199,7 +199,7 @@ class SystemProfiler(ProfilerBase):
         perf_dwarf_stack_size: int,
         perf_inject: bool,
         perf_node_attach: bool,
-        perf_no_restart: bool,
+        perf_restart: bool,
     ):
         super().__init__(frequency, duration, stop_event, storage_dir, insert_dso_name, profiling_mode)
         _ = profile_spawned_processes  # Required for mypy unused argument warning
@@ -208,7 +208,7 @@ class SystemProfiler(ProfilerBase):
         self._insert_dso_name = insert_dso_name
         self._node_processes: List[Process] = []
         self._node_processes_attached: List[Process] = []
-        self._perf_no_restart = perf_no_restart
+        self._perf_restart = perf_restart
 
         if perf_mode in ("fp", "smart"):
             self._perf_fp: Optional[PerfProcess] = PerfProcess(
@@ -298,7 +298,7 @@ class SystemProfiler(ProfilerBase):
             ).items()
         }
 
-        if not self._perf_no_restart:
+        if self._perf_restart:
             for perf in self._perfs:
                 perf.check_if_needs_restart()
 

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -83,9 +83,10 @@ class PerfProcess:
 
     def check_if_needs_restart(self) -> None:
         """Checks if perf used memory exceeds threshold, and if it does, restarts perf"""
+        assert self._process is not None
         if (
             time.monotonic() - self._start_time >= self._restart_after_s
-            and Process(self._process.pid).memory_info().rss >= self._perf_memory_usage_threshold  # type: ignore
+            and Process(self._process.pid).memory_info().rss >= self._perf_memory_usage_threshold
         ):
             self.stop()
             self.start()

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -52,7 +52,7 @@ class PerfProcess:
         inject_jit: bool,
         extra_args: List[str],
     ):
-        self.start_time = None
+        self.start_time = 0.0
         self._frequency = frequency
         self._stop_event = stop_event
         self._output_path = output_path

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -47,7 +47,7 @@ def test_nodejs_attach_maps(
         perf_inject=False,
         perf_dwarf_stack_size=0,
         perf_node_attach=True,
-        perf_no_restart=False,
+        perf_restart=False,
     ) as profiler:
         process_collapsed = snapshot_pid_collapsed(profiler, application_pid)
         assert_collapsed(process_collapsed)
@@ -104,7 +104,7 @@ def test_twoprocesses_nodejs_attach_maps(
                 perf_inject=False,
                 perf_dwarf_stack_size=0,
                 perf_node_attach=True,
-                perf_no_restart=False,
+                perf_restart=False,
             ) as profiler:
                 results = profiler.snapshot()
                 assert_collapsed(results[pid1].stacks)
@@ -154,7 +154,7 @@ def test_nodejs_matrix(
         perf_inject=False,
         perf_dwarf_stack_size=0,
         perf_node_attach=True,
-        perf_no_restart=False,
+        perf_restart=False,
     ) as profiler:
         node_version, libc = application_image_tag.split("-")
         if node_version == "12" and libc == "glibc":

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -47,6 +47,7 @@ def test_nodejs_attach_maps(
         perf_inject=False,
         perf_dwarf_stack_size=0,
         perf_node_attach=True,
+        perf_no_restart=False,
     ) as profiler:
         process_collapsed = snapshot_pid_collapsed(profiler, application_pid)
         assert_collapsed(process_collapsed)
@@ -103,6 +104,7 @@ def test_twoprocesses_nodejs_attach_maps(
                 perf_inject=False,
                 perf_dwarf_stack_size=0,
                 perf_node_attach=True,
+                perf_no_restart=False,
             ) as profiler:
                 results = profiler.snapshot()
                 assert_collapsed(results[pid1].stacks)
@@ -152,6 +154,7 @@ def test_nodejs_matrix(
         perf_inject=False,
         perf_dwarf_stack_size=0,
         perf_node_attach=True,
+        perf_no_restart=False,
     ) as profiler:
         node_version, libc = application_image_tag.split("-")
         if node_version == "12" and libc == "glibc":

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -43,6 +43,7 @@ def make_system_profiler(tmp_path: Path, perf_mode: str, insert_dso_name: bool) 
         perf_inject=False,
         perf_dwarf_stack_size=DEFAULT_PERF_DWARF_STACK_SIZE,
         perf_node_attach=False,
+        perf_no_restart=False,
     )
 
 

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -43,7 +43,7 @@ def make_system_profiler(tmp_path: Path, perf_mode: str, insert_dso_name: bool) 
         perf_inject=False,
         perf_dwarf_stack_size=DEFAULT_PERF_DWARF_STACK_SIZE,
         perf_node_attach=False,
-        perf_restart=False,
+        perf_restart=True,
     )
 
 

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -43,7 +43,7 @@ def make_system_profiler(tmp_path: Path, perf_mode: str, insert_dso_name: bool) 
         perf_inject=False,
         perf_dwarf_stack_size=DEFAULT_PERF_DWARF_STACK_SIZE,
         perf_node_attach=False,
-        perf_no_restart=False,
+        perf_restart=False,
     )
 
 

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -137,6 +137,7 @@ def test_nodejs(
         perf_inject=True,
         perf_dwarf_stack_size=0,
         perf_node_attach=False,
+        perf_no_restart=False,
     ) as profiler:
         process_collapsed = snapshot_pid_collapsed(profiler, application_pid)
         assert_collapsed(process_collapsed)

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -137,7 +137,7 @@ def test_nodejs(
         perf_inject=True,
         perf_dwarf_stack_size=0,
         perf_node_attach=False,
-        perf_no_restart=False,
+        perf_restart=False,
     ) as profiler:
         process_collapsed = snapshot_pid_collapsed(profiler, application_pid)
         assert_collapsed(process_collapsed)


### PR DESCRIPTION
## Description
Restart perf once per 60 minutes to avoid memory leak from issue https://github.com/Granulate/gprofiler/issues/528.

## Related Issue
https://github.com/Granulate/gprofiler/issues/528

## How Has This Been Tested?
Run gprofiler in continuous mode manually.

