### PR TITLE
Refactor profiler state parameters to separate object

### DIFF
--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -139,7 +139,7 @@ class GProfiler:
             Event(),
             TemporaryDirectoryWithMode(dir=TEMPORARY_STORAGE_PATH, mode=0o755),
             profile_spawned_processes,
-            user_args.get("insert_dso_name"),
+            bool(user_args.get("insert_dso_name")),
             profiling_mode,
         )
         self.system_profiler, self.process_profilers = get_profilers(user_args, profiler_state=self._profiler_state)

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -135,10 +135,9 @@ class GProfiler:
         # 2. accessible only by us.
         # the latter can be root only. the former can not. we should do this separation so we don't expose
         # files unnecessarily.
-        temp_dir = TemporaryDirectoryWithMode(dir=TEMPORARY_STORAGE_PATH, mode=0o755)
         self._profiler_state = ProfilerState(
             Event(),
-            temp_dir.name,
+            TemporaryDirectoryWithMode(dir=TEMPORARY_STORAGE_PATH, mode=0o755),
             profile_spawned_processes,
             user_args.get("insert_dso_name"),
             profiling_mode,

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -40,6 +40,7 @@ from gprofiler.metadata.enrichment import EnrichmentOptions
 from gprofiler.metadata.metadata_collector import get_current_metadata, get_static_metadata
 from gprofiler.metadata.system_metadata import get_hostname, get_run_mode, get_static_system_info
 from gprofiler.platform import is_linux, is_windows
+from gprofiler.profiler_state import ProfilerState
 from gprofiler.profilers.factory import get_profilers
 from gprofiler.profilers.profiler_base import NoopProfiler, ProcessProfilerBase, ProfilerInterface
 from gprofiler.profilers.registry import get_profilers_registry
@@ -137,12 +138,10 @@ class GProfiler:
         # the latter can be root only. the former can not. we should do this separation so we don't expose
         # files unnecessarily.
         self._temp_storage_dir = TemporaryDirectoryWithMode(dir=TEMPORARY_STORAGE_PATH, mode=0o755)
-        self.system_profiler, self.process_profilers = get_profilers(
-            user_args,
-            storage_dir=self._temp_storage_dir.name,
-            stop_event=self._stop_event,
-            profile_spawned_processes=self._profile_spawned_processes,
+        self._profiler_state = ProfilerState(
+            self._stop_event, self._temp_storage_dir.name, self._profile_spawned_processes
         )
+        self.system_profiler, self.process_profilers = get_profilers(user_args, profiler_state=self._profiler_state)
         if self._enrichment_options.container_names:
             self._container_names_client: Optional[ContainerNamesClient] = ContainerNamesClient()
         else:

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -49,7 +49,6 @@ from gprofiler.system_metrics import Metrics, NoopSystemMetricsMonitor, SystemMe
 from gprofiler.usage_loggers import CgroupsUsageLogger, NoopUsageLogger, UsageLoggerInterface
 from gprofiler.utils import (
     TEMPORARY_STORAGE_PATH,
-    TemporaryDirectoryWithMode,
     atomically_symlink,
     get_iso8601_format_time,
     grab_gprofiler_mutex,
@@ -148,7 +147,9 @@ class GProfiler:
             self._container_names_client = None
         self._usage_logger = usage_logger
         if collect_metrics:
-            self._system_metrics_monitor: SystemMetricsMonitorBase = SystemMetricsMonitor(self._profiler_state.stop_event)
+            self._system_metrics_monitor: SystemMetricsMonitorBase = SystemMetricsMonitor(
+                self._profiler_state.stop_event
+            )
         else:
             self._system_metrics_monitor = NoopSystemMetricsMonitor()
 

--- a/gprofiler/profiler_state.py
+++ b/gprofiler/profiler_state.py
@@ -1,5 +1,4 @@
 from threading import Event
-from typing import Union
 
 from gprofiler.utils import TemporaryDirectoryWithMode
 

--- a/gprofiler/profiler_state.py
+++ b/gprofiler/profiler_state.py
@@ -1,4 +1,5 @@
 from threading import Event
+from typing import Union
 
 from gprofiler.utils import TemporaryDirectoryWithMode
 
@@ -7,17 +8,18 @@ class ProfilerState:
     def __init__(
         self,
         stop_event: Event,
-        storage_dir: TemporaryDirectoryWithMode,
+        storage_dir: Union[TemporaryDirectoryWithMode, str],
         profile_spawned_processes: bool,
         insert_dso_name: bool,
         profiling_mode: str,
     ) -> None:
         self.stop_event = stop_event
-        self._storage_dir = storage_dir
         self.profile_spawned_processes = profile_spawned_processes
         self.insert_dso_name = insert_dso_name
         self.profiling_mode = profiling_mode
-
-    @property
-    def storage_dir(self) -> str:
-        return self._storage_dir.name
+        if type(storage_dir) == TemporaryDirectoryWithMode:
+            self._temporary_dir = storage_dir
+            self.storage_dir = storage_dir.name
+            print(type(self.storage_dir))
+        else:
+            self.storage_dir = storage_dir

--- a/gprofiler/profiler_state.py
+++ b/gprofiler/profiler_state.py
@@ -10,17 +10,34 @@ class ProfilerState:
     def __init__(
         self,
         stop_event: Event,
-        storage_dir: Union[TemporaryDirectoryWithMode, str],
+        storage_dir: str,
         profile_spawned_processes: bool,
         insert_dso_name: bool,
         profiling_mode: str,
     ) -> None:
-        self.stop_event = stop_event
-        self.profile_spawned_processes = profile_spawned_processes
-        self.insert_dso_name = insert_dso_name
-        self.profiling_mode = profiling_mode
-        if type(storage_dir) == TemporaryDirectoryWithMode:
-            self._temporary_dir = storage_dir
-            self.storage_dir = storage_dir.name
-        else:
-            self.storage_dir = storage_dir
+        self._stop_event = stop_event
+        self._profile_spawned_processes = profile_spawned_processes
+        self._insert_dso_name = insert_dso_name
+        self._profiling_mode = profiling_mode
+        self._temporary_dir = TemporaryDirectoryWithMode(dir=storage_dir, mode=0o755)
+        self._storage_dir = self._temporary_dir.name
+
+    @property
+    def stop_event(self) -> Event:
+        return self._stop_event
+
+    @property
+    def storage_dir(self) -> str:
+        return self._storage_dir
+
+    @property
+    def profile_spawned_processes(self) -> bool:
+        return self._profile_spawned_processes
+
+    @property
+    def insert_dso_name(self) -> bool:
+        return self._insert_dso_name
+
+    @property
+    def profiling_mode(self) -> str:
+        return self._profiling_mode

--- a/gprofiler/profiler_state.py
+++ b/gprofiler/profiler_state.py
@@ -22,6 +22,5 @@ class ProfilerState:
         if type(storage_dir) == TemporaryDirectoryWithMode:
             self._temporary_dir = storage_dir
             self.storage_dir = storage_dir.name
-            print(type(self.storage_dir))
         else:
             self.storage_dir = storage_dir

--- a/gprofiler/profiler_state.py
+++ b/gprofiler/profiler_state.py
@@ -5,6 +5,8 @@ from gprofiler.utils import TemporaryDirectoryWithMode
 
 
 class ProfilerState:
+    # Class for storing generic state parameters. These parameters are the same for each profiler.
+    # Thanks to that class adding new state parameters to profilers won't result changing code in every profiler.
     def __init__(
         self,
         stop_event: Event,

--- a/gprofiler/profiler_state.py
+++ b/gprofiler/profiler_state.py
@@ -1,17 +1,23 @@
 from threading import Event
 
+from gprofiler.utils import TemporaryDirectoryWithMode
+
 
 class ProfilerState:
     def __init__(
         self,
         stop_event: Event,
-        storage_dir: str,
+        storage_dir: TemporaryDirectoryWithMode,
         profile_spawned_processes: bool,
         insert_dso_name: bool,
         profiling_mode: str,
     ) -> None:
         self.stop_event = stop_event
-        self.storage_dir = storage_dir
+        self._storage_dir = storage_dir
         self.profile_spawned_processes = profile_spawned_processes
         self.insert_dso_name = insert_dso_name
         self.profiling_mode = profiling_mode
+
+    @property
+    def storage_dir(self) -> str:
+        return self._storage_dir.name

--- a/gprofiler/profiler_state.py
+++ b/gprofiler/profiler_state.py
@@ -27,7 +27,7 @@ class ProfilerState:
 
     @property
     def storage_dir(self) -> str:
-        return self._storage_dir
+        return str(self._storage_dir)
 
     @property
     def profile_spawned_processes(self) -> bool:

--- a/gprofiler/profiler_state.py
+++ b/gprofiler/profiler_state.py
@@ -7,7 +7,11 @@ class ProfilerState:
         stop_event: Event,
         storage_dir: str,
         profile_spawned_processes: bool,
+        insert_dso_name: bool,
+        profiling_mode: str,
     ) -> None:
         self.stop_event = stop_event
         self.storage_dir = storage_dir
         self.profile_spawned_processes = profile_spawned_processes
+        self.insert_dso_name = insert_dso_name
+        self.profiling_mode = profiling_mode

--- a/gprofiler/profiler_state.py
+++ b/gprofiler/profiler_state.py
@@ -1,0 +1,13 @@
+from threading import Event
+
+
+class ProfilerState:
+    def __init__(
+        self,
+        stop_event: Event,
+        storage_dir: str,
+        profile_spawned_processes: bool,
+    ) -> None:
+        self.stop_event = stop_event
+        self.storage_dir = storage_dir
+        self.profile_spawned_processes = profile_spawned_processes

--- a/gprofiler/profilers/dotnet.py
+++ b/gprofiler/profilers/dotnet.py
@@ -6,8 +6,7 @@ import datetime
 import functools
 import os
 import signal
-from threading import Event
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from granulate_utils.linux.ns import get_process_nspid
 from granulate_utils.linux.process import is_process_basename_matching
@@ -17,6 +16,7 @@ from gprofiler.exceptions import ProcessStoppedException, StopEventSetException
 from gprofiler.gprofiler_types import ProfileData
 from gprofiler.log import get_logger_adapter
 from gprofiler.metadata.application_metadata import ApplicationMetadata
+from gprofiler.profiler_state import ProfilerState
 from gprofiler.profilers.profiler_base import ProcessProfilerBase
 from gprofiler.profilers.registry import register_profiler
 from gprofiler.utils import pgrep_maps, random_prefix, removed_path, resource_path, run_process
@@ -64,14 +64,12 @@ class DotnetProfiler(ProcessProfilerBase):
         self,
         frequency: int,
         duration: int,
-        stop_event: Optional[Event],
-        storage_dir: str,
+        profiler_state: ProfilerState,
         insert_dso_name: bool,
-        profile_spawned_processes: bool,
         profiling_mode: str,
         dotnet_mode: str,
     ):
-        super().__init__(frequency, duration, stop_event, storage_dir, insert_dso_name, profiling_mode)
+        super().__init__(frequency, duration, profiler_state, insert_dso_name, profiling_mode)
         assert (
             dotnet_mode == "dotnet-trace"
         ), "Dotnet profiler should not be initialized, wrong dotnet-trace value given"

--- a/gprofiler/profilers/factory.py
+++ b/gprofiler/profilers/factory.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 logger = get_logger_adapter(__name__)
-COMMON_PROFILER_ARGUMENT_NAMES = ["frequency", "duration", "insert_dso_name", "profiling_mode"]
+COMMON_PROFILER_ARGUMENT_NAMES = ["frequency", "duration"]
 
 
 def get_profilers(

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -23,6 +23,7 @@ from gprofiler.gprofiler_types import AppMetadata, ProcessToProfileData, Profile
 from gprofiler.log import get_logger_adapter
 from gprofiler.metadata import application_identifiers
 from gprofiler.metadata.application_metadata import ApplicationMetadata
+from gprofiler.profiler_state import ProfilerState
 from gprofiler.profilers.node import clean_up_node_maps, generate_map_for_node_processes, get_node_processes
 from gprofiler.profilers.profiler_base import ProfilerBase
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
@@ -193,21 +194,21 @@ class SystemProfiler(ProfilerBase):
         self,
         frequency: int,
         duration: int,
-        stop_event: Event,
-        storage_dir: str,
+        profiler_state: ProfilerState,
         insert_dso_name: bool,
         profiling_mode: str,
-        profile_spawned_processes: bool,
         perf_mode: str,
         perf_dwarf_stack_size: int,
         perf_inject: bool,
         perf_node_attach: bool,
         perf_restart: bool,
     ):
-        super().__init__(frequency, duration, stop_event, storage_dir, insert_dso_name, profiling_mode)
-        _ = profile_spawned_processes  # Required for mypy unused argument warning
+        super().__init__(frequency, duration, profiler_state, insert_dso_name, profiling_mode)
         self._perfs: List[PerfProcess] = []
-        self._metadata_collectors: List[PerfMetadata] = [GolangPerfMetadata(stop_event), NodePerfMetadata(stop_event)]
+        self._metadata_collectors: List[PerfMetadata] = [
+            GolangPerfMetadata(self._stop_event),
+            NodePerfMetadata(self._stop_event),
+        ]
         self._insert_dso_name = insert_dso_name
         self._node_processes: List[Process] = []
         self._node_processes_attached: List[Process] = []

--- a/gprofiler/profilers/php.py
+++ b/gprofiler/profilers/php.py
@@ -11,12 +11,12 @@ from collections import Counter, defaultdict
 from functools import lru_cache
 from pathlib import Path
 from subprocess import Popen
-from threading import Event
 from typing import List, Optional, Pattern, cast
 
 from gprofiler.exceptions import StopEventSetException
 from gprofiler.gprofiler_types import ProcessToProfileData, ProcessToStackSampleCounters, ProfileData
 from gprofiler.log import get_logger_adapter
+from gprofiler.profiler_state import ProfilerState
 from gprofiler.profilers.profiler_base import ProfilerBase
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
 from gprofiler.utils import random_prefix, resource_path, start_process, wait_event
@@ -59,17 +59,14 @@ class PHPSpyProfiler(ProfilerBase):
         self,
         frequency: int,
         duration: int,
-        stop_event: Optional[Event],
-        storage_dir: str,
+        profiler_state: ProfilerState,
         insert_dso_name: bool,
         profiling_mode: str,
-        profile_spawned_processes: bool,
         php_process_filter: str,
         php_mode: str,
     ):
         assert php_mode == "phpspy", "PHP profiler should not be initialized, wrong php_mode value given"
-        super().__init__(frequency, duration, stop_event, storage_dir, insert_dso_name, profiling_mode)
-        _ = profile_spawned_processes  # Required for mypy unused argument warning
+        super().__init__(frequency, duration, profiler_state, insert_dso_name, profiling_mode)
         self._process: Optional[Popen] = None
         self._output_path = Path(self._storage_dir) / f"phpspy.{random_prefix()}.col"
         self._process_filter = php_process_filter

--- a/gprofiler/profilers/profiler_base.py
+++ b/gprofiler/profilers/profiler_base.py
@@ -88,7 +88,6 @@ class ProfilerBase(ProfilerInterface):
             )
         self._duration = duration
         self._profiler_state = profiler_state
-        self._stop_event = self._profiler_state.stop_event
 
         if profiler_state.profiling_mode == "allocation":
             frequency_str = f"allocation interval: {humanfriendly.format_size(frequency, binary=True)}"

--- a/gprofiler/profilers/profiler_base.py
+++ b/gprofiler/profilers/profiler_base.py
@@ -88,7 +88,7 @@ class ProfilerBase(ProfilerInterface):
             )
         self._duration = duration
         self._profiler_state = profiler_state
-        self._stop_event = self._profiler_state.stop_event or Event()
+        self._stop_event = self._profiler_state.stop_event
 
         if profiler_state.profiling_mode == "allocation":
             frequency_str = f"allocation interval: {humanfriendly.format_size(frequency, binary=True)}"

--- a/gprofiler/profilers/profiler_base.py
+++ b/gprofiler/profilers/profiler_base.py
@@ -10,7 +10,7 @@ import sched
 import time
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures._base import Future
-from threading import Event, Lock, Thread
+from threading import Lock, Thread
 from types import TracebackType
 from typing import Dict, List, Optional, Tuple, Type, TypeVar
 

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -172,14 +172,12 @@ class PySpyProfiler(SpawningProcessProfilerBase):
         frequency: int,
         duration: int,
         profiler_state: ProfilerState,
-        insert_dso_name: bool,
-        profiling_mode: str,
         *,
         add_versions: bool,
     ):
-        super().__init__(frequency, duration, profiler_state, insert_dso_name, profiling_mode)
+        super().__init__(frequency, duration, profiler_state)
         self.add_versions = add_versions
-        self._metadata = PythonMetadata(self._stop_event)
+        self._metadata = PythonMetadata(self._profiler_state.stop_event)
 
     def _make_command(self, pid: int, output_path: str, duration: int) -> List[str]:
         command = [
@@ -213,12 +211,12 @@ class PySpyProfiler(SpawningProcessProfilerBase):
         app_metadata = self._metadata.get_metadata(process)
         comm = process_comm(process)
 
-        local_output_path = os.path.join(self._storage_dir, f"pyspy.{random_prefix()}.{process.pid}.col")
+        local_output_path = os.path.join(self._profiler_state.storage_dir, f"pyspy.{random_prefix()}.{process.pid}.col")
         with removed_path(local_output_path):
             try:
                 run_process(
                     self._make_command(process.pid, local_output_path, duration),
-                    stop_event=self._stop_event,
+                    stop_event=self._profiler_state.stop_event,
                     timeout=duration + self._EXTRA_TIMEOUT,
                     kill_signal=signal.SIGTERM if is_windows() else signal.SIGKILL,
                 )
@@ -333,8 +331,6 @@ class PythonProfiler(ProfilerInterface):
         frequency: int,
         duration: int,
         profiler_state: ProfilerState,
-        insert_dso_name: bool,
-        profiling_mode: str,
         python_mode: str,
         python_add_versions: bool,
         python_pyperf_user_stacks_pages: Optional[int],
@@ -354,10 +350,8 @@ class PythonProfiler(ProfilerInterface):
                 frequency,
                 duration,
                 profiler_state,
-                insert_dso_name,
                 python_add_versions,
                 python_pyperf_user_stacks_pages,
-                profiling_mode,
             )
         else:
             self._ebpf_profiler = None
@@ -367,8 +361,6 @@ class PythonProfiler(ProfilerInterface):
                 frequency,
                 duration,
                 profiler_state,
-                insert_dso_name,
-                profiling_mode,
                 add_versions=python_add_versions,
             )
         else:
@@ -381,18 +373,14 @@ class PythonProfiler(ProfilerInterface):
             frequency: int,
             duration: int,
             profiler_state: ProfilerState,
-            insert_dso_name: bool,
             add_versions: bool,
             user_stacks_pages: Optional[int],
-            profiling_mode: str,
         ) -> Optional[PythonEbpfProfiler]:
             try:
                 profiler = PythonEbpfProfiler(
                     frequency,
                     duration,
                     profiler_state,
-                    insert_dso_name,
-                    profiling_mode,
                     add_versions=add_versions,
                     user_stacks_pages=user_stacks_pages,
                 )

--- a/gprofiler/profilers/python_ebpf.py
+++ b/gprofiler/profilers/python_ebpf.py
@@ -8,7 +8,6 @@ import resource
 import signal
 from pathlib import Path
 from subprocess import Popen
-from threading import Event
 from typing import Dict, List, NoReturn, Optional
 
 from granulate_utils.linux.ns import is_running_in_init_pid
@@ -19,6 +18,7 @@ from gprofiler.exceptions import CalledProcessError, StopEventSetException
 from gprofiler.gprofiler_types import ProcessToProfileData, ProfileData
 from gprofiler.log import get_logger_adapter
 from gprofiler.metadata import application_identifiers
+from gprofiler.profiler_state import ProfilerState
 from gprofiler.profilers import python
 from gprofiler.profilers.profiler_base import ProfilerBase
 from gprofiler.utils import (
@@ -57,17 +57,14 @@ class PythonEbpfProfiler(ProfilerBase):
         self,
         frequency: int,
         duration: int,
-        stop_event: Optional[Event],
-        storage_dir: str,
+        profiler_state: ProfilerState,
         insert_dso_name: bool,
-        profile_spawned_processes: bool,
         profiling_mode: str,
         *,
         add_versions: bool,
         user_stacks_pages: Optional[int] = None,
     ):
-        super().__init__(frequency, duration, stop_event, storage_dir, insert_dso_name, profiling_mode)
-        _ = profile_spawned_processes  # Required for mypy unused argument warning
+        super().__init__(frequency, duration, profiler_state, insert_dso_name, profiling_mode)
         self.process: Optional[Popen] = None
         self.output_path = Path(self._storage_dir) / f"pyperf.{random_prefix()}.col"
         self.add_versions = add_versions

--- a/gprofiler/profilers/ruby.py
+++ b/gprofiler/profilers/ruby.py
@@ -72,13 +72,11 @@ class RbSpyProfiler(SpawningProcessProfilerBase):
         frequency: int,
         duration: int,
         profiler_state: ProfilerState,
-        insert_dso_name: bool,
-        profiling_mode: str,
         ruby_mode: str,
     ):
-        super().__init__(frequency, duration, profiler_state, insert_dso_name, profiling_mode)
+        super().__init__(frequency, duration, profiler_state)
         assert ruby_mode == "rbspy", "Ruby profiler should not be initialized, wrong ruby_mode value given"
-        self._metadata = RubyMetadata(self._stop_event)
+        self._metadata = RubyMetadata(self._profiler_state.stop_event)
 
     def _make_command(self, pid: int, output_path: str, duration: int) -> List[str]:
         return [
@@ -110,12 +108,12 @@ class RbSpyProfiler(SpawningProcessProfilerBase):
         app_metadata = self._metadata.get_metadata(process)
         appid = application_identifiers.get_ruby_app_id(process)
 
-        local_output_path = os.path.join(self._storage_dir, f"rbspy.{random_prefix()}.{process.pid}.col")
+        local_output_path = os.path.join(self._profiler_state.storage_dir, f"rbspy.{random_prefix()}.{process.pid}.col")
         with removed_path(local_output_path):
             try:
                 run_process(
                     self._make_command(process.pid, local_output_path, duration),
-                    stop_event=self._stop_event,
+                    stop_event=self._profiler_state.stop_event,
                     timeout=duration + self._EXTRA_TIMEOUT,
                     kill_signal=signal.SIGKILL,
                 )

--- a/gprofiler/profilers/ruby.py
+++ b/gprofiler/profilers/ruby.py
@@ -7,8 +7,7 @@ import functools
 import os
 import signal
 from pathlib import Path
-from threading import Event
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from granulate_utils.linux.elf import get_elf_id
 from granulate_utils.linux.process import get_mapped_dso_elf_id, is_process_basename_matching
@@ -20,6 +19,7 @@ from gprofiler.gprofiler_types import ProfileData
 from gprofiler.log import get_logger_adapter
 from gprofiler.metadata import application_identifiers
 from gprofiler.metadata.application_metadata import ApplicationMetadata
+from gprofiler.profiler_state import ProfilerState
 from gprofiler.profilers.profiler_base import SpawningProcessProfilerBase
 from gprofiler.profilers.registry import register_profiler
 from gprofiler.utils import pgrep_maps, random_prefix, removed_path, resource_path, run_process
@@ -71,16 +71,12 @@ class RbSpyProfiler(SpawningProcessProfilerBase):
         self,
         frequency: int,
         duration: int,
-        stop_event: Optional[Event],
-        storage_dir: str,
+        profiler_state: ProfilerState,
         insert_dso_name: bool,
         profiling_mode: str,
-        profile_spawned_processes: bool,
         ruby_mode: str,
     ):
-        super().__init__(
-            frequency, duration, stop_event, storage_dir, insert_dso_name, profile_spawned_processes, profiling_mode
-        )
+        super().__init__(frequency, duration, profiler_state, insert_dso_name, profiling_mode)
         assert ruby_mode == "rbspy", "Ruby profiler should not be initialized, wrong ruby_mode value given"
         self._metadata = RubyMetadata(self._stop_event)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,9 +79,9 @@ def java_args() -> Tuple[str]:
     return cast(Tuple[str], ())
 
 
-@fixture
-def profiler_state(tmp_path_world_accessible: Path) -> ProfilerState:
-    return ProfilerState(Event(), str(tmp_path_world_accessible), False, False, CPU_PROFILING_MODE)
+@fixture()
+def profiler_state(tmp_path: Path, insert_dso_name: bool) -> ProfilerState:
+    return ProfilerState(Event(), str(tmp_path), False, insert_dso_name, CPU_PROFILING_MODE)
 
 
 def make_path_world_accessible(path: Path) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,8 +12,6 @@ from threading import Event
 from typing import Any, Callable, Dict, Generator, Iterable, Iterator, List, Mapping, Optional, Tuple, cast
 
 import docker
-from gprofiler.consts import CPU_PROFILING_MODE
-from gprofiler.profiler_state import ProfilerState
 import pytest
 from _pytest.config import Config
 from docker import DockerClient
@@ -22,6 +20,7 @@ from docker.models.images import Image
 from psutil import Process
 from pytest import FixtureRequest, TempPathFactory, fixture
 
+from gprofiler.consts import CPU_PROFILING_MODE
 from gprofiler.diagnostics import set_diagnostics
 from gprofiler.gprofiler_types import StackToSampleCount
 from gprofiler.metadata.application_identifiers import (
@@ -32,6 +31,7 @@ from gprofiler.metadata.application_identifiers import (
     set_enrichment_options,
 )
 from gprofiler.metadata.enrichment import EnrichmentOptions
+from gprofiler.profiler_state import ProfilerState
 from gprofiler.state import init_state
 from tests import CONTAINERS_DIRECTORY, PARENT, PHPSPY_DURATION
 from tests.utils import (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,7 +80,7 @@ def java_args() -> Tuple[str]:
 
 
 @fixture
-def profiler_state(tmp_path_world_accessible: Path) -> ProfilerState():
+def profiler_state(tmp_path_world_accessible: Path) -> ProfilerState:
     return ProfilerState(Event(), str(tmp_path_world_accessible), False, False, CPU_PROFILING_MODE)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,11 @@ def in_container(request: FixtureRequest) -> bool:
 
 
 @fixture
+def insert_dso_name() -> bool:
+    return False
+
+
+@fixture
 def java_args() -> Tuple[str]:
     return cast(Tuple[str], ())
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,12 @@ import subprocess
 from contextlib import _GeneratorContextManager, contextmanager
 from functools import lru_cache, partial
 from pathlib import Path
+from threading import Event
 from typing import Any, Callable, Dict, Generator, Iterable, Iterator, List, Mapping, Optional, Tuple, cast
 
 import docker
+from gprofiler.consts import CPU_PROFILING_MODE
+from gprofiler.profiler_state import ProfilerState
 import pytest
 from _pytest.config import Config
 from docker import DockerClient
@@ -74,6 +77,11 @@ def in_container(request: FixtureRequest) -> bool:
 @fixture
 def java_args() -> Tuple[str]:
     return cast(Tuple[str], ())
+
+
+@fixture
+def profiler_state(tmp_path_world_accessible: Path) -> ProfilerState():
+    return ProfilerState(Event(), str(tmp_path_world_accessible), False, False, CPU_PROFILING_MODE)
 
 
 def make_path_world_accessible(path: Path) -> None:

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -17,7 +17,6 @@ from typing import Any, Optional
 
 import docker
 import psutil
-from gprofiler.profiler_state import ProfilerState
 import pytest
 from docker import DockerClient
 from docker.models.containers import Container
@@ -28,6 +27,7 @@ from granulate_utils.linux.process import is_musl
 from packaging.version import Version
 from pytest import LogCaptureFixture, MonkeyPatch
 
+from gprofiler.profiler_state import ProfilerState
 from gprofiler.profilers.java import (
     JAVA_SAFEMODE_ALL,
     AsyncProfiledProcess,

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -97,9 +97,8 @@ def test_async_profiler_already_running(
 
         with AsyncProfiledProcess(
             process=process,
-            storage_dir=profiler._storage_dir,
+            profiler_state=profiler._profiler_state,
             insert_dso_name=False,
-            stop_event=profiler._stop_event,
             mode=profiler._mode,
             ap_safemode=0,
             ap_args="",
@@ -109,9 +108,8 @@ def test_async_profiler_already_running(
         # run "status"
         with AsyncProfiledProcessForTests(
             process=process,
-            storage_dir=profiler._storage_dir,
+            profiler_state=profiler._profiler_state,
             insert_dso_name=False,
-            stop_event=profiler._stop_event,
             mode="itimer",
             ap_safemode=0,
             ap_args="",

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -99,7 +99,6 @@ def test_async_profiler_already_running(
         with AsyncProfiledProcess(
             process=process,
             profiler_state=profiler._profiler_state,
-            insert_dso_name=False,
             mode=profiler._mode,
             ap_safemode=0,
             ap_args="",
@@ -110,7 +109,6 @@ def test_async_profiler_already_running(
         with AsyncProfiledProcessForTests(
             process=process,
             profiler_state=profiler._profiler_state,
-            insert_dso_name=False,
             mode="itimer",
             ap_safemode=0,
             ap_args="",
@@ -321,16 +319,15 @@ def test_async_profiler_stops_after_given_timeout(
     application_pid: int,
     assert_collapsed: AssertInCollapsed,
     caplog: LogCaptureFixture,
+    profiler_state: ProfilerState,
 ) -> None:
     caplog.set_level(logging.DEBUG)
 
     process = psutil.Process(application_pid)
     timeout_s = 5
-    profiler_state = ProfilerState(Event(), str(tmp_path_world_accessible), False)
     with AsyncProfiledProcessForTests(
         process=process,
         profiler_state=profiler_state,
-        insert_dso_name=False,
         mode="itimer",
         ap_safemode=0,
         ap_args="",

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -98,6 +98,7 @@ class AsyncProfiledProcessForTests(AsyncProfiledProcess):
 
 def test_async_profiler_already_running(
     application_pid: int,
+    profiler_state: ProfilerState,
     assert_collapsed: AssertInCollapsed,
     tmp_path_world_accessible: Path,
     caplog: LogCaptureFixture,
@@ -106,7 +107,7 @@ def test_async_profiler_already_running(
     Test we're able to restart async-profiler in case it's already running in the process and get results normally.
     """
     caplog.set_level(logging.INFO)
-    with make_java_profiler(storage_dir=str(tmp_path_world_accessible)) as profiler:
+    with make_java_profiler(profiler_state) as profiler:
         process = profiler._select_processes_to_profile()[0]
 
         with AsyncProfiledProcess(
@@ -142,12 +143,13 @@ def test_java_async_profiler_cpu_mode(
     tmp_path: Path,
     application_pid: int,
     assert_collapsed: AssertInCollapsed,
+    profiler_state: ProfilerState,
 ) -> None:
     """
     Run Java in a container and enable async-profiler in CPU mode, make sure we get kernel stacks.
     """
     with make_java_profiler(
-        storage_dir=str(tmp_path),
+        profiler_state,
         frequency=999,
         # this ensures auto selection picks CPU by default, if possible.
         java_async_profiler_mode="auto",
@@ -163,12 +165,13 @@ def test_java_async_profiler_musl_and_cpu(
     tmp_path: Path,
     application_pid: int,
     assert_collapsed: AssertInCollapsed,
+    profiler_state: ProfilerState,
 ) -> None:
     """
     Run Java in an Alpine-based container and enable async-profiler in CPU mode, make sure that musl profiling
     works and that we get kernel stacks.
     """
-    with make_java_profiler(storage_dir=str(tmp_path), frequency=999) as profiler:
+    with make_java_profiler(profiler_state, frequency=999) as profiler:
         assert is_musl(psutil.Process(application_pid))
 
         process_collapsed = snapshot_pid_collapsed(profiler, application_pid)
@@ -182,9 +185,9 @@ def test_java_async_profiler_musl_and_cpu(
         assert "/libgcc_s.so" not in maps
 
 
-def test_java_safemode_parameters(tmp_path: Path) -> None:
+def test_java_safemode_parameters(tmp_path: Path, profiler_state: ProfilerState) -> None:
     with pytest.raises(AssertionError) as excinfo:
-        make_java_profiler(storage_dir=str(tmp_path), java_version_check=False)
+        make_java_profiler(profiler_state, java_version_check=False)
     assert "Java version checks are mandatory in --java-safemode" in str(excinfo.value)
 
 
@@ -195,10 +198,11 @@ def test_java_safemode_version_check(
     application_pid: int,
     application_docker_container: Container,
     application_process: Optional[Popen],
+    profiler_state: ProfilerState,
 ) -> None:
     monkeypatch.setitem(JavaProfiler.MINIMAL_SUPPORTED_VERSIONS, 8, (Version("8.999"), 0))
 
-    with make_java_profiler(storage_dir=str(tmp_path)) as profiler:
+    with make_java_profiler(profiler_state) as profiler:
         process = profiler._select_processes_to_profile()[0]
         jvm_version = parse_jvm_version(get_java_version(process, profiler._profiler_state.stop_event))
         collapsed = snapshot_pid_collapsed(profiler, application_pid)
@@ -216,8 +220,9 @@ def test_java_safemode_build_number_check(
     application_pid: int,
     application_docker_container: Container,
     application_process: Optional[Popen],
+    profiler_state: ProfilerState,
 ) -> None:
-    with make_java_profiler(storage_dir=str(tmp_path)) as profiler:
+    with make_java_profiler(profiler_state) as profiler:
         process = profiler._select_processes_to_profile()[0]
         jvm_version = parse_jvm_version(get_java_version(process, profiler._profiler_state.stop_event))
         monkeypatch.setitem(JavaProfiler.MINIMAL_SUPPORTED_VERSIONS, 8, (jvm_version.version, 999))
@@ -238,7 +243,11 @@ def test_java_safemode_build_number_check(
     ],
 )
 def test_hotspot_error_file(
-    application_pid: int, tmp_path: Path, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture
+    application_pid: int,
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    caplog: LogCaptureFixture,
+    profiler_state: ProfilerState,
 ) -> None:
     start_async_profiler = AsyncProfiledProcess.start_async_profiler
 
@@ -251,7 +260,7 @@ def test_hotspot_error_file(
     monkeypatch.setattr(AsyncProfiledProcess, "start_async_profiler", start_async_profiler_and_crash)
 
     # increased duration - give the JVM some time to write the hs_err file.
-    profiler = make_java_profiler(storage_dir=str(tmp_path), duration=10)
+    profiler = make_java_profiler(profiler_state, duration=10)
     with profiler:
         profiler.snapshot()
 
@@ -265,11 +274,15 @@ def test_hotspot_error_file(
 
 
 def test_disable_java_profiling(
-    application_pid: int, tmp_path: Path, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture
+    application_pid: int,
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    caplog: LogCaptureFixture,
+    profiler_state: ProfilerState,
 ) -> None:
     caplog.set_level(logging.DEBUG)
 
-    profiler = make_java_profiler(storage_dir=str(tmp_path))
+    profiler = make_java_profiler(profiler_state)
     dummy_reason = "dummy reason"
     monkeypatch.setattr(profiler, "_safemode_disable_reason", dummy_reason)
     with profiler:
@@ -280,16 +293,20 @@ def test_disable_java_profiling(
 
 
 def test_already_loaded_async_profiler_profiling_failure(
-    tmp_path: Path, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture, application_pid: int
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    caplog: LogCaptureFixture,
+    application_pid: int,
+    profiler_state: ProfilerState,
 ) -> None:
     with monkeypatch.context() as m:
         import gprofiler.profilers.java
 
         m.setattr(gprofiler.profilers.java, "POSSIBLE_AP_DIRS", ("/tmp/fake_gprofiler_tmp",))
-        with make_java_profiler(storage_dir=str(tmp_path)) as profiler:
+        with make_java_profiler(profiler_state) as profiler:
             profiler.snapshot()
 
-    with make_java_profiler(storage_dir=str(tmp_path)) as profiler:
+    with make_java_profiler(profiler_state) as profiler:
         process = profiler._select_processes_to_profile()[0]
         assert any("/tmp/fake_gprofiler_tmp" in mmap.path for mmap in process.memory_maps())
         collapsed = snapshot_pid_collapsed(profiler, application_pid)
@@ -305,13 +322,14 @@ def test_async_profiler_output_written_upon_jvm_exit(
     application_pid: int,
     assert_collapsed: AssertInCollapsed,
     caplog: LogCaptureFixture,
+    profiler_state: ProfilerState,
 ) -> None:
     """
     Make sure async-profiler writes output upon process exit (and we manage to read it correctly)
     """
     caplog.set_level(logging.DEBUG)
 
-    with make_java_profiler(storage_dir=str(tmp_path_world_accessible), duration=10) as profiler:
+    with make_java_profiler(profiler_state, duration=10) as profiler:
 
         def delayed_kill() -> None:
             time.sleep(3)
@@ -364,10 +382,11 @@ def test_sanity_other_jvms(
     application_pid: int,
     assert_collapsed: AssertInCollapsed,
     search_for: str,
+    profiler_state: ProfilerState,
 ) -> None:
     with make_java_profiler(
+        profiler_state,
         frequency=99,
-        storage_dir=str(tmp_path),
         java_async_profiler_mode="cpu",
     ) as profiler:
         assert search_for in get_java_version(psutil.Process(application_pid), profiler._profiler_state.stop_event)
@@ -378,7 +397,11 @@ def test_sanity_other_jvms(
 # test only once. in a container, so that we don't mess up the environment :)
 @pytest.mark.parametrize("in_container", [True])
 def test_java_deleted_libjvm(
-    tmp_path: Path, application_pid: int, application_docker_container: Container, assert_collapsed: AssertInCollapsed
+    tmp_path: Path,
+    application_pid: int,
+    application_docker_container: Container,
+    assert_collapsed: AssertInCollapsed,
+    profiler_state: ProfilerState,
 ) -> None:
     """
     Tests that we can profile processes whose libjvm was deleted, e.g because Java was upgraded.
@@ -394,7 +417,7 @@ def test_java_deleted_libjvm(
         application_pid
     ), f"Not (deleted) after deleting? libjvm={libjvm} maps={_read_pid_maps(application_pid)}"
 
-    with make_java_profiler(storage_dir=str(tmp_path), duration=3) as profiler:
+    with make_java_profiler(profiler_state, duration=3) as profiler:
         process_collapsed = snapshot_pid_collapsed(profiler, application_pid)
         assert_collapsed(process_collapsed)
 
@@ -413,6 +436,7 @@ def test_java_noexec_dirs(
     noexec_tmp_dir: str,
     in_container: bool,
     monkeypatch: MonkeyPatch,
+    profiler_state: ProfilerState,
 ) -> None:
     """
     Tests that gProfiler is able to select a non-default directory for libasyncProfiler if the default one
@@ -430,7 +454,7 @@ def test_java_noexec_dirs(
         # mount because /tmp is not necessarily tmpfs; and that'll hide all current files in /tmp).
         monkeypatch.setattr(gprofiler.profilers.java, "POSSIBLE_AP_DIRS", (noexec_tmp_dir, run_dir))
 
-    with make_java_profiler(storage_dir=str(tmp_path_world_accessible)) as profiler:
+    with make_java_profiler(profiler_state) as profiler:
         assert_collapsed(snapshot_pid_collapsed(profiler, application_pid))
 
     # should use this path instead of /tmp/gprofiler_tmp/...
@@ -444,6 +468,7 @@ def test_java_symlinks_in_paths(
     application_docker_container: Container,
     assert_collapsed: AssertInCollapsed,
     caplog: LogCaptureFixture,
+    profiler_state: ProfilerState,
 ) -> None:
     """
     Tests that gProfiler correctly reads through symlinks in other namespaces (i.e where special
@@ -474,7 +499,7 @@ def test_java_symlinks_in_paths(
         user="root",
     )
 
-    with make_java_profiler(storage_dir=str(tmp_path)) as profiler:
+    with make_java_profiler(profiler_state) as profiler:
         assert_collapsed(snapshot_pid_collapsed(profiler, application_pid))
 
     # part of the commandline to AP - which shall include the final, resolved path.
@@ -488,6 +513,7 @@ def test_java_appid_and_metadata_before_process_exits(
     assert_collapsed: AssertInCollapsed,
     monkeypatch: MonkeyPatch,
     caplog: LogCaptureFixture,
+    profiler_state: ProfilerState,
 ) -> None:
     """
     Tests that an appid is generated also for a process that exits during profiling
@@ -507,7 +533,7 @@ def test_java_appid_and_metadata_before_process_exits(
     monkeypatch.setattr(AsyncProfiledProcess, "start_async_profiler", start_async_profiler_and_interrupt)
 
     with make_java_profiler(
-        storage_dir=str(tmp_path),
+        profiler_state,
         duration=10,
     ) as profiler:
         profile = snapshot_pid_profile(profiler, application_pid)
@@ -526,13 +552,14 @@ def test_java_appid_and_metadata_before_process_exits(
 def test_java_attach_socket_missing(
     tmp_path: Path,
     application_pid: int,
+    profiler_state: ProfilerState,
 ) -> None:
     """
     Tests that we get the proper JattachMissingSocketException when the attach socket is deleted.
     """
 
     with make_java_profiler(
-        storage_dir=str(tmp_path),
+        profiler_state,
         duration=1,
     ) as profiler:
         snapshot_pid_profile(profiler, application_pid)
@@ -551,13 +578,14 @@ def test_java_jattach_async_profiler_log_output(
     tmp_path: Path,
     application_pid: int,
     caplog: LogCaptureFixture,
+    profiler_state: ProfilerState,
 ) -> None:
     """
     Tests that AP log is collected and logged in gProfiler's log.
     """
     caplog.set_level(logging.DEBUG)
     with make_java_profiler(
-        storage_dir=str(tmp_path),
+        profiler_state,
         duration=1,
     ) as profiler:
         # strip the container's libvjm, so we get the AP log message about missing debug
@@ -593,6 +621,7 @@ def test_java_different_basename(
     caplog: LogCaptureFixture,
     change_argv0: bool,
     java_path: Optional[str],
+    profiler_state: ProfilerState,
 ) -> None:
     """
     Tests that we can profile a Java app that runs with non-java "comm", by reading the argv0 instead.
@@ -600,7 +629,7 @@ def test_java_different_basename(
     java_notjava_basename = "java-notjava"
 
     with make_java_profiler(
-        storage_dir=str(tmp_path),
+        profiler_state,
         duration=1,
         java_safemode=JAVA_SAFEMODE_ALL,  # explicitly enable, for basename checks
     ) as profiler:
@@ -654,10 +683,10 @@ def test_dso_name_in_ap_profile(
     tmp_path: Path,
     application_pid: int,
     insert_dso_name: bool,
+    profiler_state: ProfilerState,
 ) -> None:
     with make_java_profiler(
-        storage_dir=str(tmp_path),
-        insert_dso_name=insert_dso_name,
+        profiler_state,
         duration=3,
         frequency=999,
     ) as profiler:
@@ -675,10 +704,10 @@ def test_handling_missing_symbol_in_profile(
     application_pid: int,
     insert_dso_name: bool,
     libc_pattern: str,
+    profiler_state: ProfilerState,
 ) -> None:
     with make_java_profiler(
-        storage_dir=str(tmp_path),
-        insert_dso_name=insert_dso_name,
+        profiler_state,
         duration=3,
         frequency=999,
     ) as profiler:
@@ -691,10 +720,11 @@ def test_meminfo_logged(
     tmp_path: Path,
     application_pid: int,
     caplog: LogCaptureFixture,
+    profiler_state: ProfilerState,
 ) -> None:
     caplog.set_level(logging.DEBUG)
     with make_java_profiler(
-        storage_dir=str(tmp_path),
+        profiler_state,
         duration=3,
         frequency=999,
     ) as profiler:
@@ -707,9 +737,10 @@ def test_meminfo_logged(
 def test_java_frames_include_no_semicolons(
     tmp_path: Path,
     application_pid: int,
+    profiler_state: ProfilerState,
 ) -> None:
     with make_java_profiler(
-        storage_dir=str(tmp_path),
+        profiler_state,
         duration=3,
         frequency=999,
     ) as profiler:
@@ -737,6 +768,7 @@ def test_no_stray_output_in_stdout_stderr(
     application_docker_container: Container,
     monkeypatch: MonkeyPatch,
     assert_collapsed: AssertInCollapsed,
+    profiler_state: ProfilerState,
 ) -> None:
     # save original stop function
     stop_async_profiler = AsyncProfiledProcess.stop_async_profiler
@@ -755,7 +787,7 @@ def test_no_stray_output_in_stdout_stderr(
     monkeypatch.setattr(AsyncProfiledProcess, "stop_async_profiler", flush_output_and_stop_async_profiler)
 
     with make_java_profiler(
-        storage_dir=str(tmp_path),
+        profiler_state,
         duration=3,
         frequency=999,
     ) as profiler:

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -17,6 +17,7 @@ from typing import Any, Optional
 
 import docker
 import psutil
+from gprofiler.profiler_state import ProfilerState
 import pytest
 from docker import DockerClient
 from docker.models.containers import Container
@@ -325,11 +326,11 @@ def test_async_profiler_stops_after_given_timeout(
 
     process = psutil.Process(application_pid)
     timeout_s = 5
+    profiler_state = ProfilerState(Event(), str(tmp_path_world_accessible), False)
     with AsyncProfiledProcessForTests(
         process=process,
-        storage_dir=str(tmp_path_world_accessible),
+        profiler_state=profiler_state,
         insert_dso_name=False,
-        stop_event=Event(),
         mode="itimer",
         ap_safemode=0,
         ap_args="",

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -12,7 +12,6 @@ import time
 from collections import Counter
 from pathlib import Path
 from subprocess import Popen
-from threading import Event
 from typing import Any, Optional
 
 import docker

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -140,7 +140,6 @@ def test_async_profiler_already_running(
 
 @pytest.mark.parametrize("in_container", [True])
 def test_java_async_profiler_cpu_mode(
-    tmp_path: Path,
     application_pid: int,
     assert_collapsed: AssertInCollapsed,
     profiler_state: ProfilerState,
@@ -162,7 +161,6 @@ def test_java_async_profiler_cpu_mode(
 @pytest.mark.parametrize("in_container", [True])
 @pytest.mark.parametrize("application_image_tag", ["musl"])
 def test_java_async_profiler_musl_and_cpu(
-    tmp_path: Path,
     application_pid: int,
     assert_collapsed: AssertInCollapsed,
     profiler_state: ProfilerState,
@@ -185,14 +183,13 @@ def test_java_async_profiler_musl_and_cpu(
         assert "/libgcc_s.so" not in maps
 
 
-def test_java_safemode_parameters(tmp_path: Path, profiler_state: ProfilerState) -> None:
+def test_java_safemode_parameters(profiler_state: ProfilerState) -> None:
     with pytest.raises(AssertionError) as excinfo:
         make_java_profiler(profiler_state, java_version_check=False)
     assert "Java version checks are mandatory in --java-safemode" in str(excinfo.value)
 
 
 def test_java_safemode_version_check(
-    tmp_path: Path,
     monkeypatch: MonkeyPatch,
     caplog: LogCaptureFixture,
     application_pid: int,
@@ -214,7 +211,6 @@ def test_java_safemode_version_check(
 
 
 def test_java_safemode_build_number_check(
-    tmp_path: Path,
     monkeypatch: MonkeyPatch,
     caplog: LogCaptureFixture,
     application_pid: int,
@@ -244,7 +240,6 @@ def test_java_safemode_build_number_check(
 )
 def test_hotspot_error_file(
     application_pid: int,
-    tmp_path: Path,
     monkeypatch: MonkeyPatch,
     caplog: LogCaptureFixture,
     profiler_state: ProfilerState,
@@ -275,7 +270,6 @@ def test_hotspot_error_file(
 
 def test_disable_java_profiling(
     application_pid: int,
-    tmp_path: Path,
     monkeypatch: MonkeyPatch,
     caplog: LogCaptureFixture,
     profiler_state: ProfilerState,
@@ -293,7 +287,6 @@ def test_disable_java_profiling(
 
 
 def test_already_loaded_async_profiler_profiling_failure(
-    tmp_path: Path,
     monkeypatch: MonkeyPatch,
     caplog: LogCaptureFixture,
     application_pid: int,
@@ -378,7 +371,6 @@ def test_async_profiler_stops_after_given_timeout(
 @pytest.mark.parametrize("in_container", [True])
 @pytest.mark.parametrize("application_image_tag,search_for", [("j9", "OpenJ9"), ("zing", "Zing")])
 def test_sanity_other_jvms(
-    tmp_path: Path,
     application_pid: int,
     assert_collapsed: AssertInCollapsed,
     search_for: str,
@@ -397,7 +389,6 @@ def test_sanity_other_jvms(
 # test only once. in a container, so that we don't mess up the environment :)
 @pytest.mark.parametrize("in_container", [True])
 def test_java_deleted_libjvm(
-    tmp_path: Path,
     application_pid: int,
     application_docker_container: Container,
     assert_collapsed: AssertInCollapsed,
@@ -463,7 +454,6 @@ def test_java_noexec_dirs(
 
 @pytest.mark.parametrize("in_container", [True])
 def test_java_symlinks_in_paths(
-    tmp_path: Path,
     application_pid: int,
     application_docker_container: Container,
     assert_collapsed: AssertInCollapsed,
@@ -508,7 +498,6 @@ def test_java_symlinks_in_paths(
 
 @pytest.mark.parametrize("in_container", [True])  # only in container is enough
 def test_java_appid_and_metadata_before_process_exits(
-    tmp_path: Path,
     application_pid: int,
     assert_collapsed: AssertInCollapsed,
     monkeypatch: MonkeyPatch,
@@ -550,7 +539,6 @@ def test_java_appid_and_metadata_before_process_exits(
 
 @pytest.mark.parametrize("in_container", [True])  # only in container is enough
 def test_java_attach_socket_missing(
-    tmp_path: Path,
     application_pid: int,
     profiler_state: ProfilerState,
 ) -> None:
@@ -575,7 +563,6 @@ def test_java_attach_socket_missing(
 # we know what messages to expect when in container, not on the host Java
 @pytest.mark.parametrize("in_container", [True])
 def test_java_jattach_async_profiler_log_output(
-    tmp_path: Path,
     application_pid: int,
     caplog: LogCaptureFixture,
     profiler_state: ProfilerState,
@@ -614,7 +601,6 @@ def test_java_jattach_async_profiler_log_output(
     ],
 )
 def test_java_different_basename(
-    tmp_path: Path,
     docker_client: DockerClient,
     application_docker_image: Image,
     assert_collapsed: AssertInCollapsed,
@@ -680,7 +666,6 @@ def test_java_different_basename(
 @pytest.mark.parametrize("in_container", [True])
 @pytest.mark.parametrize("insert_dso_name", [False, True])
 def test_dso_name_in_ap_profile(
-    tmp_path: Path,
     application_pid: int,
     insert_dso_name: bool,
     profiler_state: ProfilerState,
@@ -700,7 +685,6 @@ def test_dso_name_in_ap_profile(
 @pytest.mark.parametrize("insert_dso_name", [False, True])
 @pytest.mark.parametrize("libc_pattern", [r"(^|;)\(/.*/libc-.*\.so\)($|;)"])
 def test_handling_missing_symbol_in_profile(
-    tmp_path: Path,
     application_pid: int,
     insert_dso_name: bool,
     libc_pattern: str,
@@ -717,7 +701,6 @@ def test_handling_missing_symbol_in_profile(
 
 @pytest.mark.parametrize("in_container", [True])
 def test_meminfo_logged(
-    tmp_path: Path,
     application_pid: int,
     caplog: LogCaptureFixture,
     profiler_state: ProfilerState,
@@ -735,7 +718,6 @@ def test_meminfo_logged(
 # test that java frames include no semicolon but use a pipe '|' character instead, as implemented by AP
 @pytest.mark.parametrize("in_container", [True])
 def test_java_frames_include_no_semicolons(
-    tmp_path: Path,
     application_pid: int,
     profiler_state: ProfilerState,
 ) -> None:
@@ -763,7 +745,6 @@ def test_java_frames_include_no_semicolons(
 # test that async profiler doesn't print anything to applications stdout, stderr streams
 @pytest.mark.parametrize("in_container", [True])
 def test_no_stray_output_in_stdout_stderr(
-    tmp_path: Path,
     application_pid: int,
     application_docker_container: Container,
     monkeypatch: MonkeyPatch,

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -79,7 +79,6 @@ def test_nodejs_attach_maps_from_container(
 @pytest.mark.parametrize("runtime", ["nodejs"])
 @pytest.mark.parametrize("application_image_tag", ["without-flags"])
 def test_twoprocesses_nodejs_attach_maps(
-    tmp_path: Path,
     assert_collapsed: AssertInCollapsed,
     profiler_type: str,
     profiler_flags: List[str],
@@ -126,7 +125,6 @@ def test_twoprocesses_nodejs_attach_maps(
 @pytest.mark.parametrize("profiler_type", ["attach-maps"])
 @pytest.mark.parametrize("runtime", ["nodejs"])
 def test_nodejs_matrix(
-    tmp_path: Path,
     application_pid: int,
     application_docker_container: Container,
     assert_collapsed: AssertInCollapsed,

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -3,7 +3,6 @@
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 from contextlib import _GeneratorContextManager
 from pathlib import Path
-from threading import Event
 from typing import Callable, Container, List
 
 import pytest
@@ -136,7 +135,6 @@ def test_nodejs_matrix(
     application_image_tag: str,
     profiler_state: ProfilerState,
 ) -> None:
-    profiler_state = ProfilerState(Event(), str(tmp_path), False)
     with SystemProfiler(
         1000,
         6,

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -12,6 +12,7 @@ from docker.models.images import Image
 
 from gprofiler.consts import CPU_PROFILING_MODE
 from gprofiler.merge import parse_one_collapsed
+from gprofiler.profiler_state import ProfilerState
 from gprofiler.profilers.perf import SystemProfiler
 from tests import CONTAINERS_DIRECTORY
 from tests.conftest import AssertInCollapsed
@@ -35,14 +36,13 @@ def test_nodejs_attach_maps(
     command_line: List[str],
     runtime_specific_args: List[str],
 ) -> None:
+    profiler_state = ProfilerState(Event(), str(tmp_path), False)
     with SystemProfiler(
         1000,
         6,
-        Event(),
-        str(tmp_path),
+        profiler_state,
         False,
         CPU_PROFILING_MODE,
-        False,
         perf_mode="fp",
         perf_inject=False,
         perf_dwarf_stack_size=0,
@@ -92,14 +92,13 @@ def test_twoprocesses_nodejs_attach_maps(
 ) -> None:
     with application_factory() as pid1:
         with application_factory() as pid2:
+            profiler_state = ProfilerState(Event(), str(tmp_path), False)
             with SystemProfiler(
                 1000,
                 6,
-                Event(),
-                str(tmp_path),
+                profiler_state,
                 False,
                 CPU_PROFILING_MODE,
-                False,
                 perf_mode="fp",
                 perf_inject=False,
                 perf_dwarf_stack_size=0,
@@ -142,14 +141,13 @@ def test_nodejs_matrix(
     profiler_flags: List[str],
     application_image_tag: str,
 ) -> None:
+    profiler_state = ProfilerState(Event(), str(tmp_path), False)
     with SystemProfiler(
         1000,
         6,
-        Event(),
-        str(tmp_path),
+        profiler_state,
         False,
         CPU_PROFILING_MODE,
-        False,
         perf_mode="fp",
         perf_inject=False,
         perf_dwarf_stack_size=0,

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -10,7 +10,6 @@ import pytest
 from docker import DockerClient
 from docker.models.images import Image
 
-from gprofiler.consts import CPU_PROFILING_MODE
 from gprofiler.merge import parse_one_collapsed
 from gprofiler.profiler_state import ProfilerState
 from gprofiler.profilers.perf import SystemProfiler

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -29,20 +29,17 @@ from tests.utils import (
 @pytest.mark.parametrize("application_image_tag", ["without-flags"])
 @pytest.mark.parametrize("command_line", [["node", f"{CONTAINERS_DIRECTORY}/nodejs/fibonacci.js"]])
 def test_nodejs_attach_maps(
-    tmp_path: Path,
     application_pid: int,
     assert_collapsed: AssertInCollapsed,
     profiler_type: str,
     command_line: List[str],
     runtime_specific_args: List[str],
+    profiler_state: ProfilerState,
 ) -> None:
-    profiler_state = ProfilerState(Event(), str(tmp_path), False)
     with SystemProfiler(
         1000,
         6,
         profiler_state,
-        False,
-        CPU_PROFILING_MODE,
         perf_mode="fp",
         perf_inject=False,
         perf_dwarf_stack_size=0,
@@ -89,16 +86,14 @@ def test_twoprocesses_nodejs_attach_maps(
     profiler_type: str,
     profiler_flags: List[str],
     application_factory: Callable[[], _GeneratorContextManager],
+    profiler_state: ProfilerState,
 ) -> None:
     with application_factory() as pid1:
         with application_factory() as pid2:
-            profiler_state = ProfilerState(Event(), str(tmp_path), False)
             with SystemProfiler(
                 1000,
                 6,
                 profiler_state,
-                False,
-                CPU_PROFILING_MODE,
                 perf_mode="fp",
                 perf_inject=False,
                 perf_dwarf_stack_size=0,
@@ -140,14 +135,13 @@ def test_nodejs_matrix(
     runtime_specific_args: List[str],
     profiler_flags: List[str],
     application_image_tag: str,
+    profiler_state: ProfilerState,
 ) -> None:
     profiler_state = ProfilerState(Event(), str(tmp_path), False)
     with SystemProfiler(
         1000,
         6,
         profiler_state,
-        False,
-        CPU_PROFILING_MODE,
         perf_mode="fp",
         perf_inject=False,
         perf_dwarf_stack_size=0,

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -35,13 +35,11 @@ def system_profiler(tmp_path: Path, perf_mode: str, insert_dso_name: bool) -> Sy
 
 
 def make_system_profiler(tmp_path: Path, perf_mode: str, insert_dso_name: bool) -> SystemProfiler:
-    profiler_state = ProfilerState(Event(), str(tmp_path), False)
+    profiler_state = ProfilerState(Event(), str(tmp_path), False, insert_dso_name, CPU_PROFILING_MODE)
     return SystemProfiler(
         99,
         1,
         profiler_state,
-        insert_dso_name,
-        CPU_PROFILING_MODE,
         perf_mode=perf_mode,
         perf_inject=False,
         perf_dwarf_stack_size=DEFAULT_PERF_DWARF_STACK_SIZE,

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -24,11 +24,6 @@ from tests.utils import (
 
 
 @pytest.fixture
-def insert_dso_name() -> bool:
-    return False
-
-
-@pytest.fixture
 def system_profiler(
     tmp_path: Path, perf_mode: str, insert_dso_name: bool, profiler_state: ProfilerState
 ) -> SystemProfiler:

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -30,12 +30,11 @@ def insert_dso_name() -> bool:
 
 
 @pytest.fixture
-def system_profiler(tmp_path: Path, perf_mode: str, insert_dso_name: bool) -> SystemProfiler:
-    return make_system_profiler(tmp_path, perf_mode, insert_dso_name)
+def system_profiler(tmp_path: Path, perf_mode: str, insert_dso_name: bool, profiler_state: ProfilerState) -> SystemProfiler:
+    return make_system_profiler(perf_mode, profiler_state)
 
 
-def make_system_profiler(tmp_path: Path, perf_mode: str, insert_dso_name: bool) -> SystemProfiler:
-    profiler_state = ProfilerState(Event(), str(tmp_path), False, insert_dso_name, CPU_PROFILING_MODE)
+def make_system_profiler(perf_mode: str, profiler_state: ProfilerState) -> SystemProfiler:
     return SystemProfiler(
         99,
         1,

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -12,7 +12,6 @@ import pytest
 from docker.models.containers import Container
 from pytest import LogCaptureFixture
 
-from gprofiler.consts import CPU_PROFILING_MODE
 from gprofiler.profiler_state import ProfilerState
 from gprofiler.profilers.perf import DEFAULT_PERF_DWARF_STACK_SIZE, SystemProfiler
 from gprofiler.utils import wait_event
@@ -30,7 +29,9 @@ def insert_dso_name() -> bool:
 
 
 @pytest.fixture
-def system_profiler(tmp_path: Path, perf_mode: str, insert_dso_name: bool, profiler_state: ProfilerState) -> SystemProfiler:
+def system_profiler(
+    tmp_path: Path, perf_mode: str, insert_dso_name: bool, profiler_state: ProfilerState
+) -> SystemProfiler:
     return make_system_profiler(perf_mode, profiler_state)
 
 

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -4,7 +4,6 @@
 #
 
 import logging
-from pathlib import Path
 from threading import Event
 from typing import cast
 
@@ -24,9 +23,7 @@ from tests.utils import (
 
 
 @pytest.fixture
-def system_profiler(
-    perf_mode: str, insert_dso_name: bool, profiler_state: ProfilerState
-) -> SystemProfiler:
+def system_profiler(perf_mode: str, insert_dso_name: bool, profiler_state: ProfilerState) -> SystemProfiler:
     return make_system_profiler(perf_mode, profiler_state)
 
 

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -11,6 +11,7 @@ import pytest
 from docker.models.containers import Container
 
 from gprofiler.consts import CPU_PROFILING_MODE
+from gprofiler.profiler_state import ProfilerState
 from gprofiler.profilers.perf import DEFAULT_PERF_DWARF_STACK_SIZE, SystemProfiler
 from tests.utils import (
     assert_function_in_collapsed,
@@ -31,14 +32,13 @@ def system_profiler(tmp_path: Path, perf_mode: str, insert_dso_name: bool) -> Sy
 
 
 def make_system_profiler(tmp_path: Path, perf_mode: str, insert_dso_name: bool) -> SystemProfiler:
+    profiler_state = ProfilerState(Event(), str(tmp_path), False)
     return SystemProfiler(
         99,
         1,
-        Event(),
-        str(tmp_path),
+        profiler_state,
         insert_dso_name,
         CPU_PROFILING_MODE,
-        False,
         perf_mode=perf_mode,
         perf_inject=False,
         perf_dwarf_stack_size=DEFAULT_PERF_DWARF_STACK_SIZE,

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -25,7 +25,7 @@ from tests.utils import (
 
 @pytest.fixture
 def system_profiler(
-    tmp_path: Path, perf_mode: str, insert_dso_name: bool, profiler_state: ProfilerState
+    perf_mode: str, insert_dso_name: bool, profiler_state: ProfilerState
 ) -> SystemProfiler:
     return make_system_profiler(perf_mode, profiler_state)
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -141,7 +141,6 @@ def test_dso_name_in_pyperf_profile(
     insert_dso_name: bool,
     profiler_state: ProfilerState,
 ) -> None:
-    profiler_state = ProfilerState(Event(), str(tmp_path), False, insert_dso_name, CPU_PROFILING_MODE)
     with PythonProfiler(1000, 2, profiler_state, profiler_type, True, None) as profiler:
         profile = snapshot_pid_profile(profiler, application_pid)
     python_version, _, _ = application_image_tag.split("-")

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -3,7 +3,6 @@
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
 import os
-from pathlib import Path
 
 import psutil
 import pytest

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -28,7 +28,6 @@ def runtime() -> str:
 @pytest.mark.parametrize("in_container", [True])
 @pytest.mark.parametrize("application_image_tag", ["libpython"])
 def test_python_select_by_libpython(
-    tmp_path: Path,
     application_pid: int,
     assert_collapsed: AssertInCollapsed,
     profiler_state: ProfilerState,
@@ -71,7 +70,6 @@ def test_python_select_by_libpython(
 )
 @pytest.mark.parametrize("profiler_type", ["py-spy", "pyperf"])
 def test_python_matrix(
-    tmp_path: Path,
     application_pid: int,
     assert_collapsed: AssertInCollapsed,
     profiler_type: str,
@@ -131,7 +129,6 @@ def test_python_matrix(
     ],
 )
 def test_dso_name_in_pyperf_profile(
-    tmp_path: Path,
     application_pid: int,
     assert_collapsed: AssertInCollapsed,
     profiler_type: str,

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -4,13 +4,11 @@
 #
 import os
 from pathlib import Path
-from threading import Event
 
 import psutil
 import pytest
 from granulate_utils.linux.process import is_musl
 
-from gprofiler.consts import CPU_PROFILING_MODE
 from gprofiler.profiler_state import ProfilerState
 from gprofiler.profilers.python import PythonProfiler
 from tests.conftest import AssertInCollapsed

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -142,9 +142,7 @@ def test_dso_name_in_pyperf_profile(
     profiler_state: ProfilerState,
 ) -> None:
     profiler_state = ProfilerState(Event(), str(tmp_path), False, insert_dso_name, CPU_PROFILING_MODE)
-    with PythonProfiler(
-        1000, 2, profiler_state, profiler_type, True, None
-    ) as profiler:
+    with PythonProfiler(1000, 2, profiler_state, profiler_type, True, None) as profiler:
         profile = snapshot_pid_profile(profiler, application_pid)
     python_version, _, _ = application_image_tag.split("-")
     interpreter_frame = "PyEval_EvalFrameEx" if python_version == "2.7" else "_PyEval_EvalFrameDefault"

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -11,6 +11,7 @@ import pytest
 from granulate_utils.linux.process import is_musl
 
 from gprofiler.consts import CPU_PROFILING_MODE
+from gprofiler.profiler_state import ProfilerState
 from gprofiler.profilers.python import PythonProfiler
 from tests.conftest import AssertInCollapsed
 from tests.utils import (
@@ -39,9 +40,8 @@ def test_python_select_by_libpython(
     We expect to select these because they have "libpython" in their "/proc/pid/maps".
     This test runs a Python named "shmython".
     """
-    with PythonProfiler(
-        1000, 1, Event(), str(tmp_path), False, CPU_PROFILING_MODE, False, "pyspy", True, None
-    ) as profiler:
+    profiler_state = ProfilerState(Event(), str(tmp_path), False)
+    with PythonProfiler(1000, 1, profiler_state, False, CPU_PROFILING_MODE, "pyspy", True, None) as profiler:
         process_collapsed = snapshot_pid_collapsed(profiler, application_pid)
     assert_collapsed(process_collapsed)
     assert all(stack.startswith("shmython") for stack in process_collapsed.keys())
@@ -87,9 +87,8 @@ def test_python_matrix(
     if python_version == "2.7" and profiler_type == "pyperf" and app == "uwsgi":
         pytest.xfail("This combination fails, see https://github.com/Granulate/gprofiler/issues/485")
 
-    with PythonProfiler(
-        1000, 2, Event(), str(tmp_path), False, CPU_PROFILING_MODE, False, profiler_type, True, None
-    ) as profiler:
+    profiler_state = ProfilerState(Event(), str(tmp_path), False)
+    with PythonProfiler(1000, 2, profiler_state, False, CPU_PROFILING_MODE, profiler_type, True, None) as profiler:
         profile = snapshot_pid_profile(profiler, application_pid)
 
     collapsed = profile.stacks
@@ -141,8 +140,9 @@ def test_dso_name_in_pyperf_profile(
     application_image_tag: str,
     insert_dso_name: bool,
 ) -> None:
+    profiler_state = ProfilerState(Event(), str(tmp_path), False)
     with PythonProfiler(
-        1000, 2, Event(), str(tmp_path), insert_dso_name, CPU_PROFILING_MODE, False, profiler_type, True, None
+        1000, 2, profiler_state, insert_dso_name, CPU_PROFILING_MODE, profiler_type, True, None
     ) as profiler:
         profile = snapshot_pid_profile(profiler, application_pid)
     python_version, _, _ = application_image_tag.split("-")

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -55,7 +55,6 @@ def test_java_from_host(
 
 @pytest.mark.parametrize("runtime", ["python"])
 def test_pyspy(
-    tmp_path: Path,
     application_pid: int,
     assert_collapsed: AssertInCollapsed,
     assert_app_id: Callable,
@@ -75,7 +74,6 @@ def test_pyspy(
 
 @pytest.mark.parametrize("runtime", ["php"])
 def test_phpspy(
-    tmp_path: Path,
     application_pid: int,
     assert_collapsed: AssertInCollapsed,
     in_container: bool,
@@ -97,7 +95,6 @@ def test_phpspy(
 
 @pytest.mark.parametrize("runtime", ["ruby"])
 def test_rbspy(
-    tmp_path: Path,
     application_pid: int,
     assert_collapsed: AssertInCollapsed,
     gprofiler_docker_image: Image,
@@ -110,7 +107,6 @@ def test_rbspy(
 
 @pytest.mark.parametrize("runtime", ["dotnet"])
 def test_dotnet_trace(
-    tmp_path: Path,
     application_pid: int,
     assert_collapsed: AssertInCollapsed,
     gprofiler_docker_image: Image,
@@ -123,7 +119,6 @@ def test_dotnet_trace(
 
 @pytest.mark.parametrize("runtime", ["nodejs"])
 def test_nodejs(
-    tmp_path: Path,
     application_pid: int,
     assert_collapsed: AssertInCollapsed,
     gprofiler_docker_image: Image,
@@ -145,7 +140,6 @@ def test_nodejs(
 
 @pytest.mark.parametrize("runtime", ["python"])
 def test_python_ebpf(
-    tmp_path: Path,
     application_pid: int,
     assert_collapsed: AssertInCollapsed,
     assert_app_id: Callable,

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -60,10 +60,10 @@ def test_pyspy(
     assert_collapsed: AssertInCollapsed,
     assert_app_id: Callable,
     python_version: Optional[str],
+    profiler_state: ProfilerState,
 ) -> None:
     _ = assert_app_id  # Required for mypy unused argument warning
-    profiler_state = ProfilerState(Event(), str(tmp_path), False)
-    with PySpyProfiler(1000, 3, profiler_state, False, CPU_PROFILING_MODE, add_versions=True) as profiler:
+    with PySpyProfiler(1000, 3, profiler_state, add_versions=True) as profiler:
         # not using snapshot_one_collapsed because there are multiple Python processes running usually.
         process_collapsed = snapshot_pid_collapsed(profiler, application_pid)
         assert_collapsed(process_collapsed)
@@ -79,17 +79,15 @@ def test_phpspy(
     application_pid: int,
     assert_collapsed: AssertInCollapsed,
     in_container: bool,
+    profiler_state: ProfilerState,
 ) -> None:
     if not in_container:
         pytest.skip("Flaky https://github.com/Granulate/gprofiler/issues/630")
 
-    profiler_state = ProfilerState(Event(), str(tmp_path), False)
     with PHPSpyProfiler(
         1000,
         PHPSPY_DURATION,
         profiler_state,
-        False,
-        CPU_PROFILING_MODE,
         php_process_filter="php",
         php_mode="phpspy",
     ) as profiler:
@@ -103,9 +101,9 @@ def test_rbspy(
     application_pid: int,
     assert_collapsed: AssertInCollapsed,
     gprofiler_docker_image: Image,
+    profiler_state: ProfilerState,
 ) -> None:
-    profiler_state = ProfilerState(Event(), str(tmp_path), False)
-    with RbSpyProfiler(1000, 3, profiler_state, False, CPU_PROFILING_MODE, "rbspy") as profiler:
+    with RbSpyProfiler(1000, 3, profiler_state, "rbspy") as profiler:
         process_collapsed = snapshot_pid_collapsed(profiler, application_pid)
         assert_collapsed(process_collapsed)
 
@@ -116,9 +114,9 @@ def test_dotnet_trace(
     application_pid: int,
     assert_collapsed: AssertInCollapsed,
     gprofiler_docker_image: Image,
+    profiler_state: ProfilerState,
 ) -> None:
-    profiler_state = ProfilerState(Event(), str(tmp_path), False)
-    with DotnetProfiler(1000, 3, profiler_state, False, CPU_PROFILING_MODE, "dotnet-trace") as profiler:
+    with DotnetProfiler(1000, 3, profiler_state, "dotnet-trace") as profiler:
         process_collapsed = snapshot_pid_collapsed(profiler, application_pid)
         assert_collapsed(process_collapsed)
 
@@ -129,14 +127,12 @@ def test_nodejs(
     application_pid: int,
     assert_collapsed: AssertInCollapsed,
     gprofiler_docker_image: Image,
+    profiler_state: ProfilerState,
 ) -> None:
-    profiler_state = ProfilerState(Event(), str(tmp_path), False)
     with SystemProfiler(
         1000,
         6,
         profiler_state,
-        False,
-        CPU_PROFILING_MODE,
         perf_mode="fp",
         perf_inject=True,
         perf_dwarf_stack_size=0,
@@ -156,10 +152,10 @@ def test_python_ebpf(
     gprofiler_docker_image: Image,
     python_version: Optional[str],
     no_kernel_headers: Any,
+    profiler_state: ProfilerState,
 ) -> None:
     _ = assert_app_id  # Required for mypy unused argument warning
-    profiler_state = ProfilerState(Event(), str(tmp_path), False)
-    with PythonEbpfProfiler(1000, 5, profiler_state, False, CPU_PROFILING_MODE, add_versions=True) as profiler:
+    with PythonEbpfProfiler(1000, 5, profiler_state, add_versions=True) as profiler:
         try:
             process_collapsed = snapshot_pid_collapsed(profiler, application_pid)
         except UnicodeDecodeError as e:

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -13,7 +13,6 @@ import pytest
 from docker import DockerClient
 from docker.models.images import Image
 
-from gprofiler.consts import CPU_PROFILING_MODE
 from gprofiler.merge import parse_one_collapsed
 from gprofiler.profiler_state import ProfilerState
 from gprofiler.profilers.dotnet import DotnetProfiler

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -41,10 +41,11 @@ def test_java_from_host(
     application_pid: int,
     assert_app_id: Callable,
     assert_collapsed: AssertInCollapsed,
+    profiler_state: ProfilerState,
 ) -> None:
     with make_java_profiler(
+        profiler_state,
         frequency=99,
-        storage_dir=str(tmp_path_world_accessible),
         java_async_profiler_mode="itimer",
     ) as profiler:
         _ = assert_app_id  # Required for mypy unused argument warning

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,7 +17,6 @@ from docker.models.containers import Container
 from docker.models.images import Image
 from docker.types import Mount
 
-from gprofiler.consts import CPU_PROFILING_MODE
 from gprofiler.gprofiler_types import ProfileData, StackToSampleCount
 from gprofiler.profiler_state import ProfilerState
 from gprofiler.profilers.java import (
@@ -188,12 +187,9 @@ def snapshot_pid_collapsed(profiler: ProfilerInterface, pid: int) -> StackToSamp
 
 
 def make_java_profiler(
+    profiler_state: ProfilerState,
     frequency: int = 11,
     duration: int = 1,
-    stop_event: Event = Event(),
-    insert_dso_name: bool = False,
-    storage_dir: str = None,
-    profile_spawned_processes: bool = False,
     java_version_check: bool = True,
     java_async_profiler_mode: str = "cpu",
     java_async_profiler_safemode: int = JAVA_ASYNC_PROFILER_DEFAULT_SAFEMODE,
@@ -204,10 +200,7 @@ def make_java_profiler(
     java_async_profiler_report_meminfo: bool = True,
     java_collect_spark_app_name_as_appid: bool = False,
     java_mode: str = "ap",
-    profiling_mode: str = CPU_PROFILING_MODE,
 ) -> JavaProfiler:
-    assert storage_dir is not None
-    profiler_state = ProfilerState(stop_event, storage_dir, profile_spawned_processes, insert_dso_name, profiling_mode)
     return JavaProfiler(
         frequency=frequency,
         duration=duration,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -207,12 +207,11 @@ def make_java_profiler(
     profiling_mode: str = CPU_PROFILING_MODE,
 ) -> JavaProfiler:
     assert storage_dir is not None
-    profiler_state = ProfilerState(stop_event, storage_dir, profile_spawned_processes)
+    profiler_state = ProfilerState(stop_event, storage_dir, profile_spawned_processes, insert_dso_name, profiling_mode)
     return JavaProfiler(
         frequency=frequency,
         duration=duration,
         profiler_state=profiler_state,
-        insert_dso_name=insert_dso_name,
         java_version_check=java_version_check,
         java_async_profiler_mode=java_async_profiler_mode,
         java_async_profiler_safemode=java_async_profiler_safemode,
@@ -222,7 +221,6 @@ def make_java_profiler(
         java_async_profiler_mcache=java_async_profiler_mcache,
         java_collect_spark_app_name_as_appid=java_collect_spark_app_name_as_appid,
         java_mode=java_mode,
-        profiling_mode=profiling_mode,
         java_async_profiler_report_meminfo=java_async_profiler_report_meminfo,
     )
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -19,6 +19,7 @@ from docker.types import Mount
 
 from gprofiler.consts import CPU_PROFILING_MODE
 from gprofiler.gprofiler_types import ProfileData, StackToSampleCount
+from gprofiler.profiler_state import ProfilerState
 from gprofiler.profilers.java import (
     JAVA_ASYNC_PROFILER_DEFAULT_SAFEMODE,
     JAVA_SAFEMODE_ALL,
@@ -206,13 +207,12 @@ def make_java_profiler(
     profiling_mode: str = CPU_PROFILING_MODE,
 ) -> JavaProfiler:
     assert storage_dir is not None
+    profiler_state = ProfilerState(stop_event, storage_dir, profile_spawned_processes)
     return JavaProfiler(
         frequency=frequency,
         duration=duration,
-        stop_event=stop_event,
-        storage_dir=storage_dir,
+        profiler_state=profiler_state,
         insert_dso_name=insert_dso_name,
-        profile_spawned_processes=profile_spawned_processes,
         java_version_check=java_version_check,
         java_async_profiler_mode=java_async_profiler_mode,
         java_async_profiler_safemode=java_async_profiler_safemode,


### PR DESCRIPTION
Refactor code to make any future changes in profilers parameters easier. Created another object that keeps "state parameters" for profilers.
As mentioned in https://github.com/Granulate/gprofiler/pull/667, 