### PR TITLE
Add --no-verify option to disable server certificate verification

### DIFF
--- a/gprofiler/client.py
+++ b/gprofiler/client.py
@@ -109,12 +109,14 @@ class ProfilerAPIClient(BaseAPIClient):
 
     def __init__(
         self,
+        *,
         token: str,
         service_name: str,
         server_address: str,
         curlify_requests: bool,
         hostname: str,
         upload_timeout: int,
+        verify: bool,
         version: str = "v1",
     ):
         self._server_address = server_address.rstrip("/")
@@ -123,10 +125,12 @@ class ProfilerAPIClient(BaseAPIClient):
         self._key = token
         self._service = service_name
         self._hostname = hostname
+        self._verify = verify
         super().__init__(curlify_requests)
 
     def _init_session(self) -> None:
         self._session: Session = requests.Session()
+        self._session.verify = self._verify
         self._session.headers.update({"GPROFILER-API-KEY": self._key, "GPROFILER-SERVICE-NAME": self._service})
 
         # Raises on failure

--- a/gprofiler/log.py
+++ b/gprofiler/log.py
@@ -49,11 +49,17 @@ class RemoteLogsHandler(BatchRequestsHandler):
 
     MAX_BUFFERED_RECORDS = 100 * 1000  # max number of records to buffer locally
 
-    def __init__(self, server_address: str, auth_token: str, service_name: str) -> None:
+    def __init__(self, server_address: str, auth_token: str, service_name: str, verify: bool) -> None:
         self._service_name = service_name
         url = urlparse(server_address)
         super().__init__(
-            Sender(application_name="gprofiler", auth_token=auth_token, scheme=url.scheme, server_address=url.netloc)
+            Sender(
+                application_name="gprofiler",
+                auth_token=auth_token,
+                scheme=url.scheme,
+                server_address=url.netloc,
+                verify=verify,
+            )
         )
 
     def emit(self, record: LogRecord) -> None:

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -621,6 +621,9 @@ def parse_cmd_args() -> configargparse.Namespace:
         connectivity.add_argument(
             "--curlify-requests", help="Log cURL commands for HTTP requests (used for debugging)", action="store_true"
         )
+        connectivity.add_argument(
+            "--no-verify", help="Do not verify server certificates", action="store_false", dest="verify"
+        )
 
     upload_file.set_defaults(func=send_collapsed_file_only)
 
@@ -916,7 +919,9 @@ def main() -> None:
     state = init_state()
 
     remote_logs_handler = (
-        RemoteLogsHandler(args.api_server, args.server_token, args.service_name) if _should_send_logs(args) else None
+        RemoteLogsHandler(args.api_server, args.server_token, args.service_name, args.verify)
+        if _should_send_logs(args)
+        else None
     )
     global logger
     logger = initial_root_logger_setup(
@@ -977,11 +982,12 @@ def main() -> None:
                 client_kwargs["upload_timeout"] = args.server_upload_timeout
             profiler_api_client = (
                 ProfilerAPIClient(
-                    args.server_token,
-                    args.service_name,
-                    args.server_host,
-                    args.curlify_requests,
-                    get_hostname(),
+                    token=args.server_token,
+                    service_name=args.service_name,
+                    server_address=args.server_host,
+                    curlify_requests=args.curlify_requests,
+                    hostname=get_hostname(),
+                    verify=args.verify,
                     **client_kwargs,
                 )
                 if args.upload_results


### PR DESCRIPTION
In certain non-SaaS deployments we'd like to run the server in HTTPS but with (possibly) dummy or self-signed certificates. This PR adds a simle option like curl's `--insecure`, wget's `--no-check-certificate` etc.

Tested by -
1. running a "simple HTTPS server" with self signed certificate per [this link](https://gist.github.com/dergachev/7028596?permalink_comment_id=4476598#gistcomment-4476598)
2. Testing with curl - without `-k` I get `curl: (60) SSL certificate problem: self-signed certificate`, with `-k` the connection is established.
3. Testing with gprofiler w/o this PR - getting `SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate (_ssl.c:1131)')` for the `get_health` check.
4. Testing with gprofiler with this PR without `--no-verify` - same error as the above ^^
5. Testing with gprofiler with this PR with `--no-verify` - connection is established (and then gProfiler whines on "unexpected response").
6. Did the same tests for the glogger - with `--no-verify` I get `Unsupported method ('POST') for url` (because my dummy server is `GET` only), without `--no-verify` I get `requests.exceptions.SSLError: HTTPSConnectionPool(host='127.0.0.1', port=3333): Max retries exceeded with url: /api/v1/logs (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate (_ssl.c:1131)')))`.