### PR TITLE
Drop support for Python 3.6, 3.7

### DIFF
--- a/.github/workflows/build-container-and-deploy.yml
+++ b/.github/workflows/build-container-and-deploy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: true
@@ -45,7 +45,7 @@ jobs:
     runs-on: ["self-hosted", "ARM64"]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: true
@@ -86,7 +86,7 @@ jobs:
     steps:
       # needed to set up env.GH_REPO etc
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: true

--- a/.github/workflows/build-container-and-test.yml
+++ b/.github/workflows/build-container-and-test.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -90,7 +90,7 @@ jobs:
         node-version: 10.x
 
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: true
 

--- a/.github/workflows/build-container-and-test.yml
+++ b/.github/workflows/build-container-and-test.yml
@@ -60,7 +60,7 @@ jobs:
   test:
     needs: build-container
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04  # for 3.10.0 python tag
 
     strategy:
       fail-fast: false  # helps detecting flakiness / errors specific to one Python version

--- a/.github/workflows/build-container-and-test.yml
+++ b/.github/workflows/build-container-and-test.yml
@@ -9,7 +9,7 @@ jobs:
         python-version:
           - "3.8"
           - "3.9"
-          - "3.10.0"
+          - "3.10"
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build-container-and-test.yml
+++ b/.github/workflows/build-container-and-test.yml
@@ -6,7 +6,10 @@ jobs:
   lint:
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0]
+        python-version:
+          - "3.8"
+          - "3.9"
+          - "3.10.0"
 
     runs-on: ubuntu-latest
 
@@ -62,7 +65,10 @@ jobs:
     strategy:
       fail-fast: false  # helps detecting flakiness / errors specific to one Python version
       matrix:
-        python-version: [3.6, 3.7, 3.8.8, 3.9.2, 3.10.0]
+        python-version:
+          - "3.8"
+          - "3.9"
+          - "3.10.0"
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build-container-and-test.yml
+++ b/.github/workflows/build-container-and-test.yml
@@ -68,7 +68,7 @@ jobs:
         python-version:
           - "3.8"
           - "3.9"
-          - "3.10.0"
+          - "3.10.0"  # see https://github.com/Granulate/gprofiler/issues/502, we need 3.10.0, others fail PyPerf tests.
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build-executable-test-deploy.yml
+++ b/.github/workflows/build-executable-test-deploy.yml
@@ -16,6 +16,11 @@ jobs:
          fetch-depth: 0
          submodules: true
 
+     - name: test
+       run: |
+         ls -lR .
+         exit 1
+
      - name: Get and verify tag value
        run: |
          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV

--- a/.github/workflows/build-executable-test-deploy.yml
+++ b/.github/workflows/build-executable-test-deploy.yml
@@ -11,10 +11,11 @@ jobs:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout Code
-       uses: actions/checkout@v2
+       uses: actions/checkout@v3
        with:
          fetch-depth: 0
          submodules: true
+
      - name: Get and verify tag value
        run: |
          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
@@ -84,7 +85,7 @@ jobs:
           node-version: 10.x
 
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
 
@@ -105,7 +106,7 @@ jobs:
     runs-on: ["self-hosted", "ARM64"]
     steps:
      - name: Checkout Code
-       uses: actions/checkout@v2
+       uses: actions/checkout@v3
        with:
          fetch-depth: 0
          submodules: true

--- a/.github/workflows/build-executable-test-deploy.yml
+++ b/.github/workflows/build-executable-test-deploy.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8.8
+          python-version: "3.8"
 
       - name: Install Java
         uses: actions/setup-java@v1

--- a/.github/workflows/build-executable-test-deploy.yml
+++ b/.github/workflows/build-executable-test-deploy.yml
@@ -16,11 +16,6 @@ jobs:
          fetch-depth: 0
          submodules: true
 
-     - name: test
-       run: |
-         ls -lR .
-         exit 1
-
      - name: Get and verify tag value
        run: |
          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
@@ -47,7 +42,9 @@ jobs:
 
   test-executable:
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04  # the tests which use ruby/node/python etc and run at non-root privs, fail to read the files when running
+                           # on ubuntu-22.04/ubuntu-latest:
+                           # stderr: ruby: Permission denied -- /home/runner/work/gprofiler/gprofiler/tests/containers/ruby/fibonacci.rb (LoadError)
     needs: build-executable
     strategy:
       fail-fast: false

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: true
 

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ The playbook defines 2 more variables:
 * `gprofiler_args` - additional arguments to pass to gProfiler, empty by default. You can use it to pass, for example, `'--profiling-frequency 15'` to change the frequency.
 
 ## Running from source
-gProfiler requires Python 3.6+ to run.
+gProfiler requires Python 3.8+ to run.
 
 ```bash
 pip3 install -r requirements.txt

--- a/gprofiler/merge.py
+++ b/gprofiler/merge.py
@@ -8,6 +8,7 @@ import random
 import re
 from collections import Counter, defaultdict
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
@@ -24,7 +25,7 @@ from gprofiler.gprofiler_types import (
 from gprofiler.log import get_logger_adapter
 from gprofiler.metadata.enrichment import EnrichmentOptions
 from gprofiler.system_metrics import Metrics
-from gprofiler.utils import merge_dicts, parse_iso8601_timestamp
+from gprofiler.utils import merge_dicts
 
 logger = get_logger_adapter(__name__)
 
@@ -360,8 +361,8 @@ def concatenate_from_external_file(
                 read_metadata = json.loads(line[1:])
                 metadata = merge_dicts(read_metadata, obtained_metadata)
                 try:
-                    start_time = parse_iso8601_timestamp(metadata["start_time"])
-                    end_time = parse_iso8601_timestamp(metadata["end_time"])
+                    start_time = datetime.fromisoformat(metadata["start_time"])
+                    end_time = datetime.fromisoformat(metadata["end_time"])
                 except KeyError:
                     pass
                 try:

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -119,7 +119,7 @@ class PerfProcess:
             # using read1() which performs just a single read() call and doesn't read until EOF
             # (unlike Popen.communicate())
             assert self._process is not None and self._process.stderr is not None
-            logger.debug(f"perf stderr: {self._process.stderr.read1(4096)}")  # type: ignore
+            logger.debug(f"perf stderr: {self._process.stderr.read1()}")  # type: ignore
 
         if self._inject_jit:
             inject_data = Path(f"{str(perf_data)}.inject")

--- a/gprofiler/profilers/php.py
+++ b/gprofiler/profilers/php.py
@@ -121,7 +121,7 @@ class PHPSpyProfiler(ProfilerBase):
         )
 
         # Ignoring type since _process.stderr is typed as Optional[IO[Any]] which doesn't have the `read1` method.
-        stderr = self._process.stderr.read1(1024).decode()  # type: ignore
+        stderr = self._process.stderr.read1().decode()  # type: ignore
         self._process_stderr(stderr)
 
     def _dump(self) -> Path:
@@ -209,7 +209,7 @@ class PHPSpyProfiler(ProfilerBase):
     def snapshot(self) -> ProcessToProfileData:
         if self._stop_event.wait(self._duration):
             raise StopEventSetException()
-        stderr = self._process.stderr.read1(1024).decode()  # type: ignore
+        stderr = self._process.stderr.read1().decode()  # type: ignore
         self._process_stderr(stderr)
 
         phpspy_output_path = self._dump()

--- a/gprofiler/profilers/php.py
+++ b/gprofiler/profilers/php.py
@@ -232,10 +232,8 @@ class PHPSpyProfiler(ProfilerBase):
 
     def _process_stderr(self, stderr: str) -> None:
         skip_re = self._get_stderr_skip_regex()
-        lines = stderr.splitlines()
-        for line in lines:
-            if not skip_re.search(line):
-                logger.debug(f"phpspy: error: {line}")
+        log_lines = [line for line in stderr.splitlines() if skip_re.search(line) is None]
+        logger.debug("phpspy stderr", phpspy_stderr="\n".join(log_lines))
 
     @staticmethod
     @lru_cache(maxsize=1)

--- a/gprofiler/profilers/python_ebpf.py
+++ b/gprofiler/profilers/python_ebpf.py
@@ -213,8 +213,7 @@ class PythonEbpfProfiler(ProfilerBase):
             # using read1() which performs just a single read() call and doesn't read until EOF
             # (unlike Popen.communicate())
             assert self.process is not None
-            # Python 3.6 doesn't have read1() without size argument :/
-            logger.debug(f"PyPerf output: {self.process.stderr.read1(4096)}")  # type: ignore
+            logger.debug(f"PyPerf output: {self.process.stderr.read1()}")  # type: ignore
             return output
         except TimeoutError:
             # error flow :(

--- a/gprofiler/profilers/registry.py
+++ b/gprofiler/profilers/registry.py
@@ -2,8 +2,7 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Type, Union
 
 
 class ProfilerArgument:
-    # It would have been better to replace with a dataclass, but since we want to support Python 3.6 this is the best
-    # alternative as we still need the get_dict method (which is not convenient to do with a namedtuple)
+    # TODO convert to a datalcass
     def __init__(
         self,
         name: str,

--- a/gprofiler/profilers/registry.py
+++ b/gprofiler/profilers/registry.py
@@ -2,7 +2,7 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Type, Union
 
 
 class ProfilerArgument:
-    # TODO convert to a datalcass
+    # TODO convert to a dataclass
     def __init__(
         self,
         name: str,

--- a/gprofiler/utils/__init__.py
+++ b/gprofiler/utils/__init__.py
@@ -358,11 +358,6 @@ def get_iso8601_format_time(time: datetime.datetime) -> str:
     return time.replace(microsecond=0).isoformat()
 
 
-# can be replaced by fromisoformat(), but it is unavailable in python 3.6
-def parse_iso8601_timestamp(time: str) -> Any:
-    return datetime.datetime.strptime(time, "%Y-%m-%dT%H:%M:%S.%f")
-
-
 def remove_prefix(s: str, prefix: str) -> str:
     # like str.removeprefix of Python 3.9, but this also ensures the prefix exists.
     assert s.startswith(prefix), f"{s} doesn't start with {prefix}"

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.8
 warn_unused_configs = True
 exclude = .*venv.*/|deploy/dataflow/|granulate-utils
 platform = linux

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ ConfigArgParse==1.3
 distro==1.7.0
 setuptools==59.4.0  # For pkg_resources
 six==1.16.0
-dataclasses==0.8; python_version < '3.7'
 packaging==21.2
 pyelftools==0.28
 curlify==2.2.1

--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,5 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     include_package_data=True,
     install_requires=list(read_requirements("requirements.txt")),
-    python_requires=">=3.6",
+    python_requires=">=3.8",
 )

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -30,8 +30,12 @@ def test_executable(
     docker_client: DockerClient,
     output_directory: Path,
     profiler_flags: List[str],
+    runtime: str,
 ) -> None:
     _ = application_pid  # Fixture only used for running the application.
+
+    if runtime == "php":
+        pytest.skip("Flaky, https://github.com/Granulate/gprofiler/issues/630")
 
     if exec_container_image is not None:
         if "centos:6" in exec_container_image.tags and any("pyperf" in flag for flag in profiler_flags):


### PR DESCRIPTION
After https://github.com/Granulate/granulate-utils/pull/107 is merged.

Since https://github.com/Granulate/gprofiler/pull/597 we no longer need any 3.6, 3.7 support. Time to move forward