### PR TITLE
java: Decrease the minimal supported JDK version from 19.0.2+7 to 19.0.1+10

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -855,7 +855,7 @@ class JavaProfiler(SpawningProcessProfilerBase):
         15: (Version("15.0.1"), 9),
         16: (Version("16"), 36),
         17: (Version("17.0.1"), 12),
-        19: (Version("19.0.2"), 7),
+        19: (Version("19.0.1"), 10),
     }
 
     # extra timeout seconds to add to the duration itself.


### PR DESCRIPTION
## Motivation and Context
Make gProfiler support more JDK versions by default.

## How Has This Been Tested?
Ran gProfiler on the mentioned JDK version.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
