### PR TITLE
java: Gracefully handle exited Java process upon JattachException

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -143,13 +143,13 @@ class JattachExceptionBase(CalledProcessError):
         super().__init__(returncode, cmd, stdout, stderr)
         self._target_pid = target_pid
         self._ap_log = ap_log
-        self.ap_loaded = ap_loaded
+        self._ap_loaded = ap_loaded
 
     def __str__(self) -> str:
         ap_log = self._ap_log.strip()
         if not ap_log:
             ap_log = "(empty)"
-        loaded_msg = f"async-profiler DSO loaded: {self.ap_loaded}"
+        loaded_msg = f"async-profiler DSO loaded: {self._ap_loaded}"
         return super().__str__() + f"\nJava PID: {self._target_pid}\n{loaded_msg}\nasync-profiler log:\n{ap_log}"
 
     def get_ap_log(self) -> str:
@@ -157,7 +157,7 @@ class JattachExceptionBase(CalledProcessError):
 
     @property
     def is_ap_loaded(self) -> bool:
-        return self.ap_loaded == "yes"
+        return self._ap_loaded == "yes"
 
 
 class JattachException(JattachExceptionBase):


### PR DESCRIPTION
Fixes this stacktrace:
```
Traceback (most recent call last):
File "gprofiler/profilers/java.py", line 518, in _run_async_profiler
File "gprofiler/utils/__init__.py", line 283, in run_process
gprofiler.exceptions.CalledProcessError: Command ['/opt/granulate/gprofiler/_MEInirGjV/gprofiler/resources/java/jattach', '149163', 'load', '/tmp/gprofiler_tmp/async-profiler-v2.9g4/glibc/libasyncProfiler.so', 'true', 'start,event=cpu,file=/tmp/gprofiler_tmp/tmpyevcrgni/async-profiler-149163.output,collapsed,ann,sig,interval=90909090,log=/tmp/gprofiler_tmp/tmpyevcrgni/async-profiler-149163.log,fdtransfer=@async-profiler-149163-35b4584d1aa63cffe42e,safemode=127,timeout=90'] returned non-zero exit status 1.
stdout: b'Connected to remote JVM
'
stderr: b'Unexpected EOF reading response
'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
File "gprofiler/profilers/profiler_base.py", line 136, in _wait_for_profiles
File "concurrent/futures/_base.py", line 451, in result
File "concurrent/futures/_base.py", line 403, in __get_result
File "concurrent/futures/thread.py", line 58, in run
File "gprofiler/profilers/java.py", line 945, in _profile_process
File "gprofiler/profilers/java.py", line 967, in _profile_ap_process
File "gprofiler/profilers/java.py", line 561, in start_async_profiler
File "gprofiler/profilers/java.py", line 521, in _run_async_profiler
File "pathlib.py", line 1134, in read_text
File "pathlib.py", line 1119, in open
FileNotFoundError: [Errno 2] No such file or directory: '/proc/149163/maps'
```

Instead of the `FileNotFoundError`, what I'd want to see is the Jattach*Exception` error with the piece of information that "we're not sure if AP was already loaded".