### PR TITLE
Support extracting java version for non-java named processes

### DIFF
--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -706,8 +706,8 @@ def test_non_java_basename_version(
     with _application_docker_container(
         docker_client,
         application_docker_image,
-        [],
-        [],
+        application_docker_mounts=[],
+        application_docker_capabilities=[],
         application_docker_command=[
             "bash",
             "-c",


### PR DESCRIPTION
## Related Issue
https://github.com/Granulate/gprofiler/issues/675

## Motivation and Context
Some java processes can be started from a binary that doesn't start with java. We want to support profiling them and provide full metadata including java version.
