### PR TITLE
Upgrade PyPerf to support Python 3.11

### DIFF
--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -27,8 +27,7 @@ if [ "$(uname -m)" != "x86_64" ]; then
     exit 0
 fi
 
-git clone --depth 1 -b v1.3.0 https://github.com/Granulate/bcc.git && cd bcc && git reset --hard fa7508600659622eac1fc309c7cdd7700ad2dff4
-
+git clone --depth 1 -b python-3.11 https://github.com/marcin-ol/bcc.git && cd bcc && git reset --hard e30102ff9efe4551fda544b782c3793656daa9a5
 mkdir build
 cd build
 cmake -DPYTHON_CMD=python3 -DINSTALL_CPP_EXAMPLES=y -DCMAKE_INSTALL_PREFIX=/bcc/root -DBCC_CLOADER_KERNEL_HEADERLESS=1 ..

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -27,7 +27,8 @@ if [ "$(uname -m)" != "x86_64" ]; then
     exit 0
 fi
 
-git clone --depth 1 -b python-3.11 https://github.com/marcin-ol/bcc.git && cd bcc && git reset --hard f97969b91a8d0f7e4f7333c087a076285227b24d
+git clone --depth 1 -b master https://github.com/Granulate/bcc.git && cd bcc && git reset --hard 598855b0e297e659f4f880a6fcf49dc173eb5631
+
 mkdir build
 cd build
 cmake -DPYTHON_CMD=python3 -DINSTALL_CPP_EXAMPLES=y -DCMAKE_INSTALL_PREFIX=/bcc/root -DBCC_CLOADER_KERNEL_HEADERLESS=1 ..

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -27,7 +27,7 @@ if [ "$(uname -m)" != "x86_64" ]; then
     exit 0
 fi
 
-git clone --depth 1 -b python-3.11 https://github.com/marcin-ol/bcc.git && cd bcc && git reset --hard 8d1f93b42f34e4b1212574240352cd44a5a1334b
+git clone --depth 1 -b python-3.11 https://github.com/marcin-ol/bcc.git && cd bcc && git reset --hard f97969b91a8d0f7e4f7333c087a076285227b24d
 mkdir build
 cd build
 cmake -DPYTHON_CMD=python3 -DINSTALL_CPP_EXAMPLES=y -DCMAKE_INSTALL_PREFIX=/bcc/root -DBCC_CLOADER_KERNEL_HEADERLESS=1 ..

--- a/scripts/pyperf_build.sh
+++ b/scripts/pyperf_build.sh
@@ -27,7 +27,7 @@ if [ "$(uname -m)" != "x86_64" ]; then
     exit 0
 fi
 
-git clone --depth 1 -b python-3.11 https://github.com/marcin-ol/bcc.git && cd bcc && git reset --hard e30102ff9efe4551fda544b782c3793656daa9a5
+git clone --depth 1 -b python-3.11 https://github.com/marcin-ol/bcc.git && cd bcc && git reset --hard 8d1f93b42f34e4b1212574240352cd44a5a1334b
 mkdir build
 cd build
 cmake -DPYTHON_CMD=python3 -DINSTALL_CPP_EXAMPLES=y -DCMAKE_INSTALL_PREFIX=/bcc/root -DBCC_CLOADER_KERNEL_HEADERLESS=1 ..

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -86,9 +86,6 @@ def test_python_matrix(
     if python_version == "2.7" and profiler_type == "pyperf" and app == "uwsgi":
         pytest.xfail("This combination fails, see https://github.com/Granulate/gprofiler/issues/485")
 
-    if python_version == "3.11" and profiler_type == "pyperf":
-        pytest.xfail("PyPerf does not support 3.11 - https://github.com/Granulate/gprofiler/issues/727")
-
     if is_aarch64():
         if profiler_type == "pyperf":
             pytest.skip(


### PR DESCRIPTION
Update PyPerf to support Python 3.11.

## Description
Adopting changes implemented in [Granulate/bcc#45](https://github.com/Granulate/bcc/pull/45).

## Related Issue
#727 

## Motivation and Context
Need to support latest versions of Python.

## How Has This Been Tested?
Enabled Python-3.11 configuration as a target for python tests.

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
