### PR TITLE
perf: Use "fp" mode by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ Make sure you are not passing `-s` to the `-ldflags` during your build - `-s` om
 ### System profiling options
 
 * `--perf-mode`: Controls the global perf strategy. Must be one of the following options:
-    * `fp` - Use Frame Pointers for the call graph
+    * `fp` - Use Frame Pointers for the call graph. *This is the default.*
     * `dwarf` - Use DWARF for the call graph (adds the `--call-graph dwarf` argument to the `perf` command)
-    * `smart` - Run both `fp` and `dwarf`, then choose the result with the highest average of stack frames count, per process. *This is the default.*
+    * `smart` - Run both `fp` and `dwarf`, then choose the result with the highest average of stack frames count, per process.
     * `disabled` - Avoids running `perf` at all. See [perf-less mode](#perf-less-mode).
 
 ## Other options

--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -377,7 +377,7 @@ class PerfProcess:
 @register_profiler(
     "Perf",
     possible_modes=["fp", "dwarf", "smart", "disabled"],
-    default_mode="smart",
+    default_mode="fp",
     supported_archs=["x86_64", "aarch64"],
     profiler_mode_argument_help="Run perf with either FP (Frame Pointers), DWARF, or run both and intelligently merge"
     " them by choosing the best result per process. If 'disabled' is chosen, do not invoke"


### PR DESCRIPTION
"smart" mode is more expensive memory & cpu wise due to running two perfs. Let's make it opt-in and not opt-out.
