### PR TITLE
utils: process exceptions: Strict type checks

### DIFF
--- a/gprofiler/exceptions.py
+++ b/gprofiler/exceptions.py
@@ -19,10 +19,23 @@ class CalledProcessError(subprocess.CalledProcessError):
     # Enough characters for 200 long lines
     MAX_STDIO_LENGTH = 120 * 200
 
-    def _truncate_stdio(self, string: str) -> str:
-        if len(string) > self.MAX_STDIO_LENGTH:
-            string = string[: self.MAX_STDIO_LENGTH - 3] + "..."
-        return string
+    def __init__(
+        self,
+        returncode: int,
+        cmd: Union[str, List[str]],
+        output: str,
+        stderr: str,
+    ):
+        assert isinstance(returncode, int), returncode
+        assert isinstance(cmd, str) or all(isinstance(s, str) for s in cmd), cmd
+        assert output is None or isinstance(output, str), output
+        assert stderr is None or isinstance(stderr, str), stderr
+        super().__init__(returncode, cmd, output, stderr)
+
+    def _truncate_stdio(self, stdio: str) -> str:
+        if len(stdio) > self.MAX_STDIO_LENGTH:
+            stdio = stdio[: self.MAX_STDIO_LENGTH - 3] + "..."
+        return stdio
 
     def __str__(self) -> str:
         if self.returncode and self.returncode < 0:
@@ -41,10 +54,10 @@ class CalledProcessTimeoutError(CalledProcessError):
         timeout: float,
         returncode: int,
         cmd: Union[str, List[str]],
-        stdout: Union[str, bytes],
-        stderr: Union[str, bytes],
+        output: str,
+        stderr: str,
     ):
-        super().__init__(returncode, cmd, stdout, stderr)
+        super().__init__(returncode, cmd, output, stderr)
         self.timeout = timeout
 
     def __str__(self) -> str:

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -650,6 +650,8 @@ class AsyncProfiledProcess:
                 kill_signal=signal.SIGTERM,
             )
         except CalledProcessError as e:  # catches CalledProcessTimeoutError as well
+            assert isinstance(e.stderr, str), f"unexpected type {type(e.stderr)}"
+
             ap_log = self._read_ap_log()
             try:
                 ap_loaded = (
@@ -661,7 +663,7 @@ class AsyncProfiledProcess:
             args = e.returncode, e.cmd, e.stdout, e.stderr, self.process.pid, ap_log, ap_loaded
             if isinstance(e, CalledProcessTimeoutError):
                 raise JattachTimeout(*args, timeout=self._jattach_timeout) from None
-            elif e.stderr == b"Could not start attach mechanism: No such file or directory\n":
+            elif e.stderr == "Could not start attach mechanism: No such file or directory\n":
                 # this is true for jattach_hotspot
                 raise JattachSocketMissingException(*args) from None
             else:

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -227,8 +227,10 @@ class PySpyProfiler(SpawningProcessProfilerBase):
                 logger.error(f"Profiling with py-spy timed out on process {process.pid}")
                 raise
             except CalledProcessError as e:
+                assert isinstance(e.stderr, str), f"unexpected type {type(e.stderr)}"
+
                 if (
-                    b"Error: Failed to get process executable name. Check that the process is running.\n" in e.stderr
+                    "Error: Failed to get process executable name. Check that the process is running.\n" in e.stderr
                     and not is_process_running(process)
                 ):
                     logger.debug(f"Profiled process {process.pid} exited before py-spy could start")

--- a/gprofiler/profilers/python_ebpf.py
+++ b/gprofiler/profilers/python_ebpf.py
@@ -80,6 +80,9 @@ class PythonEbpfProfiler(ProfilerBase):
             # opened in pipe mode, so these aren't None.
             assert process.stdout is not None
             assert process.stderr is not None
+            assert isinstance(process.args, list) and all(
+                isinstance(s, str) for s in process.args
+            ), process.args  # mypy
             stdout = process.stdout.read().decode()
             stderr = process.stderr.read().decode()
             raise PythonEbpfError(process.returncode, process.args, stdout, stderr)
@@ -222,6 +225,9 @@ class PythonEbpfProfiler(ProfilerBase):
             process = self.process  # save it
             exit_status, stderr, stdout = self._terminate()
             assert exit_status is not None, "PyPerf didn't exit after _terminate()!"
+            assert isinstance(process.args, list) and all(
+                isinstance(s, str) for s in process.args
+            ), process.args  # mypy
             raise PythonEbpfError(exit_status, process.args, stdout, stderr)
 
     def snapshot(self) -> ProcessToProfileData:

--- a/gprofiler/utils/perf.py
+++ b/gprofiler/utils/perf.py
@@ -21,13 +21,15 @@ def can_i_use_perf_events() -> bool:
     try:
         run_process([perf_path(), "record", "-o", "/dev/null", "--", "/bin/true"])
     except CalledProcessError as e:
+        assert isinstance(e.stderr, str), f"unexpected type {type(e.stderr)}"
+
         # perf's output upon start error (e.g due to permissions denied error)
         if not (
             e.returncode == 255
             and (
-                b"Access to performance monitoring and observability operations is limited" in e.stderr
-                or b"perf_event_open(..., PERF_FLAG_FD_CLOEXEC) failed with unexpected error" in e.stderr
-                or b"Permission error mapping pages.\n" in e.stderr
+                "Access to performance monitoring and observability operations is limited" in e.stderr
+                or "perf_event_open(..., PERF_FLAG_FD_CLOEXEC) failed with unexpected error" in e.stderr
+                or "Permission error mapping pages.\n" in e.stderr
             )
         ):
             logger.warning(


### PR DESCRIPTION
I looked at this area because I saw multiple errors like:
```
[2023-03-28 16:32:39,730] CRITICAL: gprofiler: Running perf failed; consider running gProfiler with '--perf-mode disabled' to avoid using perf
[2023-03-28 16:32:39,731] ERROR: gprofiler: Profiling run failed!
Traceback (most recent call last):
  File "gprofiler/main.py", line 378, in run_continuous
  File "gprofiler/main.py", line 310, in _snapshot
  File "concurrent/futures/_base.py", line 458, in result
  File "concurrent/futures/_base.py", line 403, in __get_result
  File "concurrent/futures/thread.py", line 58, in run
  File "gprofiler/profilers/perf.py", line 483, in snapshot
  File "gprofiler/profilers/perf.py", line 322, in wait_and_script
  File "gprofiler/utils/__init__.py", line 284, in run_process
gprofiler.exceptions.CalledProcessError: <unprintable CalledProcessError object>
```

These happen because `gprofiler.exceptions.CalledProcessError.__str__` raises an exception. I went over the code now and did another pass of validation on the inputs + added runtime asserts to catch such problems earlier.

I assume the problem here was `_truncate_stdio` adding a string to bytes input. Fixed in this PR.