### PR TITLE
Truncate stdio in CalledProcessError

### DIFF
--- a/gprofiler/exceptions.py
+++ b/gprofiler/exceptions.py
@@ -16,6 +16,14 @@ class ProcessStoppedException(Exception):
 
 
 class CalledProcessError(subprocess.CalledProcessError):
+    # Enough characters for 200 long lines
+    MAX_STDIO_LENGTH = 120 * 200
+
+    def _truncate_stdio(self, string: str) -> str:
+        if len(string) > self.MAX_STDIO_LENGTH:
+            string = string[: self.MAX_STDIO_LENGTH - 3] + "..."
+        return string
+
     def __str__(self) -> str:
         if self.returncode and self.returncode < 0:
             try:
@@ -24,7 +32,7 @@ class CalledProcessError(subprocess.CalledProcessError):
                 base = f"Command {self.cmd!r} died with unknown signal {-self.returncode}."
         else:
             base = f"Command {self.cmd!r} returned non-zero exit status {self.returncode}."
-        return f"{base}\nstdout: {self.stdout}\nstderr: {self.stderr}"
+        return f"{base}\nstdout: {self._truncate_stdio(self.stdout)}\nstderr: {self._truncate_stdio(self.stderr)}"
 
 
 class CalledProcessTimeoutError(CalledProcessError):


### PR DESCRIPTION
gProfiler gave me a super long log that killed my terminal, started with this:
<details>
<summary>Log</summary>
```
granulate-gprofiler  | [10:50:36] Running perf failed; consider running gProfiler with '--perf-mode disabled' to avoid using perf
granulate-gprofiler  | Traceback (most recent call last):
granulate-gprofiler  |   File "/app/gprofiler/main.py", line 292, in _snapshot
granulate-gprofiler  |     system_result = system_future.result()
granulate-gprofiler  |   File "/usr/lib/python3.8/concurrent/futures/_base.py", line 437, in result
granulate-gprofiler  |     return self.__get_result()
granulate-gprofiler  |   File "/usr/lib/python3.8/concurrent/futures/_base.py", line 389, in __get_result
granulate-gprofiler  |     raise self._exception
granulate-gprofiler  |   File "/usr/lib/python3.8/concurrent/futures/thread.py", line 57, in run
granulate-gprofiler  |     result = self.fn(*self.args, **self.kwargs)
granulate-gprofiler  |   File "/app/gprofiler/profilers/perf.py", line 298, in snapshot
granulate-gprofiler  |     self._perf_fp.wait_and_script() if self._perf_fp is not None else None,
granulate-gprofiler  |   File "/app/gprofiler/profilers/perf.py", line 147, in wait_and_script
granulate-gprofiler  |     perf_script_proc = run_process(
granulate-gprofiler  |   File "/app/gprofiler/utils/__init__.py", line 281, in run_process
granulate-gprofiler  |     raise CalledProcessError(retcode, process.args, output=stdout, stderr=stderr)
granulate-gprofiler  | gprofiler.exceptions.CalledProcessError: Command ['/app/gprofiler/resources/perf', 'script', '-F', '+pid', '-i', '/tmp/gprofiler_tmp/tmpf6straye/perf.fp.2023010510494447'] returned non-zero exit status 242.
granulate-gprofiler  | stdout: b'swapper     0/0     [000] 66298.216189:   10000000 cpu-clock:pppH: \n\tffffffffa87bc31b native_safe_halt+0xb ([kernel.kallsyms])\n\tffffffffa87bc970 acpi_idle_enter+0xc0 ([kernel.kallsyms])\n\tffffffffa84890ca cpuidle_enter_state+0x9a ([kernel.kallsyms])\n\tffffffffa848969e cpuidle_enter+0x2e ([kernel.kallsyms])\n\tffffffffa7b08d93 call_cpuidle+0x23 ([kernel.kallsyms])\n\tffffffffa7b08fd6 cpuidle_idle_call+0x106 ([kernel.kallsyms])\n\tffffffffa7b090a3 do_idle+0x83 ([kernel.kallsyms])\n\tffffffffa7b092d0 cpu_startup_entry+0x20 ([kernel.kallsyms])\n\tffffffffa87ae4b3 rest_init+0xd3 ([kernel.kallsyms])\n\tffffffffa9c99798 arch_call_rest_init+0xe ([kernel.kallsyms])\n\tffffffffa9c99c83 start_kernel+0x4a9 ([kernel.kallsyms])\n\tffffffffa9c9862d x86_64_start_reservations+0x24 ([kernel.kallsyms])\n\tffffffffa9c9872e x86_64_start_kernel+0xfb ([kernel.kallsyms])\n\tffffffffa7a00107 secondary_startup_64_no_verify+0xc2 ([kernel.kallsyms])\n\nperf 1794247/1794247 [001] 66298.216195:   10000000 cpu-clock:pppH: \n\tffffffffa7db34d3 __fget_files+0x53 ([kernel.kallsyms])\n\tffffffffa7db3612 __fget_light+0x32 ([kernel.kallsyms])\n\tffffffffa7db4b97 __fdget_pos+0x17 ([kernel.kallsyms])\n\tffffffffa7d8d3ae ksys_write+0x2e ([kernel.kallsyms])\n\tffffffffa7d8d489 __x64_sys_write+0x19 ([kernel.kallsyms])\n\tffffffffa87a9dfc do_syscall_64+0x5c ([kernel.kallsyms])\n\tffffffffa8800099 entry_SYSCALL_64_after_hwframe+0x61 ([kernel.kallsyms])\n\t          24d461 [unknown] (/app/gprofiler/resources/perf)\n\t           2045c process_synthesized_event+0x3c (/app/gprofiler/resources/perf)\n\t          16126b perf_tool__process_synth_event+0x8b (/app/gprofiler/resources/perf)\n\t          163957 perf_event__synthesize_modules+0x1e7 (/app/gprofiler/resources/perf)\n\t            16e8 record__synthesize.constprop.55+0x16d (/app/gprofiler/resources/perf)\n\t            1a66 record__switch_output.constprop.54+0x1b7 (/app/gprofiler/resources/perf)\n\t            35e9 __cmd_record.constprop.49+0x1b17 (/app/gprofiler/resources/perf)\n\t           21d74 cmd_record+0xd24 (/app/gprofiler/resources/perf)\n\t           a9eb9 run_builtin+0x69 (/app/gprofiler/resources/perf)\n\t            837d main+0x5dd (/app/gprofiler/resources/perf)\n\t          470076 generic_start_main+0x246 (/app/gprofiler/resources/perf)\n\t          4c5210 __strncasecmp_avx+0x0 (/app/gprofiler/resources/perf)\n\t     1c0830f0000 [unknown] ([unknown])\n\npython 1792049/1792117 [002] 66298.216198:   10000000 cpu-clock:pppH: \n\t            4430 [unknown] (/lib/x86_64-linux-gnu/libz.so.1.2.11)\n\nswapper     0/0     [003] 66298.216246:   10000000 cpu-clock:pppH: \n\tffffffffa87bc31b native_safe_halt+0xb ([kernel.kallsyms])\n\tffffffffa87bc970 acpi_idle_enter+0xc0 ([kernel.kallsyms])\n\tffffffffa84890ca cpuidle_enter_state+0x9a ([kernel.kallsyms])\n\tffffffffa848969e cpuidle_enter+0x2e ([kernel.kallsyms])\n\tffffffffa7b08d93 call_cpuidle+0x23 ([kernel.kallsyms])\n\tffffffffa7b08fd6 cpuidle_idle_call+0x106 ([kernel.kallsyms])\n\tffffffffa7b090a3 do_idle+0x83 ([kernel.kallsyms])\n\tffffffffa7b092d0 cpu_startup_entry+0x20 ([kernel.kallsyms])\n\tffffffffa7a7e9da start_secondary+0x12a ([kernel.kallsyms])\n\tffffffffa7a00107 secondary_startup_64_no_verify+0xc2 ([kernel.kallsyms])\n\nlocust 1792042/1792042 [000] 66298.226183:   10000000 cpu-clock:pppH: \n\t          144d16 _PyEval_EvalFrameDefault+0x3a6 (/usr/local/lib/libpython3.10.so.1.0)\n\t    7f021e660900 [unknown] ([unknown])\n\nperf 1794225/1794225 [001] 66298.226196:   10000000 cpu-clock:pppH: \n\tffffffffa87ae2a8 memcpy_erms+0x8 ([kernel.kallsyms])\n\tffffffffa7dbe661 seq_printf+0x91 ([kernel.kallsyms])\n\tffffffffa7b96e74 s_show+0x84 ([kernel.kallsyms])\n\tffffffffa7dbec78 seq_read_iter+0x2c8 ([kernel.kallsyms])\n\tffffffffa7dbef52 seq_read+0xf2 ([kernel.kallsyms])\n\tffffffffa7e41ffe proc_reg_read+0x5e ([kernel.kallsyms])\n\tffffffffa7d8a77f vfs_read+0x9f ([kernel.kallsyms])\n\tffffffffa7d8d2b7 ksys_read+0x67 ([kernel.kallsyms])\n\tffffffffa7d8d359 __x64_sys_read+0x19 ([kernel.kallsyms])\n\tffffffffa87a9dfc do_syscall_64+0x5c ([kernel.kallsyms])\n\tffffffffa8800099 entry_SYSCALL_64_after_hwframe+0x61 ([kernel.kallsyms])\n\t          24d4c1 [unknown] (/app/gprofiler/resources/perf)\n\t          1c2cd2 perf_event__synthesize_bpf_events+0x4f2 (/app/gprofiler/resources/perf)\n\t            17cb record__synthesize.constprop.55+0x250 (/app/gprofiler/resources/perf)\n\t            1a66 record__switch_output.constprop.54+0x1b7 (/app/gprofiler/resources/perf)\n\t            35e9 __cmd_record.constprop.49+0x1b17 (/app/gprofiler/resources/perf)\n\t           21d74 cmd_record+0xd24 (/app/gprofiler/resources/perf)\n\t           a9eb9 run_builtin+0x69 (/app/gprofiler/resources/perf)\n\t            837d main+0x5dd (/app/gprofiler/resources/perf)\n\t          470076 generic_start_main+0x246 (/app/gprofiler/resources/perf)\n\t          4c5210 __strncasecmp_avx+0x0 (/app/gprofiler/resources/perf)\n\t
```
</details>

So this PR adds truncation to the stdout and stderr to the `__str__` of this exception type.