### PR TITLE
perf: Cleanups & robustness improvements

### DIFF
--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -293,7 +293,6 @@ class GProfiler:
         except Exception:
             logger.critical(
                 "Running perf failed; consider running gProfiler with '--perf-mode disabled' to avoid using perf",
-                exc_info=True,
             )
             raise
         metadata = (

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -26,7 +26,7 @@ from gprofiler.metadata.application_metadata import ApplicationMetadata
 from gprofiler.profilers.node import clean_up_node_maps, generate_map_for_node_processes, get_node_processes
 from gprofiler.profilers.profiler_base import ProfilerBase
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
-from gprofiler.utils import run_process, start_process, wait_event, wait_for_file_by_prefix
+from gprofiler.utils import remove_path, run_process, start_process, wait_event, wait_for_file_by_prefix
 from gprofiler.utils.perf import perf_path, valid_perf_pid
 
 logger = get_logger_adapter(__name__)
@@ -62,6 +62,10 @@ class PerfProcess:
         self._extra_args = extra_args + (["-k", "1"] if self._inject_jit else [])
         self._process: Optional[Popen] = None
 
+    @property
+    def _log_name(self) -> str:
+        return f"perf ({self._type} mode)"
+
     def _get_perf_cmd(self) -> List[str]:
         return [
             perf_path(),
@@ -81,18 +85,10 @@ class PerfProcess:
             str(self._mmap_sizes[self._type]),
         ] + self._extra_args
 
-    def check_if_needs_restart(self) -> None:
-        """Checks if perf used memory exceeds threshold, and if it does, restarts perf"""
-        assert self._process is not None
-        if (
-            time.monotonic() - self._start_time >= self._restart_after_s
-            and Process(self._process.pid).memory_info().rss >= self._perf_memory_usage_threshold
-        ):
-            self.stop()
-            self.start()
-
     def start(self) -> None:
-        logger.info(f"Starting perf ({self._type} mode)")
+        logger.info(f"Starting {self._log_name}")
+        # remove old files, should they exist from previous runs
+        remove_path(self._output_path, missing_ok=True)
         process = start_process(self._get_perf_cmd(), via_staticx=False)
         try:
             wait_event(self._poll_timeout_s, self._stop_event, lambda: os.path.exists(self._output_path))
@@ -100,20 +96,55 @@ class PerfProcess:
         except TimeoutError:
             process.kill()
             assert process.stdout is not None and process.stderr is not None
-            logger.critical(f"perf failed to start. stdout {process.stdout.read()!r} stderr {process.stderr.read()!r}")
+            logger.critical(
+                f"{self._log_name} failed to start", stdout=process.stdout.read(), stderr=process.stderr.read()
+            )
             raise
         else:
             self._process = process
             os.set_blocking(self._process.stdout.fileno(), False)  # type: ignore
             os.set_blocking(self._process.stderr.fileno(), False)  # type: ignore
-            logger.info(f"Started perf ({self._type} mode)")
+            logger.info(f"Started {self._log_name}")
 
     def stop(self) -> None:
         if self._process is not None:
             self._process.terminate()  # okay to call even if process is already dead
-            self._process.wait()
+            exit_code = self._process.wait()
             self._process = None
-            logger.info(f"Stopped perf ({self._type} mode)")
+            logger.info(f"Stopped {self._log_name}", exit_code=exit_code)
+
+    def is_running(self) -> bool:
+        """
+        Is perf running? returns False if perf is stopped OR if process exited since last check
+        """
+        return self._process is not None and self._process.poll() is None
+
+    def restart(self) -> None:
+        self.stop()
+        self.start()
+
+    def restart_if_not_running(self) -> None:
+        """
+        Restarts perf if it was stopped for whatever reason.
+        """
+        if not self.is_running():
+            logger.warning(f"{self._log_name} not running (unexpectedly), restarting...")
+            self.restart()
+
+    def check_if_needs_memory_restart(self) -> None:
+        """Checks if perf used memory exceeds threshold, and if it does, restarts perf"""
+        assert self._process is not None
+        perf_rss = Process(self._process.pid).memory_info().rss
+        if (
+            time.monotonic() - self._start_time >= self._restart_after_s
+            and perf_rss >= self._perf_memory_usage_threshold
+        ):
+            logger.debug(
+                f"Restarting {self._log_name} due to memory exceeding limit",
+                limit_rss=self._perf_memory_usage_threshold,
+                perf_rss=perf_rss,
+            )
+            self.restart()
 
     def switch_output(self) -> None:
         assert self._process is not None, "profiling not started!"
@@ -125,8 +156,10 @@ class PerfProcess:
         except Exception:
             assert self._process is not None and self._process.stdout is not None and self._process.stderr is not None
             logger.critical(
-                f"perf failed to dump output. stdout {self._process.stdout.read()!r}"
-                f" stderr {self._process.stderr.read()!r}"
+                f"{self._log_name} failed to dump output",
+                perf_stdout=self._process.stdout.read(),
+                perf_stderr=self._process.stderr.read(),
+                perf_running=self.is_running(),
             )
             raise
         finally:
@@ -134,7 +167,7 @@ class PerfProcess:
             # using read1() which performs just a single read() call and doesn't read until EOF
             # (unlike Popen.communicate())
             assert self._process is not None and self._process.stderr is not None
-            logger.debug(f"perf stderr: {self._process.stderr.read1()}")  # type: ignore
+            logger.debug(f"{self._log_name} run output", perf_stderr=self._process.stderr.read1())  # type: ignore
 
         if self._inject_jit:
             inject_data = Path(f"{str(perf_data)}.inject")
@@ -171,10 +204,10 @@ class PerfProcess:
             dest="perf_dwarf_stack_size",
         ),
         ProfilerArgument(
-            "--perf-no-restart",
+            "--perf-no-memory-restart",
             help="Disable checking if perf used memory exceeds threshold and restarting perf",
             action="store_false",
-            dest="perf_restart",
+            dest="perf_memory_restart",
         ),
     ],
     disablement_help="Disable the global perf of processes,"
@@ -202,7 +235,7 @@ class SystemProfiler(ProfilerBase):
         perf_dwarf_stack_size: int,
         perf_inject: bool,
         perf_node_attach: bool,
-        perf_restart: bool,
+        perf_memory_restart: bool,
     ):
         super().__init__(frequency, duration, stop_event, storage_dir, insert_dso_name, profiling_mode)
         _ = profile_spawned_processes  # Required for mypy unused argument warning
@@ -211,7 +244,7 @@ class SystemProfiler(ProfilerBase):
         self._insert_dso_name = insert_dso_name
         self._node_processes: List[Process] = []
         self._node_processes_attached: List[Process] = []
-        self._perf_restart = perf_restart
+        self._perf_memory_restart = perf_memory_restart
 
         if perf_mode in ("fp", "smart"):
             self._perf_fp: Optional[PerfProcess] = PerfProcess(
@@ -286,6 +319,14 @@ class SystemProfiler(ProfilerBase):
             self._node_processes_attached.extend(generate_map_for_node_processes(new_processes))
             self._node_processes.extend(new_processes)
 
+        # if process is stopped for whatever reason - restart
+        for perf in self._perfs:
+            perf.restart_if_not_running()
+
+        if self._perf_memory_restart:
+            for perf in self._perfs:
+                perf.check_if_needs_memory_restart()
+
         if self._stop_event.wait(self._duration):
             raise StopEventSetException
 
@@ -300,10 +341,6 @@ class SystemProfiler(ProfilerBase):
                 self._insert_dso_name,
             ).items()
         }
-
-        if self._perf_restart:
-            for perf in self._perfs:
-                perf.check_if_needs_restart()
 
         return data
 

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -47,7 +47,7 @@ def test_nodejs_attach_maps(
         perf_inject=False,
         perf_dwarf_stack_size=0,
         perf_node_attach=True,
-        perf_restart=False,
+        perf_memory_restart=False,
     ) as profiler:
         process_collapsed = snapshot_pid_collapsed(profiler, application_pid)
         assert_collapsed(process_collapsed)
@@ -104,7 +104,7 @@ def test_twoprocesses_nodejs_attach_maps(
                 perf_inject=False,
                 perf_dwarf_stack_size=0,
                 perf_node_attach=True,
-                perf_restart=False,
+                perf_memory_restart=False,
             ) as profiler:
                 results = profiler.snapshot()
                 assert_collapsed(results[pid1].stacks)
@@ -154,7 +154,7 @@ def test_nodejs_matrix(
         perf_inject=False,
         perf_dwarf_stack_size=0,
         perf_node_attach=True,
-        perf_restart=False,
+        perf_memory_restart=False,
     ) as profiler:
         node_version, libc = application_image_tag.split("-")
         if node_version == "12" and libc == "glibc":

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -43,7 +43,7 @@ def make_system_profiler(tmp_path: Path, perf_mode: str, insert_dso_name: bool) 
         perf_inject=False,
         perf_dwarf_stack_size=DEFAULT_PERF_DWARF_STACK_SIZE,
         perf_node_attach=False,
-        perf_restart=True,
+        perf_memory_restart=True,
     )
 
 

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -141,7 +141,7 @@ def test_nodejs(
         perf_inject=True,
         perf_dwarf_stack_size=0,
         perf_node_attach=False,
-        perf_restart=False,
+        perf_memory_restart=False,
     ) as profiler:
         process_collapsed = snapshot_pid_collapsed(profiler, application_pid)
         assert_collapsed(process_collapsed)


### PR DESCRIPTION
* CLean up logging (pass stdout & stderr as extras, use standard "perf ({type} mode)" in all logs)
* Clean up leftover files before starting - leftover files are moved by perf to "xxx.old" which is later identified by our wait_for_file_by_prefix(), which we don't want.
* Refactor check_if_needs_restart() to check_if_needs_memory_restart(), to signify its purpose.
* Check if perf is running every cycle beginning, and re-start it if not. perf might be killed e.g due to OOM, and we had nothing in place to re-start it. This means all future gProfiler cycles would fails in this run :/

@d3dave lmk if you have a better design for this "cleanup".

TODO:
* [ ] add automatic tests for restart if perf is killed
* [ ] add automatic tests for restart based on memory (?)
