### PR TITLE
Java ap tryout asprof jattach passthru

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -217,11 +217,10 @@ COPY --from=phpspy-builder /tmp/phpspy/phpspy gprofiler/resources/php/phpspy
 COPY --from=phpspy-builder /tmp/binutils/binutils-2.25/bin/bin/objdump gprofiler/resources/php/objdump
 COPY --from=phpspy-builder /tmp/binutils/binutils-2.25/bin/bin/strings gprofiler/resources/php/strings
 
-COPY --from=async-profiler-builder-glibc /tmp/async-profiler/build/jattach gprofiler/resources/java/jattach
+COPY --from=async-profiler-builder-glibc /tmp/async-profiler/build/bin/asprof gprofiler/resources/java/asprof
 COPY --from=async-profiler-builder-glibc /tmp/async-profiler/build/async-profiler-version gprofiler/resources/java/async-profiler-version
-COPY --from=async-profiler-builder-glibc /tmp/async-profiler/build/libasyncProfiler.so gprofiler/resources/java/glibc/libasyncProfiler.so
-COPY --from=async-profiler-builder-musl /tmp/async-profiler/build/libasyncProfiler.so gprofiler/resources/java/musl/libasyncProfiler.so
-COPY --from=async-profiler-builder-glibc /tmp/async-profiler/build/fdtransfer gprofiler/resources/java/fdtransfer
+COPY --from=async-profiler-builder-glibc /tmp/async-profiler/build/lib/libasyncProfiler.so gprofiler/resources/java/glibc/libasyncProfiler.so
+COPY --from=async-profiler-builder-musl /tmp/async-profiler/build/lib/libasyncProfiler.so gprofiler/resources/java/musl/libasyncProfiler.so
 COPY --from=node-package-builder-musl /tmp/module_build gprofiler/resources/node/module/musl
 COPY --from=node-package-builder-glibc /tmp/module_build gprofiler/resources/node/module/glibc
 

--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -624,9 +624,7 @@ class AsyncProfiledProcess:
             f"log={self._log_path_process}"
             f"{f',fdtransfer={self._fdtransfer_path}' if self._mode == 'cpu' else ''}"
             f",safemode={self._ap_safemode},timeout={ap_timeout}"
-            f"{',lib' if self._profiler_state.insert_dso_name else ''}"
-            f"{self._get_extra_ap_args()}",
-            str(self.process.pid),
+            f"{',lib' if self._profiler_state.insert_dso_name else ''}{self._get_extra_ap_args()}"
         ]
 
     def _get_stop_cmd(self, with_output: bool) -> List[str]:
@@ -634,8 +632,7 @@ class AsyncProfiledProcess:
             f"stop,log={self._log_path_process},mcache={self._mcache}"
             f"{self._get_ap_output_args() if with_output else ''}"
             f"{',lib' if self._profiler_state.insert_dso_name else ''}{',meminfolog' if self._collect_meminfo else ''}"
-            f"{self._get_extra_ap_args()}",
-            str(self.process.pid),
+            f"{self._get_extra_ap_args()}"
         ]
 
     def _read_ap_log(self) -> str:
@@ -654,7 +651,7 @@ class AsyncProfiledProcess:
         try:
             # kill jattach with SIGTERM if it hangs. it will go down
             run_process(
-                cmd,
+                cmd + [str(self.process.pid)],
                 stop_event=self._profiler_state.stop_event,
                 timeout=self._jattach_timeout,
                 kill_signal=signal.SIGTERM,

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -84,7 +84,7 @@ RUN ./async_profiler_build_shared.sh
 # a build step to ensure the minimum CentOS version that we require can "ldd" our libasyncProfiler.so file.
 FROM centos${AP_CENTOS_MIN} AS async-profiler-centos-min-test-glibc
 SHELL ["/bin/bash", "-c", "-euo", "pipefail"]
-COPY --from=async-profiler-builder-glibc /tmp/async-profiler/build/libasyncProfiler.so /libasyncProfiler.so
+COPY --from=async-profiler-builder-glibc /tmp/async-profiler/build/lib/libasyncProfiler.so /libasyncProfiler.so
 RUN if ldd /libasyncProfiler.so 2>&1 | grep -q "not found" ; then echo "libasyncProfiler.so is not compatible with minimum CentOS!"; readelf -Ws /libasyncProfiler.so; ldd /libasyncProfiler.so; exit 1; fi
 
 # async-profiler musl
@@ -297,11 +297,10 @@ COPY --from=phpspy-builder /tmp/binutils/binutils-2.25/bin/bin/strings gprofiler
 COPY --from=async-profiler-builder-glibc /usr/bin/awk gprofiler/resources/php/awk
 COPY --from=async-profiler-builder-glibc /usr/bin/xargs gprofiler/resources/php/xargs
 
-COPY --from=async-profiler-builder-glibc /tmp/async-profiler/build/jattach gprofiler/resources/java/jattach
+COPY --from=async-profiler-builder-glibc /tmp/async-profiler/build/bin/asprof gprofiler/resources/java/asprof
 COPY --from=async-profiler-builder-glibc /tmp/async-profiler/build/async-profiler-version gprofiler/resources/java/async-profiler-version
 COPY --from=async-profiler-centos-min-test-glibc /libasyncProfiler.so gprofiler/resources/java/glibc/libasyncProfiler.so
-COPY --from=async-profiler-builder-musl /tmp/async-profiler/build/libasyncProfiler.so gprofiler/resources/java/musl/libasyncProfiler.so
-COPY --from=async-profiler-builder-glibc /tmp/async-profiler/build/fdtransfer gprofiler/resources/java/fdtransfer
+COPY --from=async-profiler-builder-musl /tmp/async-profiler/build/lib/libasyncProfiler.so gprofiler/resources/java/musl/libasyncProfiler.so
 COPY --from=node-package-builder-musl /tmp/module_build gprofiler/resources/node/module/musl
 COPY --from=node-package-builder-glibc /tmp/module_build gprofiler/resources/node/module/glibc
 

--- a/scripts/async_profiler_build_shared.sh
+++ b/scripts/async_profiler_build_shared.sh
@@ -5,10 +5,10 @@
 #
 set -euo pipefail
 
-VERSION=v2.9g6
-GIT_REV="4938ce815be597fafc6a7a185a16ff394b9d7f41"
+VERSION=tryout-asprof-jattach-passthru
+GIT_REV="d0cad8b744501551d1b7039a2b5c39cfebed9437"
 
-git clone --depth 1 -b "$VERSION" https://github.com/Granulate/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
+git clone --depth 1 -b "$VERSION" https://github.com/marcin-ol/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
 make all
 
 # add a version file to the build directory

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -429,11 +429,13 @@ def test_java_deleted_libjvm(
 def filter_jattach_load_records(records: List[LogRecord]) -> List[LogRecord]:
     def _filter_record(r: LogRecord) -> bool:
         # find the log record of
-        # Running command (command=['/app/gprofiler/resources/java/jattach', 'xxx', 'load', ....])
+        # Running command (command=['/app/gprofiler/resources/java/apsprof', 'jattach',
+        # '-L', '/path/to/libasyncProfiler.so', "--jattach-cmd", "start,..."])
         return (
             r.message == "Running command"
-            and "/jattach" in log_record_extra(r)["command"][0]
-            and "load" in log_record_extra(r)["command"][2]
+            and len(log_record_extra(r)["command"]) >= 6
+            and log_record_extra(r)["command"][1] == "jattach"
+            and any(map(lambda k: k in log_record_extra(r)["command"][5], ["start,", "stop,"]))
         )
 
     return list(filter(_filter_record, records))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
An attempt at integrating upcoming features of async-profiler in particular: binary launcher (asprof).  
This is a first approach adding a passthru mechanism for invocation of jattach with asprof.

Asprof was extended with following capabilities:
- `jattach` action, passing arguments from `--jattach-cmd` to jattach routine; this minimizes changes on gprofiler side,
- `fdtransfer` action, enabling control over fdtransfer start time,
- `jcmd` action, offering specialized call of jattach to invoke jcmd for collection of metadata.

## Description
This is a first approach adding a passthru mechanism for invocation of jattach with asprof.

Asprof was extended with following capabilities:
- `jattach` action, passing arguments from `--jattach-cmd` to jattach routine; this minimizes changes on gprofiler side,
- `fdtransfer` action, enabling control over fdtransfer start time,
- `jcmd` action, offering specialized call of jattach to invoke jcmd for collection of metadata.

## Related Issue
#745 

## Motivation and Context
We want to prepare for upcoming release of async-profiler, bringing new features and fixes.

## How Has This Been Tested?
- full suite of repository tests was executed against these changes,
- necessary changes to tests were made to account for and verify the modified behavior (e.g.: changed command line for async-profiler invocation).

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [x] I have added tests for new logic.
