### PR TITLE
Set RLIMIT_CORE=0 to disable generation of core files

### DIFF
--- a/gprofiler/utils/__init__.py
+++ b/gprofiler/utils/__init__.py
@@ -9,6 +9,7 @@ import logging
 import os
 import random
 import re
+import resource
 import shutil
 import signal
 import socket
@@ -451,6 +452,13 @@ def reset_umask() -> None:
     Resets our umask back to a sane value.
     """
     os.umask(0o022)
+
+
+def disable_core_files() -> None:
+    """
+    Prevents core files from being generated for processes executed by us.
+    """
+    resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
 
 
 def limit_frequency(


### PR DESCRIPTION
Closes: https://github.com/Granulate/gprofiler/issues/732

I tested it by:
* Setting `/proc/sys/kernel/core_pattern` on my box to `/core.%p`.
* Running gProfiler from this branch with `--dont-disable-core-files`
* `pkill -SIGSEGV PyPerf`
* Core file appears
* Running gProfiler from this branch **without** `--dont-disable-core-files`
* `pkill -SIGSEGV PyPerf`
* Core file doesn't appear
* Also ran `cat /proc/gprofiler_pid/limits` and ensured that core file has limits `0 0`.