### PR TITLE
python: Prevent implicit fallback to py-spy if pyperf is explicitly requested

### DIFF
--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -355,7 +355,7 @@ class PythonProfiler(ProfilerInterface):
 
         if get_arch() != "x86_64" or is_windows():
             if python_mode == "pyperf":
-                logger.warning("PyPerf is supported only on x86_64, falling back to py-spy")
+                raise Exception(f"PyPerf is supported only on x86_64 (and not on this arch {get_arch()})")
             python_mode = "pyspy"
 
         if python_mode in ("auto", "pyperf"):

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -14,7 +14,7 @@ from docker.models.containers import Container
 from docker.models.images import Image
 
 from gprofiler.utils.collapsed_format import parse_one_collapsed
-from tests.utils import RUNTIME_PROFILERS, _no_errors, run_gprofiler_in_container
+from tests.utils import RUNTIME_PROFILERS, _no_errors, is_aarch64, run_gprofiler_in_container
 
 
 @pytest.mark.parametrize(
@@ -36,6 +36,9 @@ def test_executable(
 
     if runtime == "php":
         pytest.skip("Flaky, https://github.com/Granulate/gprofiler/issues/630")
+
+    if runtime == "python" and any("pyperf" in flag for flag in profiler_flags) and is_aarch64():
+        pytest.xfail("PyPerf doesn't run on Aarch64 - https://github.com/Granulate/gprofiler/issues/499")
 
     if exec_container_image is not None:
         if "centos:6" in exec_container_image.tags and any("pyperf" in flag for flag in profiler_flags):


### PR DESCRIPTION
See https://github.com/Granulate/gprofiler/pull/772#issuecomment-1510183814
