### PR TITLE
Use and test golang binary identification

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "granulate-utils"]
 	path = granulate-utils
-	url = git@github.com:marcin-ol/granulate-utils.git
+	url = git@github.com:Granulate/granulate-utils.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "granulate-utils"]
 	path = granulate-utils
-	url = git@github.com:Granulate/granulate-utils.git
+	url = git@github.com:marcin-ol/granulate-utils.git

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ This requires the entrypoint of application to be CommonJS script. (Doesn't work
 
 Golang profiling is based on `perf`, used via the system profiler (explained in [System profiling options](#System-profiling-options)).
 
-As with all native programs, the Golang program must have symbols - not stripped - otherwise, additional debug info files must be provided. Without symbols/debug info, `perf` is unable to symbolicate the stacktraces of the program. In that case gProfiler will not tag the stacks as Golang and you will not see any symbols.
+As with all native programs, the Golang program must have symbols - not stripped - otherwise, additional debug info files must be provided. Without symbols info (specifically the `.symtab` section) `perf` is unable to symbolicate the stacktraces of the program. In that case gProfiler will not tag the stacks as Golang and you will not see any symbols.
 
 Make sure you are not passing `-s` to the `-ldflags` during your build - `-s` omits the symbols table; see more details [here](https://pkg.go.dev/cmd/link#hdr-Command_Line).
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -429,6 +429,14 @@ def application_docker_capabilities() -> List[str]:
 
 
 @fixture
+def application_docker_command() -> Optional[List[str]]:
+    """
+    Command to issue to application docker as an override.
+    """
+    return None
+
+
+@fixture
 def application_docker_container(
     in_container: bool,
     docker_client: DockerClient,
@@ -436,13 +444,18 @@ def application_docker_container(
     output_directory: Path,
     application_docker_mounts: List[docker.types.Mount],
     application_docker_capabilities: List[str],
+    application_docker_command: Optional[List[str]],
 ) -> Iterable[Container]:
     if not in_container:
         yield None
         return
     else:
         with _application_docker_container(
-            docker_client, application_docker_image, application_docker_mounts, application_docker_capabilities
+            docker_client,
+            application_docker_image,
+            application_docker_mounts,
+            application_docker_capabilities,
+            application_docker_command,
         ) as container:
             yield container
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -453,9 +453,9 @@ def application_docker_container(
         with _application_docker_container(
             docker_client,
             application_docker_image,
-            application_docker_mounts,
-            application_docker_capabilities,
-            application_docker_command,
+            application_docker_mounts=application_docker_mounts,
+            application_docker_capabilities=application_docker_capabilities,
+            application_docker_command=application_docker_command,
         ) as container:
             yield container
 
@@ -485,7 +485,10 @@ def application_factory(
     def _run_application() -> Iterator[int]:
         if in_container:
             with _application_docker_container(
-                docker_client, application_docker_image, application_docker_mounts, application_docker_capabilities
+                docker_client,
+                application_docker_image,
+                application_docker_mounts=application_docker_mounts,
+                application_docker_capabilities=application_docker_capabilities,
             ) as container:
                 yield container.attrs["State"]["Pid"]
         else:

--- a/tests/containers/golang/Dockerfile
+++ b/tests/containers/golang/Dockerfile
@@ -4,5 +4,6 @@ WORKDIR /app
 ADD fibonacci.go /app
 ENV GOCACHE=/tmp
 RUN go build -ldflags "-linkmode external" fibonacci.go
+RUN go build -ldflags "-linkmode external -w -s" -o fibonacci-stripped  fibonacci.go
 
 CMD ["./fibonacci"]

--- a/tests/test_app_metadata.py
+++ b/tests/test_app_metadata.py
@@ -17,12 +17,13 @@ from tests.utils import assert_jvm_flags_equal, is_aarch64, run_gprofiler_in_con
 
 
 @pytest.mark.parametrize(
-    "in_container,runtime,profiler_type,expected_metadata",
+    "in_container,runtime,profiler_type,application_docker_command,expected_metadata",
     [
         (
             True,
             "python",
             "pyperf",
+            None,
             {
                 "exe": "/usr/local/bin/python3.6",
                 "execfn": "/usr/local/bin/python",
@@ -40,6 +41,7 @@ from tests.utils import assert_jvm_flags_equal, is_aarch64, run_gprofiler_in_con
             True,
             "ruby",
             "rbspy",
+            None,
             {
                 "exe": "/usr/local/bin/ruby",
                 "execfn": "/usr/local/bin/ruby",
@@ -58,6 +60,7 @@ from tests.utils import assert_jvm_flags_equal, is_aarch64, run_gprofiler_in_con
             True,
             "java",
             "ap",
+            None,
             {
                 "exe": "/usr/local/openjdk-8/bin/java",
                 "execfn": "/usr/local/openjdk-8/bin/java",
@@ -145,6 +148,7 @@ from tests.utils import assert_jvm_flags_equal, is_aarch64, run_gprofiler_in_con
             True,
             "golang",
             "perf",
+            ["./fibonacci"],
             {
                 "exe": "/app/fibonacci",
                 "execfn": "./fibonacci",
@@ -156,8 +160,23 @@ from tests.utils import assert_jvm_flags_equal, is_aarch64, run_gprofiler_in_con
         ),
         (
             True,
+            "golang",
+            "perf",
+            ["./fibonacci-stripped"],
+            {
+                "exe": "/app/fibonacci-stripped",
+                "execfn": "./fibonacci-stripped",
+                "golang_version": None,
+                "link": "dynamic",
+                "libc": "glibc",
+                "stripped": True,
+            },
+        ),
+        (
+            True,
             "nodejs",
             "perf",
+            None,
             {
                 "exe": "/usr/local/bin/node",
                 "execfn": "/usr/local/bin/node",
@@ -170,6 +189,7 @@ from tests.utils import assert_jvm_flags_equal, is_aarch64, run_gprofiler_in_con
             True,
             "dotnet",
             "dotnet-trace",
+            None,
             {
                 "dotnet_version": "6.0.302",
                 "exe": "/usr/share/dotnet/dotnet",

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -660,8 +660,8 @@ def test_java_different_basename(
         with _application_docker_container(
             docker_client,
             application_docker_image,
-            [],
-            [],
+            application_docker_mounts=[],
+            application_docker_capabilities=[],
             application_docker_command=[
                 "bash",
                 "-c",
@@ -1084,8 +1084,8 @@ def test_collect_cmdline_and_env_jvm_flags(
         with _application_docker_container(
             docker_client,
             application_docker_image,
-            [],
-            [],
+            application_docker_mounts=[],
+            application_docker_capabilities=[],
             application_docker_command=[
                 "bash",
                 "-c",
@@ -1119,8 +1119,8 @@ def test_collect_flags_unsupported_filtered_out(
         with _application_docker_container(
             docker_client,
             application_docker_image,
-            [],
-            [],
+            application_docker_mounts=[],
+            application_docker_capabilities=[],
             application_docker_command=[
                 "bash",
                 "-c",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -350,6 +350,7 @@ def wait_container_to_start(container: Container) -> None:
 def _application_docker_container(
     docker_client: DockerClient,
     application_docker_image: Image,
+    *,
     application_docker_mounts: List[Mount],
     application_docker_capabilities: List[str],
     application_docker_command: Optional[List[str]] = None,


### PR DESCRIPTION
Use golang binary identification brought to granulate-utils with PR https://github.com/Granulate/granulate-utils/pull/179.

## Description
With new mechanism in granulate-utils it's now possible to identify golang binary looking only at ELF sections. This PR is adopting this mechanism.

## Related Issue
#817 

## How Has This Been Tested?
Added new testcase for a stripped golang binary, proving identification of golang programs is possible.

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the relevant documentation.
- [x] I have added tests for new logic.
