### PR TITLE
java: Use glibc build of async-profiler for glibc-compat processes

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -102,6 +102,11 @@ def frequency_to_ap_interval(frequency: int) -> int:
 
 @functools.lru_cache(maxsize=1024)
 def needs_musl_ap_cached(process: Process) -> bool:
+    """
+    AP needs musl build if the JVM itself is built against musl. If the JVM is built against glibc,
+    we need the glibc build of AP. For this reason we also check for glibc-compat, which is an indicator
+    for glibc-based JVM despite having musl loaded.
+    """
     maps = process.memory_maps()
     return is_musl(process, maps) and not any("glibc-compat" in m.path for m in maps)
 

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -101,8 +101,9 @@ def frequency_to_ap_interval(frequency: int) -> int:
 
 
 @functools.lru_cache(maxsize=1024)
-def is_musl_cached(process: Process) -> bool:
-    return is_musl(process)
+def needs_musl_ap_cached(process: Process) -> bool:
+    maps = process.memory_maps()
+    return is_musl(process, maps) and not any("glibc-compat" in m.path for m in maps)
 
 
 JAVA_SAFEMODE_ALL = "all"  # magic value for *all* options from JavaSafemodeOptions
@@ -461,7 +462,7 @@ class AsyncProfiledProcess:
         self._ap_dir_host = os.path.join(
             self._find_rw_exec_dir(POSSIBLE_AP_DIRS),
             f"async-profiler-{get_ap_version()}",
-            "musl" if self._is_musl() else "glibc",
+            "musl" if self._needs_musl_ap() else "glibc",
         )
 
         self._libap_path_host = os.path.join(self._ap_dir_host, "libasyncProfiler.so")
@@ -541,9 +542,11 @@ class AsyncProfiledProcess:
                 return realpath
         return None
 
-    def _is_musl(self) -> bool:
-        # Is target process musl-based?
-        return is_musl_cached(self.process)
+    def _needs_musl_ap(self) -> bool:
+        """
+        Should we use the musl build of AP for this process?
+        """
+        return needs_musl_ap_cached(self.process)
 
     def _copy_libap(self) -> None:
         # copy *is* racy with respect to other processes running in the same namespace, because they all use
@@ -557,7 +560,7 @@ class AsyncProfiledProcess:
             if not os.path.exists(self._libap_path_host):
                 # atomically copy it
                 libap_resource = resource_path(
-                    os.path.join("java", "musl" if self._is_musl() else "glibc", "libasyncProfiler.so")
+                    os.path.join("java", "musl" if self._needs_musl_ap() else "glibc", "libasyncProfiler.so")
                 )
                 os.chmod(
                     libap_resource, 0o755


### PR DESCRIPTION
See related async-profiler ticket which explains further: https://github.com/async-profiler/async-profiler/pull/717

See the comment on `needs_musl_ap_cached()` for an explanation on this PR.
I'm not adding an automatic test now because async-profiler currently fails running on the image I used to test it, anyway. The glibc build requires libstdc++ (unlike the musl build) but the image has musl and glibc-compat but NO libstdc++. At the very least, we don't crash glibc-compat processes anymore :shrug: which is what happens before this PR. That's a start...

I'm not sure I plan to support a glibc build with static libstdc++ (for this case) because async-profiler might, in the near future, be libc agnostic, and then we have to restructure the code here anyway. My goal with this PR now is to avoid crashing glibc-compat processes.

I tested it against the image `ngrinder/controller:3.5.5` which runs a glibc-compat Java app.

Related granulate-utils PR: https://github.com/Granulate/granulate-utils/pull/134