### PR TITLE
Profiling error stacks

### DIFF
--- a/gprofiler/merge.py
+++ b/gprofiler/merge.py
@@ -435,14 +435,22 @@ def merge_profiles(
         profile_samples_count = sum(profile.stacks.values())
         assert profile_samples_count > 0
 
-        # do the scaling by the ratio of samples: samples we received from perf for this process,
-        # divided by samples we received from the runtime profiler of this process.
-        ratio = perf_samples_count / profile_samples_count
-        if process_perf is not None and ProfilingErrorStack.is_error_stack(profile.stacks):
+        if process_perf is not None and perf_samples_count > 0 and ProfilingErrorStack.is_error_stack(profile.stacks):
+            # runtime profiler returned an error stack; extend it with perf profiler stacks for the pid
             profile.stacks = ProfilingErrorStack.attach_error_to_stacks(process_perf.stacks, profile.stacks)
+            metadata = dict(profiling_mode="cpu")
+            enrichment_options = EnrichmentOptions(
+                profile_api_version=None,
+                container_names=False,
+                application_identifiers=False,
+                application_identifier_args_filters=[],
+                application_metadata=False,
+            )
         else:
+            # do the scaling by the ratio of samples: samples we received from perf for this process,
+            # divided by samples we received from the runtime profiler of this process.
+            ratio = perf_samples_count / profile_samples_count
             profile.stacks = scale_sample_counts(profile.stacks, ratio)
-        # swap them: use the scaled samples from the runtime profiler.
+        # swap them: use the processed (scaled or extended) samples from the runtime profiler.
         perf_pid_to_profiles[pid] = profile
-
     return concatenate_profiles(perf_pid_to_profiles, container_names_client, enrichment_options, metadata, metrics)

--- a/gprofiler/profilers/profiler_base.py
+++ b/gprofiler/profilers/profiler_base.py
@@ -8,7 +8,6 @@ import contextlib
 import os
 import sched
 import time
-from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures._base import Future
 from threading import Event, Lock, Thread
@@ -21,7 +20,7 @@ from granulate_utils.linux.process import is_process_running
 from psutil import NoSuchProcess, Process
 
 from gprofiler.exceptions import StopEventSetException
-from gprofiler.gprofiler_types import ProcessToProfileData, ProfileData, StackToSampleCount
+from gprofiler.gprofiler_types import ProcessToProfileData, ProfileData, ProfilingErrorStack, StackToSampleCount
 from gprofiler.log import get_logger_adapter
 from gprofiler.utils import limit_frequency
 from gprofiler.utils.process import process_comm
@@ -171,7 +170,7 @@ class ProcessProfilerBase(ProfilerBase):
         # return 1 sample, it will be scaled later in merge_profiles().
         # if --perf-mode=none mode is used, it will not, but we don't have anything logical to
         # do here in that case :/
-        return Counter({f"{comm};[Profiling {what}: {reason}]": 1})
+        return ProfilingErrorStack(what, reason, comm)
 
     def snapshot(self) -> ProcessToProfileData:
         processes_to_profile = self._select_processes_to_profile()

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -10,8 +10,12 @@ Tests for the logic from gprofiler/merge.py
 from typing import Dict
 
 import pytest
+from granulate_utils.metadata import Metadata
 
-from gprofiler.merge import _collapse_stack, get_average_frame_count
+from gprofiler.gprofiler_types import ProcessToProfileData, ProcessToStackSampleCounters, ProfileData
+from gprofiler.merge import _collapse_stack, get_average_frame_count, merge_profiles, parse_many_collapsed
+from gprofiler.metadata.enrichment import EnrichmentOptions
+from gprofiler.system_metrics import Metrics
 
 
 @pytest.mark.parametrize(
@@ -145,3 +149,77 @@ def test_get_average_frame_count(samples: str, count: float) -> None:
 def test_collapse_stack_consider_dso(stack: str, insert_dso_name: bool, outcome_dict: Dict[str, str]) -> None:
     expected = f"program;{outcome_dict['dso_true' if insert_dso_name else 'dso_false']}"
     assert expected == _collapse_stack("program", stack, insert_dso_name)
+
+
+def parse_profiles_text(profiles_text: str) -> ProcessToProfileData:
+    parsed: ProcessToStackSampleCounters = parse_many_collapsed(profiles_text)
+    process_to_profile_data: ProcessToProfileData = dict()
+    for pid in parsed:
+        process_to_profile_data[pid] = ProfileData(parsed[pid], None, None)
+    return process_to_profile_data
+
+
+@pytest.mark.parametrize(
+    "input_dict, expected",
+    [
+        pytest.param(
+            dict(
+                perf_text="python-123/123;[unknown];_PyEval_EvalFrameDefault;(/usr/local/lib/libpython3.6m.so.1.0);"
+                "(/usr/local/lib/libpython3.6m.so.1.0) 3",
+                process_text="python-123/123;[Profiling error: exception CalledProcessError] 1",
+            ),
+            ";python;[Profiling error: exception CalledProcessError];[unknown];_PyEval_EvalFrameDefault;"
+            "(/usr/local/lib/libpython3.6m.so.1.0);(/usr/local/lib/libpython3.6m.so.1.0) 3",
+            id="1perf_1pyspy-error",
+        ),
+        pytest.param(
+            dict(
+                perf_text="python-123/123;_PyObject_Call_Prepend;_PyObject_FastCallDict;_PyFunction_FastCallDict 2\n"
+                "python-123/123;_start;__libc_start_main;main;Py_Main;PyRun_SimpleFileExFlags 3\n"
+                "python-123/123;entry_SYSCALL_64_[k] 1",
+                process_text="python-123/123;[Profiling error: exception CalledProcessError] 1",
+            ),
+            ";python;[Profiling error: exception CalledProcessError];_PyObject_Call_Prepend;_PyObject_FastCallDict;"
+            "_PyFunction_FastCallDict 2\n"
+            ";python;[Profiling error: exception CalledProcessError];_start;__libc_start_main;main;Py_Main;"
+            "PyRun_SimpleFileExFlags 3\n"
+            ";python;[Profiling error: exception CalledProcessError];entry_SYSCALL_64_[k] 1",
+            id="3perf_1pyspy-error",
+        ),
+        pytest.param(
+            dict(
+                perf_text="java-123/123;(/opt/java/lib/libjvm.so);__vdso_gettimeofday;(vdso);apic_timer_interrupt_[k];"
+                "smp_apic_timer_interrupt_[k] 4",
+                process_text="java-123/123;[Profiling skipped: async-profiler is already loaded] 1",
+            ),
+            ";java;[Profiling skipped: async-profiler is already loaded];(/opt/java/lib/libjvm.so);__vdso_gettimeofday;"
+            "(vdso);apic_timer_interrupt_[k];smp_apic_timer_interrupt_[k] 4",
+            id="1perf_1java-skipped",
+        ),
+        pytest.param(
+            dict(
+                perf_text="python-123/123;EMPTY 0",
+                process_text="python-123/123;[Profiling error: exception CalledProcessError] 1",
+            ),
+            "",
+            id="empty-perf_1pyspy-error",
+        ),
+    ],
+)
+def test_merge_profiles_onto_errors(input_dict: Dict[str, str], expected: str) -> None:
+    enrichment_options = EnrichmentOptions(
+        profile_api_version=None,
+        container_names=False,
+        application_identifiers=False,
+        application_identifier_args_filters=[],
+        application_metadata=False,
+    )
+    metadata: Metadata = dict(profiling_mode="cpu")
+    metrics = Metrics(cpu_avg=1.0, mem_avg=1.0)
+    perf_pid_to_profiles = parse_profiles_text(input_dict["perf_text"])
+    process_profiles = parse_profiles_text(input_dict["process_text"])
+    outcome_raw = merge_profiles(perf_pid_to_profiles, process_profiles, None, enrichment_options, metadata, metrics)
+    header_outcome = outcome_raw.split("\n", maxsplit=1)
+    header, outcome = header_outcome[0], header_outcome[1] if len(header_outcome) >= 2 else ""
+    assert header.startswith("#")
+    assert expected == outcome


### PR DESCRIPTION
Support displaying the stacks collected by perf above the Profiling error stack.

## Description
In case a runtime profiler fails for any reason (e.g.: profiler gets terminated), an error stack is placed in the resulting profile file.
This PR enables extending error information with stacks collected by perf for respective PID.

## Related Issue
https://github.com/Granulate/gprofiler/issues/565

## Motivation and Context
We aim to provide as accurate profiling data as possible, even if runtime profilers fail.

## How Has This Been Tested?
- Tests were added to `test_merge.py` test suite.
- Other profilers that emit profiling error stack are covered by tests already present in the repository.


## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [x] I have added tests for new logic.
