### PR TITLE
Add "profiling_mode" to metadata outside of metadata_collector

### DIFF
--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -301,6 +301,7 @@ class GProfiler:
             if self._collect_metadata
             else {"hostname": get_hostname()}
         )
+        metadata.update({"profiling_mode": self._profiling_mode})
         metrics = self._system_metrics_monitor.get_metrics()
         if NoopProfiler.is_noop_profiler(self.system_profiler):
             assert system_result == {}, system_result  # should be empty!

--- a/gprofiler/metadata/metadata_collector.py
+++ b/gprofiler/metadata/metadata_collector.py
@@ -1,5 +1,4 @@
 import datetime
-from typing import cast
 
 from granulate_utils.metadata import Metadata
 from granulate_utils.metadata.cloud import get_static_cloud_instance_metadata
@@ -33,8 +32,4 @@ def get_current_metadata(static_metadata: Metadata) -> Metadata:
     current_time = datetime.datetime.utcnow().replace(microsecond=0).isoformat()
     dynamic_metadata = static_metadata
     dynamic_metadata.update({"current_time": current_time})
-    # For now, just use the profiling mode provided in the args.
-    profiling_mode = cast(UserArgs, static_metadata["run_arguments"])["profiling_mode"]
-    assert profiling_mode is not None
-    dynamic_metadata.update({"profiling_mode": profiling_mode})
     return dynamic_metadata


### PR DESCRIPTION
metadata_collector isn't used if --disable-metadata, but we need profiling_mode in all cases.

If you run with `--disable-metadata` without this branch, you'll get:
```
[2022-12-16 23:47:16,222] ERROR: gprofiler: Unexpected error occurred                                                                                                                         
Traceback (most recent call last):                                                                                                                                                            
  File "/app/gprofiler/main.py", line 993, in main                                                                                                                                            
    gprofiler.run_single()                                                                                                                                                                    
  File "/app/gprofiler/main.py", line 364, in run_single                                                                                                                                      
    self._snapshot()                                                                                                                                                                          
  File "/app/gprofiler/main.py", line 307, in _snapshot                                                                                                                                       
    merged_result = concatenate_profiles(                                                                                                                                                     
  File "/app/gprofiler/merge.py", line 402, in concatenate_profiles                                                                                                                           
    _make_profile_metadata(                                                                                                                                                                     File "/app/gprofiler/merge.py", line 263, in _make_profile_metadata                                                                                                                             "profiling_mode": metadata["profiling_mode"],                                                                                                                                             KeyError: 'profiling_mode'   
```