### PR TITLE
dataproc: collect Spark metrics when spark-metrics attribute is 1

### DIFF
--- a/deploy/dataproc/gprofiler_initialization_action.sh
+++ b/deploy/dataproc/gprofiler_initialization_action.sh
@@ -14,12 +14,20 @@ readonly GPROFILER_SERVICE
 ENABLE_STDOUT=$(/usr/share/google/get_metadata_value attributes/enable-stdout)
 readonly ENABLE_STDOUT
 
+SPARK_METRICS=$(/usr/share/google/get_metadata_value attributes/spark-metrics)
+readonly SPARK_METRICS
+
 OUTPUT_REDIRECTION=""
 if [ "$ENABLE_STDOUT" != "1" ]; then
   OUTPUT_REDIRECTION="> /dev/null 2>&1"
 fi
 
+flags=""
+if [[ "$SPARK_METRICS" == "1" ]]; then
+	flags="$flags --collect-spark-metrics"
+fi
+
 wget --no-verbose "https://github.com/Granulate/gprofiler/releases/latest/download/gprofiler_$(uname -m)" -O gprofiler
 sudo chmod +x gprofiler
-sudo sh -c "setsid ./gprofiler -cu --token='$GPROFILER_TOKEN' --service-name='$GPROFILER_SERVICE' $OUTPUT_REDIRECTION &"
+sudo sh -c "setsid ./gprofiler -cu --token='$GPROFILER_TOKEN' --service-name='$GPROFILER_SERVICE' $flags $OUTPUT_REDIRECTION &"
 echo "gProfiler installed successfully."

--- a/deploy/dataproc/gprofiler_initialization_action.sh
+++ b/deploy/dataproc/gprofiler_initialization_action.sh
@@ -14,7 +14,7 @@ readonly GPROFILER_SERVICE
 ENABLE_STDOUT=$(/usr/share/google/get_metadata_value attributes/enable-stdout)
 readonly ENABLE_STDOUT
 
-SPARK_METRICS=$(/usr/share/google/get_metadata_value attributes/spark-metrics)
+SPARK_METRICS=$(/usr/share/google/get_metadata_value attributes/spark-metrics || true)
 readonly SPARK_METRICS
 
 OUTPUT_REDIRECTION=""


### PR DESCRIPTION
Tested using:

```sh
gsutil cp deploy/dataproc/gprofiler_initialization_action.sh gs://.../gprofiler_initialization_action.sh
export TOKEN='...'
export SERVICE='dataproc'
gcloud dataproc clusters create gprofiler-spark \
   --initialization-actions gs://.../gprofiler_initialization_action.sh \
   --metadata gprofiler-token="$TOKEN",gprofiler-service="$SERVICE",spark-metrics=1,enable-stdout="1" --region us-east1
```

with both `spark-metrics=1` and w/o. Works as expected; with it appends `--collect-spark-metrics` to command, without it does not.