### PR TITLE
Filter PIDs to profile

### DIFF
--- a/gprofiler/gprofiler_types.py
+++ b/gprofiler/gprofiler_types.py
@@ -6,7 +6,7 @@
 import re
 from collections import Counter
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, MutableMapping, Optional, Union
+from typing import Any, Callable, Dict, List, MutableMapping, Optional, Union
 
 import configargparse
 
@@ -74,6 +74,16 @@ def nonnegative_integer(value_str: str) -> int:
     if value < 0:
         raise configargparse.ArgumentTypeError("invalid non-negative integer value: {!r}".format(value))
     return value
+
+
+def integers_list(value_str: str) -> List[int]:
+    try:
+        pids = [int(pid) for pid in value_str.split(",")]
+    except ValueError:
+        raise configargparse.ArgumentTypeError(
+            "IntegerList should be a single integer, or comma separated list of integers f.e. 13,452,2388"
+        )
+    return pids
 
 
 def integer_range(min_range: int, max_range: int) -> Callable[[str], int]:

--- a/gprofiler/gprofiler_types.py
+++ b/gprofiler/gprofiler_types.py
@@ -81,7 +81,7 @@ def integers_list(value_str: str) -> List[int]:
         pids = [int(pid) for pid in value_str.split(",")]
     except ValueError:
         raise configargparse.ArgumentTypeError(
-            "IntegerList should be a single integer, or comma separated list of integers f.e. 13,452,2388"
+            "Integer list should be a single integer, or comma separated list of integers f.e. 13,452,2388"
         )
     return pids
 

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -786,7 +786,7 @@ def parse_cmd_args() -> configargparse.Namespace:
     if args.nodejs_mode in ("perf", "attach-maps") and args.perf_mode not in ("fp", "smart"):
         parser.error("--nodejs-mode perf or attach-maps requires --perf-mode 'fp' or 'smart'")
 
-    if args.profile_spawned_processes and len(args.pids_to_profile) > 0:
+    if args.profile_spawned_processes and args.pids_to_profile is not None:
         parser.error("--pids is not allowed when profiling spawned processes")
 
     return args

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -857,6 +857,7 @@ def verify_preconditions(args: configargparse.Namespace) -> None:
                 pids_to_profile.append(pid)
             except NoSuchProcess:
                 continue
+        setattr(args, "pids_to_profile", pids_to_profile)
         if len(pids_to_profile) == 0:
             print("There aren't any alive processes from provided via --pid PID list")
             sys.exit(1)

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -803,11 +803,11 @@ def parse_cmd_args() -> configargparse.Namespace:
 
     if args.profile_spawned_processes and len(args.pids_to_profile) > 0:
         parser.error("--pids is not allowed when profiling spawned processes")
-    
+
     pids_to_profile = []
     try:
         for input in args.pids_to_profile:
-            pids_to_profile.extend([int(pid) for pid in input.split(',')])
+            pids_to_profile.extend([int(pid) for pid in input.split(",")])
     except ValueError:
         parser.error("--pids should be integer or coma separated list of integers f.e. --pids 13,452,2388")
     setattr(args, "pids_to_profile", pids_to_profile)

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -148,15 +148,16 @@ class GProfiler:
         # the latter can be root only. the former can not. we should do this separation so we don't expose
         # files unnecessarily.
         container_names_client = ContainerNamesClient() if self._enrichment_options.container_names else None
-        self._profiler_state = ProfilerState(
-            Event(),
-            TEMPORARY_STORAGE_PATH,
-            profile_spawned_processes,
-            bool(user_args.get("insert_dso_name")),
-            profiling_mode,
-            pids_to_profile,
-            container_names_client,
-        )
+        profiler_state_kwargs = {
+            'stop_event': Event(),
+            'profile_spawned_processes': profile_spawned_processes,
+            'insert_dso_name': bool(user_args.get("insert_dso_name")),
+            'profiling_mode': profiling_mode,
+            'container_names_client': container_names_client,
+            'pids_to_profile': pids_to_profile,
+            'storage_dir': TEMPORARY_STORAGE_PATH
+        }
+        self._profiler_state = ProfilerState(**profiler_state_kwargs)
         self.system_profiler, self.process_profilers = get_profilers(user_args, profiler_state=self._profiler_state)
         self._usage_logger = usage_logger
         if collect_metrics:

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -963,8 +963,6 @@ def main() -> None:
         args.log_rotate_backup_count,
         remote_logs_handler,
     )
-    if processes_to_profile is not None:
-        logger.info("Target PIDs given by --pids: ", pids=[process.pid for process in processes_to_profile])
 
     setup_env(args.disable_core_files, args.pid_file)
 
@@ -982,7 +980,8 @@ def main() -> None:
         logger.info(
             "Running gProfiler", version=__version__, commandline=" ".join(sys.argv[1:]), arguments=args.__dict__
         )
-
+        if processes_to_profile is not None:
+            logger.info("Target PIDs given by --pids: ", pids=[process.pid for process in processes_to_profile])
         if args.controller_pid is not None:
             try:
                 controller_process: Optional[Process] = Process(args.controller_pid)

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -981,7 +981,7 @@ def main() -> None:
             "Running gProfiler", version=__version__, commandline=" ".join(sys.argv[1:]), arguments=args.__dict__
         )
         if processes_to_profile is not None:
-            logger.info("Target PIDs given by --pids: ", pids=[process.pid for process in processes_to_profile])
+            logger.info("Target PIDs given by --pids", pids=[process.pid for process in processes_to_profile])
         if args.controller_pid is not None:
             try:
                 controller_process: Optional[Process] = Process(args.controller_pid)

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -806,8 +806,17 @@ def parse_cmd_args() -> configargparse.Namespace:
 
     pids_to_profile = []
     try:
-        for input in args.pids_to_profile:
-            pids_to_profile.extend([int(pid) for pid in input.split(",")])
+        if len(args.pids_to_profile) > 0:
+            for input in args.pids_to_profile:
+                pids = [int(pid) for pid in input.split(",")]
+                for pid in pids:
+                    try:
+                        Process(pid)
+                        pids_to_profile.append(pid)
+                    except NoSuchProcess:
+                        continue
+            if len(pids_to_profile) == 0:
+                parser.error("There aren't any alive processes from provided PID list")
     except ValueError:
         parser.error("--pids should be integer or coma separated list of integers f.e. --pids 13,452,2388")
     setattr(args, "pids_to_profile", pids_to_profile)

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -528,8 +528,8 @@ def parse_cmd_args() -> configargparse.Namespace:
         dest="pids_to_profile",
         action="append",
         default=list(),
-        type=int,
-        help="List of processes that will be filtered to profile",
+        type=str,
+        help="Coma separated list of processes that will be filtered to profile",
     )
 
     _add_profilers_arguments(parser)
@@ -803,6 +803,14 @@ def parse_cmd_args() -> configargparse.Namespace:
 
     if args.profile_spawned_processes and len(args.pids_to_profile) > 0:
         parser.error("--pids is not allowed when profiling spawned processes")
+    
+    pids_to_profile = []
+    try:
+        for input in args.pids_to_profile:
+            pids_to_profile.extend([int(pid) for pid in input.split(',')])
+    except ValueError:
+        parser.error("--pids should be integer or coma separated list of integers f.e. --pids 13,452,2388")
+    setattr(args, "pids_to_profile", pids_to_profile)
 
     return args
 

--- a/gprofiler/profiler_state.py
+++ b/gprofiler/profiler_state.py
@@ -16,7 +16,7 @@ class ProfilerState:
         self._temporary_dir = TemporaryDirectoryWithMode(dir=kwargs.pop("storage_dir"), mode=0o755)
         self._storage_dir = self._temporary_dir.name
         self._container_names_client: Optional[ContainerNamesClient] = kwargs.get("container_names_client", None)
-        self._pids_to_profile: List[int] = kwargs.pop("pids_to_profile")
+        self._pids_to_profile: Optional[List[int]] = kwargs.pop("pids_to_profile")
 
     @property
     def stop_event(self) -> Event:

--- a/gprofiler/profiler_state.py
+++ b/gprofiler/profiler_state.py
@@ -9,14 +9,14 @@ class ProfilerState:
     # Class for storing generic state parameters. These parameters are the same for each profiler.
     # Thanks to that class adding new state parameters to profilers won't result changing code in every profiler.
     def __init__(self, **kwargs: Any) -> None:
-        self._stop_event = kwargs.pop('stop_event')
-        self._profile_spawned_processes = kwargs.pop('profile_spawned_processes')
-        self._insert_dso_name = kwargs.pop('insert_dso_name')
-        self._profiling_mode = kwargs.pop('profiling_mode')
-        self._temporary_dir = TemporaryDirectoryWithMode(dir=kwargs.pop('storage_dir'), mode=0o755)
+        self._stop_event: Event = kwargs.pop("stop_event")
+        self._profile_spawned_processes: bool = kwargs.pop("profile_spawned_processes")
+        self._insert_dso_name: bool = kwargs.pop("insert_dso_name")
+        self._profiling_mode: str = kwargs.pop("profiling_mode")
+        self._temporary_dir = TemporaryDirectoryWithMode(dir=kwargs.pop("storage_dir"), mode=0o755)
         self._storage_dir = self._temporary_dir.name
-        self._container_names_client = kwargs.pop('container_names_client')
-        self._pids_to_profile = kwargs.pop('pids_to_profile')
+        self._container_names_client: Optional[ContainerNamesClient] = kwargs.get("container_names_client", None)
+        self._pids_to_profile: List[int] = kwargs.pop("pids_to_profile")
 
     @property
     def stop_event(self) -> Event:
@@ -44,10 +44,7 @@ class ProfilerState:
 
     @property
     def pids_to_profile(self) -> Optional[List[int]]:
-        if len(self._pids_to_profile) > 0:
-            return self._pids_to_profile
-        else:
-            return None
+        return self._pids_to_profile
 
     def get_container_name(self, pid: int) -> str:
         if self._container_names_client is not None:

--- a/gprofiler/profiler_state.py
+++ b/gprofiler/profiler_state.py
@@ -53,7 +53,6 @@ class ProfilerState:
 
     @property
     def pids_to_profile(self) -> Optional[List[int]]:
-        print(f"Marcin debug {self._pids_to_profile}")
         if len(self._pids_to_profile) > 0:
             return self._pids_to_profile
         else:

--- a/gprofiler/profiler_state.py
+++ b/gprofiler/profiler_state.py
@@ -1,5 +1,5 @@
 from threading import Event
-from typing import Optional
+from typing import List, Optional
 
 from gprofiler.containers_client import ContainerNamesClient
 from gprofiler.utils import TemporaryDirectoryWithMode
@@ -15,6 +15,7 @@ class ProfilerState:
         profile_spawned_processes: bool,
         insert_dso_name: bool,
         profiling_mode: str,
+        pids_to_profile: List[int],
         container_names_client: Optional[ContainerNamesClient],
     ) -> None:
         self._stop_event = stop_event
@@ -24,6 +25,7 @@ class ProfilerState:
         self._temporary_dir = TemporaryDirectoryWithMode(dir=storage_dir, mode=0o755)
         self._storage_dir = self._temporary_dir.name
         self._container_names_client = container_names_client
+        self._pids_to_profile = pids_to_profile
 
     @property
     def stop_event(self) -> Event:
@@ -48,6 +50,14 @@ class ProfilerState:
     @property
     def container_names_client(self) -> Optional[ContainerNamesClient]:
         return self._container_names_client
+
+    @property
+    def pids_to_profile(self) -> Optional[List[int]]:
+        print(f"Marcin debug {self._pids_to_profile}")
+        if len(self._pids_to_profile) > 0:
+            return self._pids_to_profile
+        else:
+            return None
 
     def get_container_name(self, pid: int) -> str:
         if self._container_names_client is not None:

--- a/gprofiler/profiler_state.py
+++ b/gprofiler/profiler_state.py
@@ -1,5 +1,5 @@
 from threading import Event
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from gprofiler.containers_client import ContainerNamesClient
 from gprofiler.utils import TemporaryDirectoryWithMode
@@ -8,24 +8,15 @@ from gprofiler.utils import TemporaryDirectoryWithMode
 class ProfilerState:
     # Class for storing generic state parameters. These parameters are the same for each profiler.
     # Thanks to that class adding new state parameters to profilers won't result changing code in every profiler.
-    def __init__(
-        self,
-        stop_event: Event,
-        storage_dir: str,
-        profile_spawned_processes: bool,
-        insert_dso_name: bool,
-        profiling_mode: str,
-        pids_to_profile: List[int],
-        container_names_client: Optional[ContainerNamesClient],
-    ) -> None:
-        self._stop_event = stop_event
-        self._profile_spawned_processes = profile_spawned_processes
-        self._insert_dso_name = insert_dso_name
-        self._profiling_mode = profiling_mode
-        self._temporary_dir = TemporaryDirectoryWithMode(dir=storage_dir, mode=0o755)
+    def __init__(self, **kwargs: Any) -> None:
+        self._stop_event = kwargs.pop('stop_event')
+        self._profile_spawned_processes = kwargs.pop('profile_spawned_processes')
+        self._insert_dso_name = kwargs.pop('insert_dso_name')
+        self._profiling_mode = kwargs.pop('profiling_mode')
+        self._temporary_dir = TemporaryDirectoryWithMode(dir=kwargs.pop('storage_dir'), mode=0o755)
         self._storage_dir = self._temporary_dir.name
-        self._container_names_client = container_names_client
-        self._pids_to_profile = pids_to_profile
+        self._container_names_client = kwargs.pop('container_names_client')
+        self._pids_to_profile = kwargs.pop('pids_to_profile')
 
     @property
     def stop_event(self) -> Event:

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -393,9 +393,9 @@ class SystemProfiler(ProfilerBase):
         self._node_processes_attached: List[Process] = []
         self._perf_memory_restart = perf_memory_restart
         pid_args: List[str] = []
-        if self._profiler_state.pids_to_profile is not None:
+        if self._profiler_state.processes_to_profile is not None:
             pid_args.append("--pid")
-            pid_args.append(",".join([str(pid) for pid in self._profiler_state.pids_to_profile]))
+            pid_args.append(",".join([str(process.pid) for process in self._profiler_state.processes_to_profile]))
 
         if perf_mode in ("fp", "smart"):
             self._perf_fp: Optional[PerfProcess] = PerfProcess(

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -218,22 +218,26 @@ class PerfProcess:
         return f"perf ({self._type} mode)"
 
     def _get_perf_cmd(self) -> List[str]:
-        return [
-            perf_path(),
-            "record",
-            "-F",
-            str(self._frequency),
-            "-g",
-            "-o",
-            self._output_path,
-            "--switch-output=signal",
-            # explicitly pass '-m', otherwise perf defaults to deriving this number from perf_event_mlock_kb,
-            # and it ends up using it entirely (and we want to spare some for async-profiler)
-            # this number scales linearly with the number of active cores (so we don't need to do this calculation
-            # here)
-            "-m",
-            str(self._mmap_sizes[self._type]),
-        ] + self._pid_args + self._extra_args
+        return (
+            [
+                perf_path(),
+                "record",
+                "-F",
+                str(self._frequency),
+                "-g",
+                "-o",
+                self._output_path,
+                "--switch-output=signal",
+                # explicitly pass '-m', otherwise perf defaults to deriving this number from perf_event_mlock_kb,
+                # and it ends up using it entirely (and we want to spare some for async-profiler)
+                # this number scales linearly with the number of active cores (so we don't need to do this calculation
+                # here)
+                "-m",
+                str(self._mmap_sizes[self._type]),
+            ]
+            + self._pid_args
+            + self._extra_args
+        )
 
     def start(self) -> None:
         logger.info(f"Starting {self._log_name}")

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -392,10 +392,10 @@ class SystemProfiler(ProfilerBase):
         self._node_processes: List[Process] = []
         self._node_processes_attached: List[Process] = []
         self._perf_memory_restart = perf_memory_restart
-        extra_args: List[str] = []
+        pid_args: List[str] = []
         if self._profiler_state.pids_to_profile is not None:
-            extra_args.append("--pid")
-            extra_args.append(",".join([str(pid) for pid in self._profiler_state.pids_to_profile]))
+            pid_args.append("--pid")
+            pid_args.append(",".join([str(pid) for pid in self._profiler_state.pids_to_profile]))
 
         if perf_mode in ("fp", "smart"):
             self._perf_fp: Optional[PerfProcess] = PerfProcess(
@@ -404,21 +404,20 @@ class SystemProfiler(ProfilerBase):
                 os.path.join(self._profiler_state.storage_dir, "perf.fp"),
                 False,
                 perf_inject,
-                extra_args,
+                pid_args,
             )
             self._perfs.append(self._perf_fp)
         else:
             self._perf_fp = None
 
         if perf_mode in ("dwarf", "smart"):
-            extra_args.extend(["--call-graph", f"dwarf,{perf_dwarf_stack_size}"])
             self._perf_dwarf: Optional[PerfProcess] = PerfProcess(
                 self._frequency,
                 self._profiler_state.stop_event,
                 os.path.join(self._profiler_state.storage_dir, "perf.dwarf"),
                 True,
                 False,  # no inject in dwarf mode, yet
-                extra_args,
+                pid_args + ["--call-graph", f"dwarf,{perf_dwarf_stack_size}"],
             )
             self._perfs.append(self._perf_dwarf)
         else:

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -35,7 +35,7 @@ from gprofiler.profiler_state import ProfilerState
 from gprofiler.profilers.node import clean_up_node_maps, generate_map_for_node_processes, get_node_processes
 from gprofiler.profilers.profiler_base import ProfilerBase
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
-from gprofiler.utils import reap_process, remove_path, run_process, start_process, wait_event, wait_for_file_by_prefix
+from gprofiler.utils import extend_cmd_with_pids, reap_process, remove_path, run_process, start_process, wait_event, wait_for_file_by_prefix
 from gprofiler.utils.perf import perf_path, valid_perf_pid
 
 logger = get_logger_adapter(__name__)
@@ -160,7 +160,10 @@ def merge_global_perfs(
 
     total_fp_samples = sum([sum(stacks.values()) for stacks in fp_perf.values()])
     total_dwarf_samples = sum([sum(stacks.values()) for stacks in dwarf_perf.values()])
-    fp_to_dwarf_sample_ratio = total_fp_samples / total_dwarf_samples
+    if total_dwarf_samples == 0:
+        fp_to_dwarf_sample_ratio = 0 # ratio can be 0 because if total_dwarf_samples is 0 then it will be never used
+    else:
+        fp_to_dwarf_sample_ratio = total_fp_samples / total_dwarf_samples
 
     # The FP perf is used here as the "main" perf, to which the DWARF perf is scaled.
     merged_pid_to_stacks_counters: ProcessToStackSampleCounters = defaultdict(Counter)
@@ -389,6 +392,8 @@ class SystemProfiler(ProfilerBase):
         self._node_processes: List[Process] = []
         self._node_processes_attached: List[Process] = []
         self._perf_memory_restart = perf_memory_restart
+        extra_args = []
+        extra_args = extend_cmd_with_pids(extra_args, self._profiler_state)
 
         if perf_mode in ("fp", "smart"):
             self._perf_fp: Optional[PerfProcess] = PerfProcess(
@@ -397,20 +402,21 @@ class SystemProfiler(ProfilerBase):
                 os.path.join(self._profiler_state.storage_dir, "perf.fp"),
                 False,
                 perf_inject,
-                [],
+                extra_args,
             )
             self._perfs.append(self._perf_fp)
         else:
             self._perf_fp = None
 
         if perf_mode in ("dwarf", "smart"):
+            extra_args.extend(["--call-graph", f"dwarf,{perf_dwarf_stack_size}"])
             self._perf_dwarf: Optional[PerfProcess] = PerfProcess(
                 self._frequency,
                 self._profiler_state.stop_event,
                 os.path.join(self._profiler_state.storage_dir, "perf.dwarf"),
                 True,
                 False,  # no inject in dwarf mode, yet
-                ["--call-graph", f"dwarf,{perf_dwarf_stack_size}"],
+                extra_args,
             )
             self._perfs.append(self._perf_dwarf)
         else:

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -35,7 +35,15 @@ from gprofiler.profiler_state import ProfilerState
 from gprofiler.profilers.node import clean_up_node_maps, generate_map_for_node_processes, get_node_processes
 from gprofiler.profilers.profiler_base import ProfilerBase
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
-from gprofiler.utils import extend_cmd_with_pids, reap_process, remove_path, run_process, start_process, wait_event, wait_for_file_by_prefix
+from gprofiler.utils import (
+    extend_cmd_with_pids,
+    reap_process,
+    remove_path,
+    run_process,
+    start_process,
+    wait_event,
+    wait_for_file_by_prefix,
+)
 from gprofiler.utils.perf import perf_path, valid_perf_pid
 
 logger = get_logger_adapter(__name__)
@@ -161,7 +169,7 @@ def merge_global_perfs(
     total_fp_samples = sum([sum(stacks.values()) for stacks in fp_perf.values()])
     total_dwarf_samples = sum([sum(stacks.values()) for stacks in dwarf_perf.values()])
     if total_dwarf_samples == 0:
-        fp_to_dwarf_sample_ratio = 0 # ratio can be 0 because if total_dwarf_samples is 0 then it will be never used
+        fp_to_dwarf_sample_ratio = 0  # ratio can be 0 because if total_dwarf_samples is 0 then it will be never used
     else:
         fp_to_dwarf_sample_ratio = total_fp_samples / total_dwarf_samples
 

--- a/gprofiler/profilers/php.py
+++ b/gprofiler/profilers/php.py
@@ -19,7 +19,7 @@ from gprofiler.log import get_logger_adapter
 from gprofiler.profiler_state import ProfilerState
 from gprofiler.profilers.profiler_base import ProfilerBase
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
-from gprofiler.utils import extend_cmd_with_pids, random_prefix, reap_process, resource_path, start_process, wait_event
+from gprofiler.utils import random_prefix, reap_process, resource_path, start_process, wait_event
 
 logger = get_logger_adapter(__name__)
 # Currently tracing only php-fpm, TODO: support mod_php in apache.
@@ -87,7 +87,6 @@ class PHPSpyProfiler(ProfilerBase):
             str(self._output_path),
             # Duration is irrelevant here, we want to run continuously.
         ]
-        cmd = extend_cmd_with_pids(cmd, self._profiler_state)
 
         # importlib.resources doesn't provide a way to get a directory because it's not "a resource",
         # we use the same dir for required binaries, if they are not available.
@@ -195,6 +194,9 @@ class PHPSpyProfiler(ProfilerBase):
 
         profiles: ProcessToProfileData = {}
         for pid in results:
+            if profiler_state.pids_to_profile is not None:
+                if pid not in profiler_state.pids_to_profile:
+                    continue
             # TODO: appid & app metadata for php!
             appid = None
             app_metadata = None

--- a/gprofiler/profilers/php.py
+++ b/gprofiler/profilers/php.py
@@ -19,7 +19,7 @@ from gprofiler.log import get_logger_adapter
 from gprofiler.profiler_state import ProfilerState
 from gprofiler.profilers.profiler_base import ProfilerBase
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
-from gprofiler.utils import random_prefix, reap_process, resource_path, start_process, wait_event
+from gprofiler.utils import random_prefix, reap_process, resource_path, start_process, wait_event, extend_cmd_with_pids
 
 logger = get_logger_adapter(__name__)
 # Currently tracing only php-fpm, TODO: support mod_php in apache.
@@ -87,6 +87,7 @@ class PHPSpyProfiler(ProfilerBase):
             str(self._output_path),
             # Duration is irrelevant here, we want to run continuously.
         ]
+        cmd = extend_cmd_with_pids(cmd, self._profiler_state)
 
         # importlib.resources doesn't provide a way to get a directory because it's not "a resource",
         # we use the same dir for required binaries, if they are not available.

--- a/gprofiler/profilers/php.py
+++ b/gprofiler/profilers/php.py
@@ -194,6 +194,8 @@ class PHPSpyProfiler(ProfilerBase):
 
         profiles: ProcessToProfileData = {}
         for pid in results:
+            # Because of https://github.com/Granulate/gprofiler/issues/763,
+            # for now we only filter output of phpspy to return only profiles from chosen pids
             if profiler_state.pids_to_profile is not None:
                 if pid not in profiler_state.pids_to_profile:
                     continue

--- a/gprofiler/profilers/php.py
+++ b/gprofiler/profilers/php.py
@@ -196,8 +196,8 @@ class PHPSpyProfiler(ProfilerBase):
         for pid in results:
             # Because of https://github.com/Granulate/gprofiler/issues/763,
             # for now we only filter output of phpspy to return only profiles from chosen pids
-            if profiler_state.pids_to_profile is not None:
-                if pid not in profiler_state.pids_to_profile:
+            if profiler_state.processes_to_profile is not None:
+                if pid not in [process.pid for process in profiler_state.processes_to_profile]:
                     continue
             # TODO: appid & app metadata for php!
             appid = None

--- a/gprofiler/profilers/php.py
+++ b/gprofiler/profilers/php.py
@@ -19,7 +19,7 @@ from gprofiler.log import get_logger_adapter
 from gprofiler.profiler_state import ProfilerState
 from gprofiler.profilers.profiler_base import ProfilerBase
 from gprofiler.profilers.registry import ProfilerArgument, register_profiler
-from gprofiler.utils import random_prefix, reap_process, resource_path, start_process, wait_event, extend_cmd_with_pids
+from gprofiler.utils import extend_cmd_with_pids, random_prefix, reap_process, resource_path, start_process, wait_event
 
 logger = get_logger_adapter(__name__)
 # Currently tracing only php-fpm, TODO: support mod_php in apache.

--- a/gprofiler/profilers/profiler_base.py
+++ b/gprofiler/profilers/profiler_base.py
@@ -171,9 +171,9 @@ class ProcessProfilerBase(ProfilerBase):
     def snapshot(self) -> ProcessToProfileData:
         processes_to_profile = self._select_processes_to_profile()
         logger.debug(f"{self.__class__.__name__}: selected {len(processes_to_profile)} processes to profile")
-        if self._profiler_state.pids_to_profile is not None:
+        if self._profiler_state.processes_to_profile is not None:
             processes_to_profile = [
-                process for process in processes_to_profile if process.pid in self._profiler_state.pids_to_profile
+                process for process in processes_to_profile if process in self._profiler_state.processes_to_profile
             ]
             logger.debug(f"{self.__class__.__name__}: processes left after filtering: {len(processes_to_profile)}")
         self._notify_selected_processes(processes_to_profile)

--- a/gprofiler/profilers/profiler_base.py
+++ b/gprofiler/profilers/profiler_base.py
@@ -175,7 +175,8 @@ class ProcessProfilerBase(ProfilerBase):
             processes_to_profile = [
                 process for process in processes_to_profile if process in self._profiler_state.processes_to_profile
             ]
-            logger.debug(f"{self.__class__.__name__}: processes left after filtering: {len(processes_to_profile)}")
+            if len(processes_to_profile) > 0:
+                logger.debug(f"{self.__class__.__name__}: processes left after filtering: {len(processes_to_profile)}")
         self._notify_selected_processes(processes_to_profile)
 
         if not processes_to_profile:

--- a/gprofiler/profilers/profiler_base.py
+++ b/gprofiler/profilers/profiler_base.py
@@ -170,7 +170,12 @@ class ProcessProfilerBase(ProfilerBase):
 
     def snapshot(self) -> ProcessToProfileData:
         processes_to_profile = self._select_processes_to_profile()
+        print(f"Marcin debug2 : {processes_to_profile}")
         logger.debug(f"{self.__class__.__name__}: selected {len(processes_to_profile)} processes to profile")
+        if self._profiler_state.pids_to_profile is not None:
+            processes_to_profile = [process for process in processes_to_profile if process.pid in self._profiler_state.pids_to_profile]
+            print(f"Marcin debug3 : {processes_to_profile}")
+            logger.debug(f"Processes left after filtering: {len(processes_to_profile)}")
         self._notify_selected_processes(processes_to_profile)
 
         if not processes_to_profile:

--- a/gprofiler/profilers/profiler_base.py
+++ b/gprofiler/profilers/profiler_base.py
@@ -175,7 +175,7 @@ class ProcessProfilerBase(ProfilerBase):
             processes_to_profile = [
                 process for process in processes_to_profile if process.pid in self._profiler_state.pids_to_profile
             ]
-            logger.debug(f"Processes left after filtering: {len(processes_to_profile)}")
+            logger.debug(f"{self.__class__.__name__}: processes left after filtering: {len(processes_to_profile)}")
         self._notify_selected_processes(processes_to_profile)
 
         if not processes_to_profile:

--- a/gprofiler/profilers/profiler_base.py
+++ b/gprofiler/profilers/profiler_base.py
@@ -170,13 +170,11 @@ class ProcessProfilerBase(ProfilerBase):
 
     def snapshot(self) -> ProcessToProfileData:
         processes_to_profile = self._select_processes_to_profile()
-        print(f"Marcin debug2 : {processes_to_profile}")
         logger.debug(f"{self.__class__.__name__}: selected {len(processes_to_profile)} processes to profile")
         if self._profiler_state.pids_to_profile is not None:
             processes_to_profile = [
                 process for process in processes_to_profile if process.pid in self._profiler_state.pids_to_profile
             ]
-            print(f"Marcin debug3 : {processes_to_profile}")
             logger.debug(f"Processes left after filtering: {len(processes_to_profile)}")
         self._notify_selected_processes(processes_to_profile)
 

--- a/gprofiler/profilers/profiler_base.py
+++ b/gprofiler/profilers/profiler_base.py
@@ -173,7 +173,9 @@ class ProcessProfilerBase(ProfilerBase):
         print(f"Marcin debug2 : {processes_to_profile}")
         logger.debug(f"{self.__class__.__name__}: selected {len(processes_to_profile)} processes to profile")
         if self._profiler_state.pids_to_profile is not None:
-            processes_to_profile = [process for process in processes_to_profile if process.pid in self._profiler_state.pids_to_profile]
+            processes_to_profile = [
+                process for process in processes_to_profile if process.pid in self._profiler_state.pids_to_profile
+            ]
             print(f"Marcin debug3 : {processes_to_profile}")
             logger.debug(f"Processes left after filtering: {len(processes_to_profile)}")
         self._notify_selected_processes(processes_to_profile)

--- a/gprofiler/profilers/profiler_base.py
+++ b/gprofiler/profilers/profiler_base.py
@@ -171,12 +171,11 @@ class ProcessProfilerBase(ProfilerBase):
     def snapshot(self) -> ProcessToProfileData:
         processes_to_profile = self._select_processes_to_profile()
         logger.debug(f"{self.__class__.__name__}: selected {len(processes_to_profile)} processes to profile")
-        if self._profiler_state.processes_to_profile is not None:
+        if self._profiler_state.processes_to_profile is not None and len(processes_to_profile) > 0:
             processes_to_profile = [
                 process for process in processes_to_profile if process in self._profiler_state.processes_to_profile
             ]
-            if len(processes_to_profile) > 0:
-                logger.debug(f"{self.__class__.__name__}: processes left after filtering: {len(processes_to_profile)}")
+            logger.debug(f"{self.__class__.__name__}: processes left after filtering: {len(processes_to_profile)}")
         self._notify_selected_processes(processes_to_profile)
 
         if not processes_to_profile:

--- a/gprofiler/profilers/python_ebpf.py
+++ b/gprofiler/profilers/python_ebpf.py
@@ -21,7 +21,6 @@ from gprofiler.profiler_state import ProfilerState
 from gprofiler.profilers import python
 from gprofiler.profilers.profiler_base import ProfilerBase
 from gprofiler.utils import (
-    extend_cmd_with_pids,
     poll_process,
     random_prefix,
     reap_process,
@@ -133,7 +132,6 @@ class PythonEbpfProfiler(ProfilerBase):
             "--stack-offset",
             str(self._kernel_stack_offset()),
         ]
-        cmd = extend_cmd_with_pids(cmd, self._profiler_state)
         if self._verbose:
             # 4 is the max verbosityLevel in PyPerf.
             cmd.extend(["-v", "4"])

--- a/gprofiler/profilers/python_ebpf.py
+++ b/gprofiler/profilers/python_ebpf.py
@@ -238,13 +238,13 @@ class PythonEbpfProfiler(ProfilerBase):
             parsed = python._add_versions_to_stacks(parsed)
         profiles = {}
         for pid in parsed:
-            # Because of https://github.com/Granulate/gprofiler/issues/764,
-            # for now we only filter output of pyperf to return only profiles from chosen pids
-            if self._profiler_state.pids_to_profile is not None:
-                if pid not in self._profiler_state.pids_to_profile:
-                    continue
             try:
                 process = Process(pid)
+                # Because of https://github.com/Granulate/gprofiler/issues/764,
+                # for now we only filter output of pyperf to return only profiles from chosen pids
+                if self._profiler_state.processes_to_profile is not None:
+                    if process not in self._profiler_state.processes_to_profile:
+                        continue
                 appid = application_identifiers.get_python_app_id(process)
                 app_metadata = self._metadata.get_metadata(process)
                 container_name = self._profiler_state.get_container_name(pid)

--- a/gprofiler/profilers/python_ebpf.py
+++ b/gprofiler/profilers/python_ebpf.py
@@ -238,6 +238,11 @@ class PythonEbpfProfiler(ProfilerBase):
             parsed = python._add_versions_to_stacks(parsed)
         profiles = {}
         for pid in parsed:
+            # Because of https://github.com/Granulate/gprofiler/issues/764,
+            # for now we only filter output of pyperf to return only profiles from chosen pids
+            if self._profiler_state.pids_to_profile is not None:
+                if pid not in self._profiler_state.pids_to_profile:
+                    continue
             try:
                 process = Process(pid)
                 appid = application_identifiers.get_python_app_id(process)

--- a/gprofiler/profilers/python_ebpf.py
+++ b/gprofiler/profilers/python_ebpf.py
@@ -21,6 +21,7 @@ from gprofiler.profiler_state import ProfilerState
 from gprofiler.profilers import python
 from gprofiler.profilers.profiler_base import ProfilerBase
 from gprofiler.utils import (
+    extend_cmd_with_pids,
     poll_process,
     random_prefix,
     reap_process,
@@ -132,6 +133,7 @@ class PythonEbpfProfiler(ProfilerBase):
             "--stack-offset",
             str(self._kernel_stack_offset()),
         ]
+        cmd = extend_cmd_with_pids(cmd, self._profiler_state)
         if self._verbose:
             # 4 is the max verbosityLevel in PyPerf.
             cmd.extend(["-v", "4"])

--- a/gprofiler/utils/__init__.py
+++ b/gprofiler/utils/__init__.py
@@ -34,6 +34,7 @@ from psutil import Process
 
 from gprofiler.consts import CPU_PROFILING_MODE
 from gprofiler.platform import is_linux, is_windows
+from gprofiler.profiler_state import ProfilerState
 
 if is_windows():
     import pythoncom
@@ -523,3 +524,10 @@ def merge_dicts(source: Dict[str, Any], dest: Dict[str, Any]) -> Dict[str, Any]:
         else:
             dest[key] = value
     return dest
+
+
+def extend_cmd_with_pids(cmd: List[str], profiler_state: ProfilerState) -> List[str]:
+    if profiler_state.pids_to_profile is not None:
+        for pid in profiler_state.pids_to_profile:
+            cmd.extend(["-p", str(pid)])
+    return cmd

--- a/gprofiler/utils/__init__.py
+++ b/gprofiler/utils/__init__.py
@@ -34,7 +34,6 @@ from psutil import Process
 
 from gprofiler.consts import CPU_PROFILING_MODE
 from gprofiler.platform import is_linux, is_windows
-from gprofiler.profiler_state import ProfilerState
 
 if is_windows():
     import pythoncom
@@ -524,10 +523,3 @@ def merge_dicts(source: Dict[str, Any], dest: Dict[str, Any]) -> Dict[str, Any]:
         else:
             dest[key] = value
     return dest
-
-
-def extend_cmd_with_pids(cmd: List[str], profiler_state: ProfilerState) -> List[str]:
-    if profiler_state.pids_to_profile is not None:
-        for pid in profiler_state.pids_to_profile:
-            cmd.extend(["-p", str(pid)])
-    return cmd

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,7 +96,7 @@ def profiler_state(tmp_path: Path, insert_dso_name: bool) -> ProfilerState:
         "insert_dso_name": insert_dso_name,
         "profiling_mode": CPU_PROFILING_MODE,
         "container_names_client": ContainerNamesClient,
-        "pids_to_profile": list(),
+        "pids_to_profile": None,
         "storage_dir": str(tmp_path),
     }
     return ProfilerState(**profiler_state_kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,16 +90,15 @@ def java_args() -> Tuple[str]:
 
 @fixture()
 def profiler_state(tmp_path: Path, insert_dso_name: bool) -> ProfilerState:
-    profiler_state_kwargs = {
-        "stop_event": Event(),
-        "profile_spawned_processes": False,
-        "insert_dso_name": insert_dso_name,
-        "profiling_mode": CPU_PROFILING_MODE,
-        "container_names_client": ContainerNamesClient(),
-        "pids_to_profile": None,
-        "storage_dir": str(tmp_path),
-    }
-    return ProfilerState(**profiler_state_kwargs)
+    return ProfilerState(
+        stop_event=Event(),
+        profile_spawned_processes=False,
+        insert_dso_name=insert_dso_name,
+        profiling_mode=CPU_PROFILING_MODE,
+        container_names_client=ContainerNamesClient(),
+        processes_to_profile=None,
+        storage_dir=str(tmp_path),
+    )
 
 
 def make_path_world_accessible(path: Path) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,7 @@ def profiler_state(tmp_path: Path, insert_dso_name: bool) -> ProfilerState:
         "profile_spawned_processes": False,
         "insert_dso_name": insert_dso_name,
         "profiling_mode": CPU_PROFILING_MODE,
-        "container_names_client": ContainerNamesClient,
+        "container_names_client": ContainerNamesClient(),
         "pids_to_profile": None,
         "storage_dir": str(tmp_path),
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,9 +90,16 @@ def java_args() -> Tuple[str]:
 
 @fixture()
 def profiler_state(tmp_path: Path, insert_dso_name: bool) -> ProfilerState:
-    return ProfilerState(
-        Event(), str(tmp_path), False, insert_dso_name, CPU_PROFILING_MODE, list(), ContainerNamesClient()
-    )
+    profiler_state_kwargs = {
+        'stop_event': Event(),
+        'profile_spawned_processes': False,
+        'insert_dso_name': insert_dso_name,
+        'profiling_mode': CPU_PROFILING_MODE,
+        'container_names_client': ContainerNamesClient,
+        'pids_to_profile': list(),
+        'storage_dir': str(tmp_path)
+    }
+    return ProfilerState(**profiler_state_kwargs)
 
 
 def make_path_world_accessible(path: Path) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,7 +90,9 @@ def java_args() -> Tuple[str]:
 
 @fixture()
 def profiler_state(tmp_path: Path, insert_dso_name: bool) -> ProfilerState:
-    return ProfilerState(Event(), str(tmp_path), False, insert_dso_name, CPU_PROFILING_MODE, ContainerNamesClient())
+    return ProfilerState(
+        Event(), str(tmp_path), False, insert_dso_name, CPU_PROFILING_MODE, list(), ContainerNamesClient()
+    )
 
 
 def make_path_world_accessible(path: Path) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,13 +91,13 @@ def java_args() -> Tuple[str]:
 @fixture()
 def profiler_state(tmp_path: Path, insert_dso_name: bool) -> ProfilerState:
     profiler_state_kwargs = {
-        'stop_event': Event(),
-        'profile_spawned_processes': False,
-        'insert_dso_name': insert_dso_name,
-        'profiling_mode': CPU_PROFILING_MODE,
-        'container_names_client': ContainerNamesClient,
-        'pids_to_profile': list(),
-        'storage_dir': str(tmp_path)
+        "stop_event": Event(),
+        "profile_spawned_processes": False,
+        "insert_dso_name": insert_dso_name,
+        "profiling_mode": CPU_PROFILING_MODE,
+        "container_names_client": ContainerNamesClient,
+        "pids_to_profile": list(),
+        "storage_dir": str(tmp_path),
     }
     return ProfilerState(**profiler_state_kwargs)
 

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -311,7 +311,6 @@ def test_profiling_provided_pids(
                 profiler_flags,
             )
             wait_for_gprofiler_container(container, output_collapsed)
-            assert "selected 2 processes to profile" in container.logs().decode()
             assert "processes left after filtering: 1" in container.logs().decode()
             assert f"Profiling process {pid1} with async-profiler" in container.logs().decode()
             assert f"Profiling process {pid2} with async-profiler" not in container.logs().decode()

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -311,5 +311,7 @@ def test_profiling_provided_pids(
                 profiler_flags,
             )
             wait_for_gprofiler_container(container, output_collapsed)
+            assert "selected 2 processes to profile" in container.logs().decode()
+            assert "processes left after filtering: 1" in container.logs().decode()
             assert f"Profiling process {pid1} with async-profiler" in container.logs().decode()
             assert f"Profiling process {pid2} with async-profiler" not in container.logs().decode()

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -287,14 +287,14 @@ def test_container_name_when_stopped(
 @pytest.mark.parametrize("runtime", ["java"])
 @pytest.mark.parametrize("profiler_type", ["ap"])
 def test_profiling_provided_pids(
-        docker_client: DockerClient,
-        gprofiler_docker_image: Image,
-        output_directory: Path,
-        output_collapsed: Path,
-        runtime_specific_args: List[str],
-        profiler_flags: List[str],
-        application_factory: Callable[[], _GeneratorContextManager],
-        profiler_type: str,
+    docker_client: DockerClient,
+    gprofiler_docker_image: Image,
+    output_directory: Path,
+    output_collapsed: Path,
+    runtime_specific_args: List[str],
+    profiler_flags: List[str],
+    application_factory: Callable[[], _GeneratorContextManager],
+    profiler_type: str,
 ) -> None:
     """
     Tests that gprofiler will profile only processes provided via flag --pids
@@ -303,7 +303,12 @@ def test_profiling_provided_pids(
         with application_factory() as pid2:
             profiler_flags.extend(["--pids", str(pid1)])
             container = start_gprofiler_in_container_for_one_session(
-                docker_client, gprofiler_docker_image, output_directory, output_collapsed, runtime_specific_args, profiler_flags
+                docker_client,
+                gprofiler_docker_image,
+                output_directory,
+                output_collapsed,
+                runtime_specific_args,
+                profiler_flags,
             )
             wait_for_gprofiler_container(container, output_collapsed)
             assert f"Profiling process {pid1} with async-profiler" in container.logs().decode()


### PR DESCRIPTION
## Description
This PR:
- Add flag --pid that enables providing chosen pids to profile
- Checks if at least one of processes provided is alive
- pids are passed to profilers via ProfilerState
- Adds test for checking if only provided pid is profiled with async-profiler

## Related Issue
https://github.com/Granulate/gprofiler/issues/605

