### PR TITLE
perf: Set stdout and stderr streams of perf process to non blocking

### DIFF
--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -89,8 +89,8 @@ class PerfProcess:
             raise
         else:
             self._process = process
-            os.set_blocking(self._process.stdout.fileno(), False)
-            os.set_blocking(self._process.stderr.fileno(), False)
+            os.set_blocking(self._process.stdout.fileno(), False)  # type: ignore
+            os.set_blocking(self._process.stderr.fileno(), False)  # type: ignore
             logger.info(f"Started perf ({self._type} mode)")
 
     def stop(self) -> None:

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -89,6 +89,8 @@ class PerfProcess:
             raise
         else:
             self._process = process
+            os.set_blocking(self._process.stdout.fileno(), False)
+            os.set_blocking(self._process.stderr.fileno(), False)
             logger.info(f"Started perf ({self._type} mode)")
 
     def stop(self) -> None:
@@ -107,8 +109,6 @@ class PerfProcess:
             perf_data = wait_for_file_by_prefix(f"{self._output_path}.", self._dump_timeout_s, self._stop_event)
         except Exception:
             assert self._process is not None and self._process.stdout is not None and self._process.stderr is not None
-            os.set_blocking(self._process.stdout.fileno(), False)
-            os.set_blocking(self._process.stderr.fileno(), False)
             logger.critical(
                 f"perf failed to dump output. stdout {self._process.stdout.read()!r}"
                 f" stderr {self._process.stderr.read()!r}"

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -107,7 +107,8 @@ class PerfProcess:
             perf_data = wait_for_file_by_prefix(f"{self._output_path}.", self._dump_timeout_s, self._stop_event)
         except Exception:
             assert self._process is not None and self._process.stdout is not None and self._process.stderr is not None
-            self._process.kill()
+            os.set_blocking(self._process.stdout.fileno(), False)
+            os.set_blocking(self._process.stderr.fileno(), False)
             logger.critical(
                 f"perf failed to dump output. stdout {self._process.stdout.read()!r}"
                 f" stderr {self._process.stderr.read()!r}"

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -107,6 +107,7 @@ class PerfProcess:
             perf_data = wait_for_file_by_prefix(f"{self._output_path}.", self._dump_timeout_s, self._stop_event)
         except Exception:
             assert self._process is not None and self._process.stdout is not None and self._process.stderr is not None
+            self._process.kill()
             logger.critical(
                 f"perf failed to dump output. stdout {self._process.stdout.read()!r}"
                 f" stderr {self._process.stderr.read()!r}"


### PR DESCRIPTION
## Description
This PR sets stdout and stderr streams of perf process to non blocking.

## Related Issue
https://github.com/Granulate/gprofiler/issues/612

## How Has This Been Tested?
Added `raise exception()` to try block in `wait_and_script()` -> on master - gProfiler stucks on reading from stdout and stderr (like in related issue), after these changes it reads the stream and continues
