### PR TITLE
Use glogger as remote logging infra

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -235,6 +235,7 @@ RUN pip3 install --upgrade --no-cache-dir pip
 COPY requirements.txt ./
 COPY granulate-utils/setup.py granulate-utils/requirements.txt granulate-utils/README.md granulate-utils/
 COPY granulate-utils/granulate_utils granulate-utils/granulate_utils
+COPY granulate-utils/glogger granulate-utils/glogger
 RUN pip3 install --no-cache-dir -r requirements.txt
 
 COPY LICENSE.md MANIFEST.in README.md setup.py  ./

--- a/gprofiler/exceptions.py
+++ b/gprofiler/exceptions.py
@@ -52,14 +52,6 @@ class APIError(Exception):
         return self.message
 
 
-class UninitializedStateException(Exception):
-    pass
-
-
-class StateAlreadyInitializedException(Exception):
-    pass
-
-
 class ThreadStopTimeoutError(Exception):
     pass
 

--- a/gprofiler/log.py
+++ b/gprofiler/log.py
@@ -58,10 +58,12 @@ class RemoteLogsHandler(BatchRequestsHandler):
         )
 
     def emit(self, record: LogRecord) -> None:
-        if self.get_extra_fields(record).pop(NO_SERVER_LOG_KEY, False):
+        extra = self.get_extra_fields(record)
+
+        if extra.pop(NO_SERVER_LOG_KEY, False):
             return
 
-        if self.get_extra_fields(record).pop(NO_SERVER_EXTRA_KEY, False):
+        if extra.pop(NO_SERVER_EXTRA_KEY, False):
             record.extra = {}
 
         return super().emit(record)

--- a/gprofiler/log.py
+++ b/gprofiler/log.py
@@ -23,6 +23,7 @@ DEFAULT_API_SERVER_ADDRESS = "https://api.granulate.io"
 
 NO_SERVER_LOG_KEY = "no_server_log"
 NO_SERVER_EXTRA_KEY = "no_extra_to_server"
+CYCLE_ID_KEY = "cycle_id"
 LOGGER_NAME_RE = re.compile(r"gprofiler(?:\..+)?")
 
 
@@ -37,8 +38,8 @@ class GProfilerExtraAdapter(ExtraAdapter):
         extra = super().get_extra(**kwargs)
         # here we add fields which change during the lifetime of gProfiler.
         # fields that do not change go in RemoteLogsHandler.get_metadata().
-        assert "cycle_id" not in extra
-        return {**extra, "cycle_id": get_state().cycle_id}
+        assert CYCLE_ID_KEY not in extra
+        return {**extra, CYCLE_ID_KEY: get_state().cycle_id}
 
 
 class RemoteLogsHandler(BatchRequestsHandler):
@@ -88,7 +89,7 @@ class RemoteLogsHandler(BatchRequestsHandler):
 
 
 class _ExtraFormatter(logging.Formatter):
-    FILTERED_EXTRA_KEYS = [NO_SERVER_LOG_KEY, NO_SERVER_EXTRA_KEY]  # don't print those fields locally
+    FILTERED_EXTRA_KEYS = [NO_SERVER_LOG_KEY, NO_SERVER_EXTRA_KEY, CYCLE_ID_KEY]  # don't print those fields locally
 
     def format(self, record: LogRecord) -> str:
         formatted = super().format(record)

--- a/gprofiler/log.py
+++ b/gprofiler/log.py
@@ -2,85 +2,37 @@
 # Copyright (c) Granulate. All rights reserved.
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
-import datetime
-import json
 import logging
 import logging.handlers
 import os
 import re
 import sys
 import time
-from logging import Logger, LogRecord
-from typing import TYPE_CHECKING, Any, Dict, List, MutableMapping, Optional, Tuple
+from logging import LogRecord
+from typing import Dict, Optional
+from urllib.parse import urlparse
 
-from requests import RequestException
+from glogger.extra_adapter import ExtraAdapter
+from glogger.handler import BatchRequestsHandler
+from glogger.sender import Sender
 
 from gprofiler import __version__
-from gprofiler.exceptions import APIError, UninitializedStateException
-from gprofiler.state import State, get_state
+from gprofiler.state import get_state
 
-if TYPE_CHECKING:
-    from gprofiler.client import APIClient
+DEFAULT_API_SERVER_ADDRESS = "https://api.granulate.io"
 
 NO_SERVER_LOG_KEY = "no_server_log"
 NO_SERVER_EXTRA_KEY = "no_extra_to_server"
-RUN_ID_KEY = "run_id"
-CYCLE_ID_KEY = "cycle_id"
-GPROFILER_VERSION_KEY = "gprofiler_version"
 LOGGER_NAME_RE = re.compile(r"gprofiler(?:\..+)?")
 
 
 def get_logger_adapter(logger_name: str) -> logging.LoggerAdapter:
     # Validate the name starts with gprofiler (the root logger name), so logging parent logger propagation will work.
     assert LOGGER_NAME_RE.match(logger_name) is not None, "logger name must start with 'gprofiler'"
-    logger = logging.getLogger(logger_name)
-    return GProfilerLoggingAdapter(logger)
+    return ExtraAdapter(logging.getLogger(logger_name))
 
 
-class GProfilerLoggingAdapter(logging.LoggerAdapter):
-    LOGGING_KWARGS = ["exc_info", "extra", "stack_info"]
-
-    def __init__(self, logger: Logger) -> None:
-        super().__init__(logger, {})
-        # Lazy initialization of state because it will be initialized only after calling `init_state` while the adapter
-        # may initialize before (at module import stage)
-        self._state: Optional[State] = None
-
-    def _get_state_extra(self) -> Dict[str, str]:
-        if self._state is None:
-            try:
-                self._state = get_state()
-            except UninitializedStateException:
-                return {}
-
-        state_extra = {
-            RUN_ID_KEY: self._state.run_id,
-        }
-
-        if self._state.cycle_id:
-            state_extra[CYCLE_ID_KEY] = self._state.cycle_id
-
-        return state_extra
-
-    def process(self, msg: Any, kwargs: MutableMapping[str, Any]) -> Tuple[Any, MutableMapping[str, Any]]:
-        extra_kwargs = {}
-        logging_kwargs = {}
-        for k, v in kwargs.items():
-            if k in self.LOGGING_KWARGS:
-                logging_kwargs[k] = v
-            else:
-                extra_kwargs[k] = v
-
-        extra_kwargs.update(self._get_state_extra())
-        extra_kwargs.update({GPROFILER_VERSION_KEY: __version__})
-
-        extra = logging_kwargs.get("extra", {})
-        extra["gprofiler_adapter_extra"] = extra_kwargs
-        logging_kwargs["extra"] = extra
-        return msg, logging_kwargs
-
-
-class RemoteLogsHandler(logging.Handler):
+class RemoteLogsHandler(BatchRequestsHandler):
     """
     logging.Handler that supports accumulating logs and sending them to server upon request.
     Because we don't want to lose log records before the APIClient initialized we support lazy initialization of
@@ -89,101 +41,49 @@ class RemoteLogsHandler(logging.Handler):
 
     MAX_BUFFERED_RECORDS = 100 * 1000  # max number of records to buffer locally
 
-    def __init__(self, path: str = "logs", api_client: Optional["APIClient"] = None) -> None:
-        super().__init__(logging.DEBUG)
-        self._api_client = api_client
-        self._path = path
-        self._logs: List[Dict] = []
-        self._logger = get_logger_adapter("gprofiler.RemoteLogsHandler")
-        self._truncated = False
-
-        # The formatter is needed to format tracebacks
-        self.setFormatter(logging.Formatter())
-
-    def init_api_client(self, api_client: "APIClient") -> None:
-        self._api_client = api_client
+    def __init__(self, server_address: str, auth_token: str, service_name: str) -> None:
+        self._service_name = service_name
+        url = urlparse(server_address)
+        super().__init__(
+            Sender(application_name="gprofiler", auth_token=auth_token, scheme=url.scheme, server_address=url.netloc)
+        )
 
     def emit(self, record: LogRecord) -> None:
-        extra_kwargs = record.gprofiler_adapter_extra  # type: ignore
-        if extra_kwargs.pop(NO_SERVER_LOG_KEY, False):
+        if self.get_extra_fields(record).pop(NO_SERVER_LOG_KEY, False):
             return
 
-        self._logs.append(self._make_dict_record(record))
-        # truncate logs to last N entries
-        if len(self._logs) > self.MAX_BUFFERED_RECORDS:
-            self._truncated = True
-            self._logs[: -self.MAX_BUFFERED_RECORDS] = []
+        if self.get_extra_fields(record).pop(NO_SERVER_EXTRA_KEY, False):
+            record.extra = {}
 
-    def _make_dict_record(self, record: LogRecord) -> Dict[str, Any]:
-        formatted_timestamp = datetime.datetime.utcfromtimestamp(record.created).isoformat()
-        extra = record.gprofiler_adapter_extra  # type: ignore
+        return super().emit(record)
 
-        run_id = extra.pop(RUN_ID_KEY, None)
-        if run_id is None:
-            self._logger.error("state.run_id is not defined! probably a bug!")
-            run_id = ""
+    def get_metadata(self) -> Dict[str, str]:
+        from gprofiler.metadata.system_metadata import get_hostname_or_none
 
-        cycle_id = extra.pop(CYCLE_ID_KEY, "")
+        state = get_state()
+        hostname = get_hostname_or_none()
 
-        # We don't want to serialize a JSON inside JSON but either don't want to fail record because of extra
-        # serialization, so we test if the extra can be serialized and have a fail-safe.
-        try:
-            json.dumps(extra)
-        except TypeError:
-            self._logger.exception(
-                f"Can't serialize extra (extra={extra!r}), sending empty extra", bad_extra=repr(extra)
-            )
-            extra = {}
-
-        assert self.formatter is not None
-        if record.exc_info:
-            # Use cached exc_text if available.
-            exception_traceback = (
-                record.exc_text if record.exc_text else self.formatter.formatException(record.exc_info)
-            )
-        else:
-            exception_traceback = ""
-
-        extra = extra if not extra.pop(NO_SERVER_EXTRA_KEY, False) else {}
-
-        return {
-            "message": record.message,
-            "level": record.levelname,
-            "timestamp": formatted_timestamp,
-            "extra": extra,
-            "logger_name": record.name,
-            "exception": exception_traceback,
-            RUN_ID_KEY: run_id,
-            CYCLE_ID_KEY: cycle_id,
+        metadata = {
+            "run_id": state.run_id,
+            "cycle_id": state.cycle_id,
+            "gprofiler_version": __version__,
+            "service_name": self._service_name,
         }
+        if hostname is not None:
+            metadata["hostname"] = hostname
 
-    def try_send_log_to_server(self) -> None:
-        assert self._api_client is not None, "APIClient is not initialized, can't send logs to server"
-        # Snapshot the current num logs because logs list might be extended meanwhile.
-        logs_count = len(self._logs)
-        try:
-            if self._truncated:
-                self._logger.warning(
-                    f"Log buffer truncation has occurred as the maximum number of records ({self.MAX_BUFFERED_RECORDS})"
-                    " was reached",
-                )
-                self._truncated = False
-            self._api_client.post(self._path, data=self._logs[:logs_count], api_version="v1")
-        except (APIError, RequestException):
-            self._logger.exception("Failed sending logs to server")
-        else:
-            # If succeeded, remove the sent logs from the list.
-            self._logs[:logs_count] = []
+        return metadata
 
 
 class _ExtraFormatter(logging.Formatter):
-    FILTERED_EXTRA_KEYS = [CYCLE_ID_KEY, RUN_ID_KEY, NO_SERVER_LOG_KEY, NO_SERVER_EXTRA_KEY, GPROFILER_VERSION_KEY]
+    FILTERED_EXTRA_KEYS = [NO_SERVER_LOG_KEY, NO_SERVER_EXTRA_KEY]  # don't print those fields locally
 
     def format(self, record: LogRecord) -> str:
         formatted = super().format(record)
-        extra = record.gprofiler_adapter_extra  # type: ignore
 
-        formatted_extra = ", ".join(f"{k}={v}" for k, v in extra.items() if k not in self.FILTERED_EXTRA_KEYS)
+        formatted_extra = ", ".join(
+            f"{k}={v}" for k, v in record.__dict__.get("extra", {}).items() if k not in self.FILTERED_EXTRA_KEYS
+        )
         if formatted_extra:
             formatted = f"{formatted} ({formatted_extra})"
 

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -121,13 +121,15 @@ class GProfiler:
         self._collect_metadata = collect_metadata
         self._enrichment_options = enrichment_options
         self._stop_event = Event()
+        self._static_metadata: Optional[Metadata] = None
         self._spawn_time = time.time()
         self._last_diagnostics = 0.0
         self._gpid = ""
         self._controller_process = controller_process
         self._duration = duration
         self._profiling_mode = profiling_mode
-        self._static_metadata = get_static_metadata(spawn_time=self._spawn_time, run_args=user_args)
+        if collect_metadata:
+            self._static_metadata = get_static_metadata(spawn_time=self._spawn_time, run_args=user_args)
         self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=10)
         # TODO: we actually need 2 types of temporary directories.
         # 1. accessible by everyone - for profilers that run code in target processes, like async-profiler

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -346,6 +346,7 @@ class GProfiler:
             # In case of single run mode, use the same id for run_id and cycle_id
             self._state.set_cycle_id(self._state.run_id)
             self._snapshot()
+            self._state.set_cycle_id(None)
 
     def run_continuous(self) -> None:
         with self:
@@ -367,6 +368,8 @@ class GProfiler:
                 if self._controller_process is not None and not is_process_running(self._controller_process):
                     logger.info(f"Controller process {self._controller_process.pid} has exited; gProfiler stopping...")
                     break
+
+            self._state.set_cycle_id(None)
 
 
 def _submit_profile_logged(

--- a/gprofiler/metadata/application_identifiers_java.py
+++ b/gprofiler/metadata/application_identifiers_java.py
@@ -63,7 +63,7 @@ class _JavaSparkApplicationIdentifier(_ApplicationIdentifier):
         if not os.path.exists(props_path):
             _logger.warning(
                 f"Spark props file doesn't exist: {props_path}. \
-                        Proces args: {process.cmdline()}, pid: {process.pid}"
+                        Process args: {process.cmdline()}, pid: {process.pid}"
             )
             return self._APP_NAME_NOT_FOUND
         with open(props_path) as f:

--- a/gprofiler/metadata/metadata_collector.py
+++ b/gprofiler/metadata/metadata_collector.py
@@ -12,7 +12,7 @@ from gprofiler.metadata.system_metadata import get_static_system_info
 logger = get_logger_adapter(__name__)
 
 
-def get_static_metadata(spawn_time: float, run_args: UserArgs = None) -> Metadata:
+def get_static_metadata(spawn_time: float, run_args: UserArgs) -> Metadata:
     formatted_spawn_time = datetime.datetime.utcfromtimestamp(spawn_time).replace(microsecond=0).isoformat()
     static_system_metadata = get_static_system_info()
     cloud_metadata = get_static_cloud_instance_metadata(logger)
@@ -25,8 +25,7 @@ def get_static_metadata(spawn_time: float, run_args: UserArgs = None) -> Metadat
     metadata_dict.update(static_system_metadata.__dict__)
     if cloud_metadata is not None:
         metadata_dict["cloud_info"] = cloud_metadata
-    if run_args is not None:
-        metadata_dict["run_arguments"] = run_args
+    metadata_dict["run_arguments"] = run_args
     return metadata_dict
 
 

--- a/gprofiler/metadata/system_metadata.py
+++ b/gprofiler/metadata/system_metadata.py
@@ -281,6 +281,13 @@ def get_hostname() -> str:
     return hostname
 
 
+def get_hostname_or_none() -> Optional[str]:
+    """
+    Can be used early, possibly before hostname was initialized, and will return None if not initialized.
+    """
+    return hostname
+
+
 def _initialize_system_info_windows() -> Any:
     global hostname
     hostname = f"<{UNKNOWN_VALUE}>"

--- a/gprofiler/state.py
+++ b/gprofiler/state.py
@@ -17,7 +17,7 @@ class State:
         self._run_id: str = run_id or generate_random_id()
         self._cycle_id: Optional[str] = None
 
-    def set_cycle_id(self, cycle_id: str) -> None:
+    def set_cycle_id(self, cycle_id: Optional[str]) -> None:
         self._cycle_id = cycle_id
 
     def init_new_cycle(self) -> None:

--- a/gprofiler/state.py
+++ b/gprofiler/state.py
@@ -28,8 +28,7 @@ class State:
         return self._run_id
 
     @property
-    def cycle_id(self) -> str:
-        assert self._cycle_id is not None
+    def cycle_id(self) -> Optional[str]:
         return self._cycle_id
 
 

--- a/gprofiler/state.py
+++ b/gprofiler/state.py
@@ -6,8 +6,6 @@
 import uuid
 from typing import Optional
 
-from gprofiler.exceptions import StateAlreadyInitializedException, UninitializedStateException
-
 
 # Declare this function here (rather than in utils.py) to avoid circular imports.
 def generate_random_id() -> str:
@@ -30,7 +28,8 @@ class State:
         return self._run_id
 
     @property
-    def cycle_id(self) -> Optional[str]:
+    def cycle_id(self) -> str:
+        assert self._cycle_id is not None
         return self._cycle_id
 
 
@@ -39,15 +38,12 @@ _state: Optional[State] = None
 
 def init_state(run_id: str = None) -> State:
     global _state
-    if _state is not None:
-        raise StateAlreadyInitializedException("gProfiler state already initialized")
+    assert _state is None
 
     _state = State(run_id=run_id)
     return _state
 
 
 def get_state() -> State:
-    if _state is None:
-        raise UninitializedStateException("gProfiler state is not initialized")
-
+    assert _state is not None
     return _state

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -257,6 +257,7 @@ RUN python3 -m pip install --no-cache-dir --upgrade pip
 COPY requirements.txt requirements.txt
 COPY granulate-utils/setup.py granulate-utils/requirements.txt granulate-utils/README.md granulate-utils/
 COPY granulate-utils/granulate_utils granulate-utils/granulate_utils
+COPY granulate-utils/glogger granulate-utils/glogger
 RUN python3 -m pip install --no-cache-dir -r requirements.txt
 
 COPY exe-requirements.txt exe-requirements.txt

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ from gprofiler.metadata.application_identifiers import (
     set_enrichment_options,
 )
 from gprofiler.metadata.enrichment import EnrichmentOptions
+from gprofiler.state import init_state
 from tests import CONTAINERS_DIRECTORY, PARENT, PHPSPY_DURATION
 from tests.utils import (
     _application_docker_container,
@@ -553,6 +554,7 @@ def _set_enrichment_options() -> None:
         )
     )
     set_diagnostics(False)
+    init_state(run_id="tests-run-id")
 
 
 def pytest_addoption(parser: Any) -> None:

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -195,7 +195,7 @@ def test_java_safemode_version_check(
         assert collapsed == Counter({"java;[Profiling skipped: profiling this JVM is not supported]": 1})
 
     log_record = next(filter(lambda r: r.message == "Unsupported JVM version", caplog.records))
-    log_extra = log_record.gprofiler_adapter_extra  # type: ignore
+    log_extra = log_record.extra  # type: ignore  # our logging adapter adds "extra"
     assert log_extra["jvm_version"] == repr(jvm_version)
 
 
@@ -215,7 +215,7 @@ def test_java_safemode_build_number_check(
         assert collapsed == Counter({"java;[Profiling skipped: profiling this JVM is not supported]": 1})
 
     log_record = next(filter(lambda r: r.message == "Unsupported JVM version", caplog.records))
-    log_extra = log_record.gprofiler_adapter_extra  # type: ignore
+    log_extra = log_record.extra  # type: ignore  # our logging adapter adds "extra"
     assert log_extra["jvm_version"] == repr(jvm_version)
 
 
@@ -561,11 +561,11 @@ def test_java_jattach_async_profiler_log_output(
         assert len(log_records) == 2  # start,stop
         # start
         assert (
-            log_records[0].gprofiler_adapter_extra["ap_log"]  # type: ignore
+            log_records[0].extra["ap_log"]  # type: ignore  # our logging adapter adds "extra"
             == "[WARN] Install JVM debug symbols to improve profile accuracy\n"
         )
         # stop
-        assert log_records[1].gprofiler_adapter_extra["ap_log"] == ""  # type: ignore
+        assert log_records[1].extra["ap_log"] == ""  # type: ignore  # our logging adapter adds "extra"
 
 
 @pytest.mark.parametrize(
@@ -634,7 +634,7 @@ def test_java_different_basename(
                 )
                 assert len(log_records) == 1
                 assert (
-                    os.path.basename(log_records[0].gprofiler_adapter_extra["exe"])  # type: ignore
+                    os.path.basename(log_records[0].extra["exe"])  # type: ignore  # our logging adapter adds "extra"
                     == java_notjava_basename
                 )
 


### PR DESCRIPTION
## Description

Closes: https://github.com/Granulate/gprofiler/issues/525

I didn't support this feature in A/B mode as suggested in the ticket, it's much changes than I expected and it'll be hard to maintain both infras in the code.

Some changes I did as part of it:
* state `run_id` and `cycle_id` are no longer added in logging level, then omitted in local logger - I add them in glogger level.

TODOs:
* [x] Call the handler.close() method of glogger - is it needed to ensure all logs are sent back? Or does glogger have some kind of finalization?

## How Has This Been Tested?

* [x] `NO_SERVER_LOG_KEY` doesn't send the message to the server.
* [x] `NO_SERVER_EXTRA_KEY` doesn't send `extra`s to the server.
* [x] `NO_SERVER_LOG_KEY` and `NO_SERVER_EXTRA_KEY` are not sent to server / printed locally.
* [x] plain messages are logged locally
* [x] plain messages marked with `NO_SERVER_LOG_KEY` are logged locally
* [x] messages with extras are logged locally with the extras.
* [x] messages with extras marked with `NO_SERVER_EXTRA_KEY` are logged locally with the extras.
* [x] messages with traceback logged locally with traceback
* [x] messages with traceback logged remotely with traceback
* [x] `cycle_id` passes to the backend properly
* [x] changing `--glogger-server` works
