### PR TITLE
utils: run_process(): Don't try writing stdin more than once

### DIFF
--- a/gprofiler/utils/__init__.py
+++ b/gprofiler/utils/__init__.py
@@ -233,12 +233,14 @@ def run_process(
     reraise_exc: Optional[BaseException] = None
     with start_process(cmd, via_staticx, **kwargs) as process:
         try:
-            communicate_kwargs = dict(input=stdin) if stdin is not None else {}
+            if stdin is not None:
+                assert process.stdin is not None
+                process.stdin.write(stdin)
             if stop_event is None:
                 assert timeout is None, f"expected no timeout, got {timeout!r}"
                 if communicate:
                     # wait for stderr & stdout to be closed
-                    stdout, stderr = process.communicate(timeout=timeout, **communicate_kwargs)
+                    stdout, stderr = process.communicate()
                 else:
                     # just wait for the process to exit
                     process.wait()
@@ -247,7 +249,7 @@ def run_process(
                 while True:
                     try:
                         if communicate:
-                            stdout, stderr = process.communicate(timeout=1, **communicate_kwargs)
+                            stdout, stderr = process.communicate(timeout=1)
                         else:
                             process.wait(timeout=1)
                         break


### PR DESCRIPTION
Fixes:
```
[2023-01-04 18:16:52,954] ERROR: gprofiler: Profiling run failed!
Traceback (most recent call last):
  File "/app/gprofiler/main.py", line 361, in run_continuous
    self._snapshot()
  File "/app/gprofiler/main.py", line 327, in _snapshot
    self._generate_output_files(merged_result, local_start_time, local_end_time)
  File "/app/gprofiler/main.py", line 213, in _generate_output_files
    run_process(
  File "/app/gprofiler/utils/__init__.py", line 279, in run_process
    raise reraise_exc
  File "/app/gprofiler/utils/__init__.py", line 250, in run_process
    stdout, stderr = process.communicate(timeout=0.001, **communicate_kwargs)
  File "/usr/lib/python3.8/subprocess.py", line 1003, in communicate
    raise ValueError("Cannot send input after starting communication")
ValueError: Cannot send input after starting communication
```

It's fairly rare as it'll happen only if `burn` takes more than 1s... but reproduces in some cases.