### PR TITLE
metrics: send time as ISO8601

### DIFF
--- a/gprofiler/client.py
+++ b/gprofiler/client.py
@@ -241,7 +241,7 @@ class APIClient(BaseAPIClient):
 
 def bake_metrics_payload(snapshot: MetricsSnapshot) -> Dict[str, Any]:
     return {
-        "format_version": 0,
+        "format_version": 2,
         "timestamp": get_iso8601_format_time(snapshot.timestamp),
         "metrics": [sample.__dict__ for sample in snapshot.samples],
     }

--- a/gprofiler/client.py
+++ b/gprofiler/client.py
@@ -16,7 +16,7 @@ from gprofiler.exceptions import APIError
 from gprofiler.log import get_logger_adapter
 from gprofiler.metadata.system_metadata import get_hostname
 from gprofiler.metrics import MetricsSnapshot
-from gprofiler.utils import get_iso8601_format_time, get_iso8601_format_time_from_epoch_time
+from gprofiler.utils import format_as_short_iso8601, get_iso8601_format_time, get_iso8601_format_time_from_epoch_time
 
 if TYPE_CHECKING:
     from gprofiler.system_metrics import Metrics
@@ -242,6 +242,6 @@ class APIClient(BaseAPIClient):
 def bake_metrics_payload(snapshot: MetricsSnapshot) -> Dict[str, Any]:
     return {
         "format_version": 0,
-        "timestamp": int(snapshot.timestamp.timestamp()),
+        "timestamp": format_as_short_iso8601(snapshot.timestamp),
         "metrics": [sample.__dict__ for sample in snapshot.samples],
     }

--- a/gprofiler/client.py
+++ b/gprofiler/client.py
@@ -241,7 +241,7 @@ class APIClient(BaseAPIClient):
 
 def bake_metrics_payload(snapshot: MetricsSnapshot) -> Dict[str, Any]:
     return {
-        "format_version": 2,
+        "format_version": 1,
         "timestamp": get_iso8601_format_time(snapshot.timestamp),
         "metrics": [sample.__dict__ for sample in snapshot.samples],
     }

--- a/gprofiler/client.py
+++ b/gprofiler/client.py
@@ -16,7 +16,7 @@ from gprofiler.exceptions import APIError
 from gprofiler.log import get_logger_adapter
 from gprofiler.metadata.system_metadata import get_hostname
 from gprofiler.metrics import MetricsSnapshot
-from gprofiler.utils import format_as_short_iso8601, get_iso8601_format_time, get_iso8601_format_time_from_epoch_time
+from gprofiler.utils import get_iso8601_format_time, get_iso8601_format_time_from_epoch_time
 
 if TYPE_CHECKING:
     from gprofiler.system_metrics import Metrics
@@ -242,6 +242,6 @@ class APIClient(BaseAPIClient):
 def bake_metrics_payload(snapshot: MetricsSnapshot) -> Dict[str, Any]:
     return {
         "format_version": 0,
-        "timestamp": format_as_short_iso8601(snapshot.timestamp),
+        "timestamp": get_iso8601_format_time(snapshot.timestamp),
         "metrics": [sample.__dict__ for sample in snapshot.samples],
     }

--- a/gprofiler/utils/__init__.py
+++ b/gprofiler/utils/__init__.py
@@ -362,16 +362,6 @@ def get_iso8601_format_time(time: datetime.datetime) -> str:
     return time.replace(microsecond=0).isoformat()
 
 
-def format_as_short_iso8601(dt: datetime.datetime) -> str:
-    """
-    Format a datetime object as ISO 8601. If the timezone is UTC, indicate it with a Z suffix instead of +00:00.
-    """
-    s = dt.isoformat(timespec="seconds")
-    if s.endswith("+00:00"):
-        s = s[:-6] + "Z"
-    return s
-
-
 def remove_prefix(s: str, prefix: str) -> str:
     # like str.removeprefix of Python 3.9, but this also ensures the prefix exists.
     assert s.startswith(prefix), f"{s} doesn't start with {prefix}"

--- a/gprofiler/utils/__init__.py
+++ b/gprofiler/utils/__init__.py
@@ -366,9 +366,9 @@ def format_as_short_iso8601(dt: datetime.datetime) -> str:
     """
     Format a datetime object as ISO 8601. If the timezone is UTC, indicate it with a Z suffix instead of +00:00.
     """
-    s = dt.isoformat(timespec='seconds')
-    if s.endswith('+00:00'):
-        s = s[:-6] + 'Z'
+    s = dt.isoformat(timespec="seconds")
+    if s.endswith("+00:00"):
+        s = s[:-6] + "Z"
     return s
 
 

--- a/gprofiler/utils/__init__.py
+++ b/gprofiler/utils/__init__.py
@@ -362,6 +362,16 @@ def get_iso8601_format_time(time: datetime.datetime) -> str:
     return time.replace(microsecond=0).isoformat()
 
 
+def format_as_short_iso8601(dt: datetime.datetime) -> str:
+    """
+    Format a datetime object as ISO 8601. If the timezone is UTC, indicate it with a Z suffix instead of +00:00.
+    """
+    s = dt.isoformat(timespec='seconds')
+    if s.endswith('+00:00'):
+        s = s[:-6] + 'Z'
+    return s
+
+
 def remove_prefix(s: str, prefix: str) -> str:
     # like str.removeprefix of Python 3.9, but this also ensures the prefix exists.
     assert s.startswith(prefix), f"{s} doesn't start with {prefix}"


### PR DESCRIPTION
~The existing `get_iso8601_format_time` cannot be changed because the server might not support Z-suffixed timestamps, which we've agreed to use for the spark metrics :/~

Agreed to send in long format.