### PR TITLE
Don't try getting container name for PIDs 0 / -1

### DIFF
--- a/gprofiler/containers_client.py
+++ b/gprofiler/containers_client.py
@@ -10,6 +10,7 @@ from granulate_utils.linux.containers import get_process_container_id
 from psutil import NoSuchProcess, Process
 
 from gprofiler.log import get_logger_adapter
+from gprofiler.utils.perf import valid_perf_pid
 
 logger = get_logger_adapter(__name__)
 
@@ -42,6 +43,9 @@ class ContainerNamesClient:
 
     def get_container_name(self, pid: int) -> str:
         if self._containers_client is None:
+            return ""
+
+        if not valid_perf_pid(pid):
             return ""
 
         if pid in self._pid_to_container_name_cache:

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -27,7 +27,7 @@ from gprofiler.profilers.node import clean_up_node_maps, generate_map_for_node_p
 from gprofiler.profilers.profiler_base import ProfilerBase
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
 from gprofiler.utils import run_process, start_process, wait_event, wait_for_file_by_prefix
-from gprofiler.utils.perf import perf_path
+from gprofiler.utils.perf import perf_path, valid_perf_pid
 
 logger = get_logger_adapter(__name__)
 
@@ -259,7 +259,7 @@ class SystemProfiler(ProfilerBase):
             perf.stop()
 
     def _get_metadata(self, pid: int) -> Optional[AppMetadata]:
-        if pid in (0, -1):  # funny values retrieved by perf
+        if not valid_perf_pid(pid):
             return None
 
         try:

--- a/gprofiler/utils/perf.py
+++ b/gprofiler/utils/perf.py
@@ -37,3 +37,11 @@ def can_i_use_perf_events() -> bool:
     else:
         # all good
         return True
+
+
+def valid_perf_pid(pid: int) -> bool:
+    """
+    perf, in some cases, reports PID 0 / -1. These are not real PIDs and we don't want to
+    try and look up the processes related to them.
+    """
+    return pid not in (0, -1)


### PR DESCRIPTION
Fixes:
```
granulate-gprofiler  | [15:55:20] Could not get a container name for PID -1
granulate-gprofiler  | Traceback (most recent call last):
granulate-gprofiler  |   File "/app/gprofiler/containers_client.py", line 61, in _safely_get_process_container_name
granulate-gprofiler  |     container_id = get_process_container_id(Process(pid))
granulate-gprofiler  |   File "/usr/local/lib/python3.8/dist-packages/psutil/__init__.py", line 326, in __init__
granulate-gprofiler  |     self._init(pid)
granulate-gprofiler  |   File "/usr/local/lib/python3.8/dist-packages/psutil/__init__.py", line 335, in _init
granulate-gprofiler  |     raise ValueError('pid must be a positive integer (got %s)'
granulate-gprofiler  | ValueError: pid must be a positive integer (got -1)
```