### PR TITLE
Enable running gprofiler executable on Alpine

### DIFF
--- a/.github/workflows/build-executable-test-deploy.yml
+++ b/.github/workflows/build-executable-test-deploy.yml
@@ -50,12 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         containers:
-          # TODO alpine doesn't work, I get FileNotFoundError: [Errno 2] No such file or directory: '/tmp/_MEIMV2FRL/gprofiler/resources/java/jattach',
-          # which is probably due to the musl ld.so being used instead of the glibc one jattach was built for.
-          # we can force the use the glibc ld.so (like used for PyPerf, see get_pyperf_cmd) but in general we need a distribution of
-          # async-profiler compiled for musl (because libasyncProfiler.so itself is to be loaded to musl-based processes).
-          # The Python process seems like it's not being identified.
-          # - alpine
+          - alpine
           - ubuntu:14.04
           - ubuntu:16.04
           - ubuntu:18.04

--- a/README.md
+++ b/README.md
@@ -165,12 +165,6 @@ The logs can then be viewed in their default location (`/var/log/gprofiler`).
 
 `TMPDIR` is added because gProfiler unpacks executables to `/tmp` by default; this is done by `staticx`. For cases where `/tmp` is marked with `noexec`, we add `TMPDIR=/proc/self/cwd` to have everything unpacked in your current working directory, which is surely executable before gProfiler was started in it.
 
-### Executable known issues
-The following platforms are currently not supported with the gProfiler executable:
-+ Alpine
-
-**Remark:** container-based execution works and can be used in those cases.
-
 ## Running as systemd service
 
 You can generate a systemd service configuration that [runs gProfiler as an executable](#running-as-an-executable) (and therefore, bears the same [known issues](#executable-known-issues)) by running:

--- a/gprofiler/profilers/dotnet.py
+++ b/gprofiler/profilers/dotnet.py
@@ -129,4 +129,4 @@ class DotnetProfiler(ProcessProfilerBase):
             )
 
     def _select_processes_to_profile(self) -> List[Process]:
-        return pgrep_maps(r"(?:^.+/dotnet[^/]*$)")
+        return pgrep_maps(r"(^.+/dotnet[^/]*$)")

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -250,7 +250,7 @@ class PySpyProfiler(SpawningProcessProfilerBase):
             all_processes = [x for x in pgrep_exe("python")]
         else:
             all_processes = [
-                x for x in pgrep_maps(r"(^.+/(lib)?python[^/]*$)|(^.+/site-packages/.+?$)|(^.+/dist-packages/.+?$)")
+                x for x in pgrep_maps(DETECTED_PYTHON_PROCESSES_REGEX)
             ]
 
         for process in all_processes:

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -249,7 +249,9 @@ class PySpyProfiler(SpawningProcessProfilerBase):
         if is_windows():
             all_processes = [x for x in pgrep_exe("python")]
         else:
-            all_processes = [x for x in pgrep_maps(DETECTED_PYTHON_PROCESSES_REGEX)]
+            all_processes = [
+                x for x in pgrep_maps(r"(^.+/(?:lib)?python[^/]*$)|(^.+/site-packages/.+?$)|(^.+/dist-packages/.+?$)")
+            ]
 
         for process in all_processes:
             try:

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -250,7 +250,7 @@ class PySpyProfiler(SpawningProcessProfilerBase):
             all_processes = [x for x in pgrep_exe("python")]
         else:
             all_processes = [
-                x for x in pgrep_maps(r"(^.+/(?:lib)?python[^/]*$)|(^.+/site-packages/.+?$)|(^.+/dist-packages/.+?$)")
+                x for x in pgrep_maps(r"(^.+/(lib)?python[^/]*$)|(^.+/site-packages/.+?$)|(^.+/dist-packages/.+?$)")
             ]
 
         for process in all_processes:

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -249,9 +249,7 @@ class PySpyProfiler(SpawningProcessProfilerBase):
         if is_windows():
             all_processes = [x for x in pgrep_exe("python")]
         else:
-            all_processes = [
-                x for x in pgrep_maps(DETECTED_PYTHON_PROCESSES_REGEX)
-            ]
+            all_processes = [x for x in pgrep_maps(DETECTED_PYTHON_PROCESSES_REGEX)]
 
         for process in all_processes:
             try:

--- a/gprofiler/profilers/ruby.py
+++ b/gprofiler/profilers/ruby.py
@@ -65,7 +65,7 @@ class RbSpyProfiler(SpawningProcessProfilerBase):
     RESOURCE_PATH = "ruby/rbspy"
     MAX_FREQUENCY = 100
     _EXTRA_TIMEOUT = 10  # extra time like given to py-spy
-    DETECTED_RUBY_PROCESSES_REGEX = r"(?:^.+/ruby[^/]*$)"
+    DETECTED_RUBY_PROCESSES_REGEX = r"(^.+/ruby[^/]*$)"
 
     def __init__(
         self,

--- a/gprofiler/utils/__init__.py
+++ b/gprofiler/utils/__init__.py
@@ -313,6 +313,7 @@ else:
 
 def pgrep_maps(match: str) -> List[Process]:
     # this is much faster than iterating over processes' maps with psutil.
+    # We use flag -E in grep to support systems where grep is not PCRE
     result = run_process(
         f"grep -lE '{match}' /proc/*/maps",
         stdout=subprocess.PIPE,

--- a/gprofiler/utils/__init__.py
+++ b/gprofiler/utils/__init__.py
@@ -314,7 +314,7 @@ else:
 def pgrep_maps(match: str) -> List[Process]:
     # this is much faster than iterating over processes' maps with psutil.
     result = run_process(
-        f"grep -lP '{match}' /proc/*/maps",
+        f"grep -lE '{match}' /proc/*/maps",
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         shell=True,


### PR DESCRIPTION
## Description
Alpine grep doesn't support flag -P (Perl compatible regular expressions), so pgrep_map method now uses -E (Extended regular expressions)

## Related Issue
https://github.com/Granulate/gprofiler/issues/636