### PR TITLE
python: Add missing NoSuchProcess catch

### DIFF
--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -261,6 +261,8 @@ class PySpyProfiler(SpawningProcessProfilerBase):
             try:
                 if not self._should_skip_process(process):
                     filtered_procs.append(process)
+            except NoSuchProcess:
+                pass
             except Exception:
                 logger.exception(f"Couldn't add pid {process.pid} to list")
 


### PR DESCRIPTION
Fixes:
```
Traceback (most recent call last):
File "psutil/_pslinux.py", line 1576, in wrapper
File "psutil/_pslinux.py", line 1696, in cmdline
File "psutil/_common.py", line 725, in open_text
FileNotFoundError: [Errno 2] No such file or directory: '/proc/17961/cmdline'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
File "gprofiler/profilers/python.py", line 262, in _select_processes_to_profile
File "gprofiler/profilers/python.py", line 278, in _should_skip_process
File "psutil/__init__.py", line 677, in cmdline
File "psutil/_pslinux.py", line 1583, in wrapper
psutil.NoSuchProcess: psutil.NoSuchProcess process no longer exists (pid=17961)
```