### PR TITLE
Add ids to in_container fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,7 +73,7 @@ def chdir(path: Path) -> Iterator[None]:
         os.chdir(cwd)
 
 
-@fixture(params=[False, True])
+@fixture(params=[False, True], ids=["on_host", "in_container"])
 def in_container(request: FixtureRequest) -> bool:
     return cast(bool, request.param)  # type: ignore # SubRequest isn't exported yet,
     # https://github.com/pytest-dev/pytest/issues/7469


### PR DESCRIPTION
## Description
In test titles instead of f.e.:
```
tests/test_node.py::test_nodejs_attach_maps[False-command_line0-without-flags-nodejs-attach-maps]
tests/test_node.py::test_nodejs_attach_maps_from_container[True-command_line0-without-flags-nodejs-attach-maps]
```
we will have
```
tests/test_node.py::test_nodejs_attach_maps[on_host-command_line0-without-flags-nodejs-attach-maps]
tests/test_node.py::test_nodejs_attach_maps_from_container[in_container-command_line0-without-flags-nodejs-attach-maps]
```

# Related Issue
https://github.com/Granulate/gprofiler/issues/536