### PR TITLE
java-ap: remove semicolon patch

### DIFF
--- a/scripts/async_profiler_build_shared.sh
+++ b/scripts/async_profiler_build_shared.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 VERSION=v2.9g5
 GIT_REV="60cbc128a752c657e8a97300784686e08c8dbe9d"
 
-git clone --depth 1 -b "$VERSION" https://github.com/granulate/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
+git clone --depth 1 -b "$VERSION" https://github.com/Granulate/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
 make all
 
 # add a version file to the build directory

--- a/scripts/async_profiler_build_shared.sh
+++ b/scripts/async_profiler_build_shared.sh
@@ -5,10 +5,10 @@
 #
 set -euo pipefail
 
-VERSION=v2.9g4
-GIT_REV="cde6aead3f8c30ccc79eaa3a44f36ed97b8ebc91"
+VERSION=remove-our-semicolon-patch
+GIT_REV="f9d5b861eb0b0bb2e0a8e2b4ed7bf6ca13a41d63"
 
-git clone --depth 1 -b "$VERSION" https://github.com/Granulate/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
+git clone --depth 1 -b "$VERSION" https://github.com/marcin-ol/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
 make all
 
 # add a version file to the build directory

--- a/scripts/async_profiler_build_shared.sh
+++ b/scripts/async_profiler_build_shared.sh
@@ -5,10 +5,10 @@
 #
 set -euo pipefail
 
-VERSION=remove-our-semicolon-patch
-GIT_REV="f9d5b861eb0b0bb2e0a8e2b4ed7bf6ca13a41d63"
+VERSION=v2.9g5
+GIT_REV="60cbc128a752c657e8a97300784686e08c8dbe9d"
 
-git clone --depth 1 -b "$VERSION" https://github.com/marcin-ol/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
+git clone --depth 1 -b "$VERSION" https://github.com/granulate/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
 make all
 
 # add a version file to the build directory

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -705,4 +705,5 @@ def test_java_frames_include_no_semicolons(
     ) as profiler:
         collapsed = snapshot_pid_profile(profiler, application_pid).stacks
         assert is_function_in_collapsed(".main([Ljava/lang/String|)", collapsed)
+        assert not is_function_in_collapsed(";_[j];", collapsed)
         assert not is_pattern_in_collapsed(r"\([^);]+[;][^)]*\)", collapsed)

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -715,4 +715,6 @@ def test_java_frames_include_no_semicolons(
         # no semicolon in return type:
         assert not is_function_in_collapsed(";_[j];", collapsed)
         # no semicolon in arguments list signatures:
-        assert not is_pattern_in_collapsed(r"\([^);]+[;][^)]*\)", collapsed)
+        assert not is_pattern_in_collapsed(r"\([^);]+;[^)]*\)", collapsed)
+        # only a pipe can occur within arguments
+        assert is_pattern_in_collapsed(r"\([^);|]+\|[^)]*\)", collapsed)

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -691,3 +691,18 @@ def test_meminfo_logged(
     ) as profiler:
         snapshot_pid_profile(profiler, application_pid)
         assert "async-profiler memory usage (in bytes)" in caplog.text
+
+
+@pytest.mark.parametrize("in_container", [True])
+def test_java_frames_include_no_semicolons(
+    tmp_path: Path,
+    application_pid: int,
+) -> None:
+    with make_java_profiler(
+        storage_dir=str(tmp_path),
+        duration=3,
+        frequency=999,
+    ) as profiler:
+        collapsed = snapshot_pid_profile(profiler, application_pid).stacks
+        assert is_function_in_collapsed(".main([Ljava/lang/String|)", collapsed)
+        assert not is_pattern_in_collapsed(r"\([^);]+[;][^)]*\)", collapsed)


### PR DESCRIPTION

## Description
Removing local workaround for semicolons in frame names; upstream already handles this.
- Integrate with Granulate/async-profiler#4.
- Add test that verifies the java frames from async profiler include no semicolon `';'`.

## Related Issue
#648 

## Motivation and Context
- the less changes to upstream AP, the better.

## How Has This Been Tested?
Testcase added in `test_java.py` testsuite.
