### PR TITLE
Disabled spark_collector applications metrics by default

### DIFF
--- a/gprofiler/spark/spark_collector.py
+++ b/gprofiler/spark/spark_collector.py
@@ -71,8 +71,8 @@ class SparkCollector:
         master_address: str,
         *,
         cluster_metrics: bool = True,
-        applications_metrics: bool = True,
-        streaming_metrics: bool = True,
+        applications_metrics: bool = False,
+        streaming_metrics: bool = False,
     ) -> None:
         self._last_sample_time_ms = 0
         self._cluster_mode = cluster_mode


### PR DESCRIPTION
Applications metrics is their current form result in too high metrics cardinality. Disabling them for now until we improve it.