### PR TITLE
Add test for zero stray output from java async-proviler

### DIFF
--- a/scripts/async_profiler_build_shared.sh
+++ b/scripts/async_profiler_build_shared.sh
@@ -5,10 +5,10 @@
 #
 set -euo pipefail
 
-VERSION=trigger-failure-for-zero-stray-output-test
-GIT_REV="623637b593282cc7fe5a07b85d35c00bc6c245d1"
+VERSION=v2.9g5
+GIT_REV="60cbc128a752c657e8a97300784686e08c8dbe9d"
 
-git clone --depth 1 -b "$VERSION" https://github.com/marcin-ol/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
+git clone --depth 1 -b "$VERSION" https://github.com/Granulate/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
 make all
 
 # add a version file to the build directory

--- a/scripts/async_profiler_build_shared.sh
+++ b/scripts/async_profiler_build_shared.sh
@@ -5,8 +5,8 @@
 #
 set -euo pipefail
 
-VERSION=v2.9g5
-GIT_REV="60cbc128a752c657e8a97300784686e08c8dbe9d"
+VERSION=trigger-failure-for-zero-stray-output-test
+GIT_REV="623637b593282cc7fe5a07b85d35c00bc6c245d1"
 
 git clone --depth 1 -b "$VERSION" https://github.com/Granulate/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
 make all

--- a/scripts/async_profiler_build_shared.sh
+++ b/scripts/async_profiler_build_shared.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 VERSION=trigger-failure-for-zero-stray-output-test
 GIT_REV="623637b593282cc7fe5a07b85d35c00bc6c245d1"
 
-git clone --depth 1 -b "$VERSION" https://github.com/Granulate/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
+git clone --depth 1 -b "$VERSION" https://github.com/marcin-ol/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
 make all
 
 # add a version file to the build directory

--- a/tests/containers/java/Fibonacci.java
+++ b/tests/containers/java/Fibonacci.java
@@ -10,6 +10,7 @@ public class Fibonacci {
     }
 
     public static void main(final String[] args) {
+        System.out.println("Fibonacci thread starting");
         Thread thread = new Thread() {
             public void run() {
                 while (true) {
@@ -21,7 +22,7 @@ public class Fibonacci {
             }
         };
         thread.start();
-
+        System.err.println("Fibonacci loop starting");
         while (true) {
             fibonacci(30);
         }

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -25,6 +25,7 @@ from granulate_utils.java import parse_jvm_version
 from granulate_utils.linux.ns import get_process_nspid
 from granulate_utils.linux.process import is_musl
 from packaging.version import Version
+from psutil import Process
 from pytest import LogCaptureFixture, MonkeyPatch
 
 from gprofiler.profilers.java import (
@@ -80,6 +81,19 @@ class AsyncProfiledProcessForTests(AsyncProfiledProcess):
         self._run_async_profiler(
             self._get_base_cmd() + [f"status,log={self._log_path_process},file={self._output_path_process}"],
         )
+
+    def read_ap_version(self: AsyncProfiledProcess) -> str:
+        # call async-profiler 'version' action to discover its version number
+        # read output from AsyncProfiledProcess, which should be empty
+        output_without_version = cast_away_optional(self.read_output())
+        assert output_without_version == ""
+        self._run_async_profiler(
+            self._get_base_cmd() + [f"version" f"{self._get_ap_output_args()}" f",log={self._log_path_process}"]
+        )
+        # async-profiler emits version number compiled into itself
+        output_with_version = cast_away_optional(self.read_output())
+        version = output_with_version.strip()
+        return version
 
 
 def test_async_profiler_already_running(
@@ -753,13 +767,24 @@ def test_no_stray_output_in_stdout_stderr(
         duration=3,
         frequency=999,
     ) as profiler:
+        # read ap-version from test ap-process to match the proper output against it
+        with AsyncProfiledProcessForTests(
+            process=Process(application_pid),
+            storage_dir=profiler._storage_dir,
+            insert_dso_name=False,
+            stop_event=profiler._stop_event,
+            mode="itimer",
+            ap_safemode=0,
+            ap_args="",
+        ) as ap_proc:
+            ap_version = ap_proc.read_ap_version()
         collapsed = snapshot_pid_collapsed(profiler, application_pid)
         assert_collapsed(collapsed)
     application_docker_container.stop(timeout=3)
     application_docker_container.wait(timeout=3)
     textout = application_docker_container.logs(stdout=True, stderr=False).decode()
     texterr = application_docker_container.logs(stdout=False, stderr=True).decode()
-    # output from Fibonacci should be the only output in stdout
-    assert textout.strip() == "Fibonacci thread starting"
+    # output from Fibonacci and async-profiler version should be the only lines  in stdout
+    assert textout.splitlines() == ["Fibonacci thread starting", ap_version]
     # output from Fibonacci should be the only expected output in stderr
     assert texterr.strip() == "Fibonacci loop starting"

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -736,14 +736,12 @@ def test_java_frames_include_no_semicolons(
 
 # test that async profiler doesn't print anything to applications stdout, stderr streams
 @pytest.mark.parametrize("in_container", [True])
-@pytest.mark.parametrize("flush_ap_output", [False, True])
 def test_no_stray_output_in_stdout_stderr(
     tmp_path: Path,
     application_pid: int,
     application_docker_container: Container,
     monkeypatch: MonkeyPatch,
     assert_collapsed: AssertInCollapsed,
-    flush_ap_output: bool,
 ) -> None:
     # save original stop function
     stop_async_profiler = AsyncProfiledProcess.stop_async_profiler
@@ -759,8 +757,7 @@ def test_no_stray_output_in_stdout_stderr(
         result = stop_async_profiler(self, *args, **kwargs)
         return result
 
-    if flush_ap_output:
-        monkeypatch.setattr(AsyncProfiledProcess, "stop_async_profiler", flush_output_and_stop_async_profiler)
+    monkeypatch.setattr(AsyncProfiledProcess, "stop_async_profiler", flush_output_and_stop_async_profiler)
 
     with make_java_profiler(
         storage_dir=str(tmp_path),

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -736,7 +736,9 @@ def test_no_stray_output_in_stdout_stderr(
 
     # replace async profiler stop routine to trigger flushing standard output
     def flush_output_and_stop_async_profiler(self: AsyncProfiledProcess, *args: Any, **kwargs: Any) -> str:
-        # Call 'version' action on async-profiler to make sure writes to stdout are flushed
+        # Call 'version' action on async-profiler to make sure writes to stdout are flushed. Handling of 'version'
+        # action involves calling flush on output stream:
+        # (https://github.com/Granulate/async-profiler/blob/58c62fe4e816b60907ca84e315936834fc1cbae4/src/profiler.cpp#L1548)
         self._run_async_profiler(
             self._get_base_cmd() + [f"version" f",log={self._log_path_process}"],
         )
@@ -753,8 +755,8 @@ def test_no_stray_output_in_stdout_stderr(
     ) as profiler:
         collapsed = snapshot_pid_collapsed(profiler, application_pid)
         assert_collapsed(collapsed)
-        application_docker_container.stop(timeout=3)
-        application_docker_container.wait(timeout=3)
+    application_docker_container.stop(timeout=3)
+    application_docker_container.wait(timeout=3)
     textout = application_docker_container.logs(stdout=True, stderr=False).decode()
     texterr = application_docker_container.logs(stdout=False, stderr=True).decode()
     # output from Fibonacci should be the only output in stdout


### PR DESCRIPTION
## Description
Make sure that async-profiler generates no output to profiled process stdout/ stderr streams.

## Related Issue
#649 

## Motivation and Context
We don't need any output from async-profiler to appear in profiled process output streams. We don't need it and want to avoid it.  
Recently few commits were merged which removed some print statements reaching process outputs.

## How Has This Been Tested?
Testcase was added to `test_java` testsuite.
