### PR TITLE
Fix getaddrinfo() EBUSY on ARM

### DIFF
--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -212,13 +212,6 @@ COPY granulate-utils/glogger granulate-utils/glogger
 RUN python3 -m pip install --no-cache-dir -r requirements.txt
 
 COPY exe-requirements.txt exe-requirements.txt
-# build on centos:8 of Aarch64 requires -lnss_files and -lnss_dns. the files are missing but the symbols
-# seem to be provided from another archive (e.g libc.a), so this "fix" bypasses the ld error of "missing -lnss..."
-# see https://github.com/JonathonReinhart/staticx/issues/219
-RUN if grep -q "CentOS Linux 8" /etc/os-release ; then \
-    ! test -f /lib64/libnss_files.a && ar rcs /lib64/libnss_files.a && \
-    ! test -f /lib64/libnss_dns.a && ar rcs /lib64/libnss_dns.a; \
-    fi
 RUN python3 -m pip install --no-cache-dir -r exe-requirements.txt
 
 # copy PyPerf, licenses and notice file.
@@ -277,6 +270,8 @@ RUN if [ "$(uname -m)" = "aarch64" ]; then \
         cd staticx && \
         git reset --hard 819d8eafecbaab3646f70dfb1e3e19f6bbc017f8 && \
         git apply ../staticx_patch.diff && \
+        ln -s libnss_files.so.2 /lib64/libnss_files.so && \
+        ln -s libnss_dns.so.2 /lib64/libnss_dns.so && \
         python3 -m pip install --no-cache-dir . ; \
     fi
 

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -145,6 +145,10 @@ RUN if grep -q "CentOS Linux 8" /etc/os-release ; then \
         ./fix_centos8.sh; \
     fi
 
+# update libmodulemd to fix https://bugzilla.redhat.com/show_bug.cgi?id=2004853
+RUN yum install -y epel-release && \
+    yum install -y libmodulemd
+
 # python 3.10 installation
 WORKDIR /python
 RUN yum install -y \
@@ -166,8 +170,7 @@ RUN ./python310_build.sh
 
 WORKDIR /app
 
-RUN yum clean all && yum --setopt=skip_missing_names_on_install=False install -y \
-        epel-release \
+RUN yum --setopt=skip_missing_names_on_install=False install -y \
         gcc \
         curl \
         libicu

--- a/pyi.Dockerfile
+++ b/pyi.Dockerfile
@@ -147,7 +147,8 @@ RUN if grep -q "CentOS Linux 8" /etc/os-release ; then \
 
 # update libmodulemd to fix https://bugzilla.redhat.com/show_bug.cgi?id=2004853
 RUN yum install -y epel-release && \
-    yum install -y libmodulemd
+    yum install -y libmodulemd && \
+    yum clean all
 
 # python 3.10 installation
 WORKDIR /python
@@ -173,7 +174,8 @@ WORKDIR /app
 RUN yum --setopt=skip_missing_names_on_install=False install -y \
         gcc \
         curl \
-        libicu
+        libicu && \
+    yum clean all
 
 # needed for aarch64 (for staticx)
 RUN set -e; \


### PR DESCRIPTION
CPython uses glibc's `getaddrinfo()` to resolve hostnames. glibc tries to dynamically load the backend libs that implement the actual resolution, `libnss_files.so` and `libnss_dns.so` (as configured by staticx), which are unfortunately missing. When running staticx, it determines the libs to include by examining dependencies using `ldd`. For this reason, staticx adds a "fake" dependency on these two libs by linking `libnssfix` -- staticx's injected lib to configure nss to use only `files` and `dns` backends and ignore system configuration -- with `nss_files` and `nss_dns`. When building for ARM, we recompile staticx v0.13.6 with a patch that fixes some other static NSS issues (resolved in v0.13.7+) instead of using the prebuilt version from pypi.

The nss libs were never intended to be loaded by anything other than glibc itself, thus the `lib.so -> lib.so.X` symlinks for the linker are not installed. In turn, the linker complains that it cannot find `-lnss_files` and `-lnss_dns`. It appears that this was overcome by linking against fake _static_ libraries, thus preventing the creation of dependencies for `ldd` to discover.

The solution is simply to replace these with the `*.so` symlinks `ld` expects.

## Related Issue
<!--- If there's an issue related, please link it here -->
<!--- If suggesting a new feature or a medium/big change, please discuss it in an issue first. -->
<!--- For small changes, it's okay to open a PR immediately. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What does it improve? -->

## How Has This Been Tested?
Built and tested on graviton instance.

## Screenshots
<!--- (if appropriate) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
