### PR TITLE
Use BuildKit via "docker buildx" everywhere

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -30,10 +30,9 @@ jobs:
 
      # TODO: Add docker layer caching when GitHub Actions cache is stabilized and works good with "satackey/action-docker-layer-caching@v0.0.11"
      - name: Build gProfiler executable
-       # Using DOCKER_BUILDKIT=1 although it has another cache mechanism which is not supported by satackey/action-docker-layer-caching@v0.0.11
+       # Using BuildKit although it has another cache mechanism which is not supported by satackey/action-docker-layer-caching@v0.0.11
        # We tried to cache using buildx cache (cache-from, cache-to flags) and got strange behavior when caching,
        # decided not to use buildkit here to get nice caches.
-       # if we enable caching again, we can disable DOCKER_BUILDKIT.
        run: |
         mkdir -p output
         ./scripts/build_x86_64_executable.sh
@@ -296,7 +295,6 @@ jobs:
       - name: Build and push
         run: |
           set -x
-          export DOCKER_BUILDKIT=1
 
           BASE_IMAGE="${{ env.GH_REPO }}:${{ env.RELEASE_VERSION }}"
           AARCH64_IMAGE="$BASE_IMAGE-aarch64"
@@ -342,7 +340,6 @@ jobs:
       - name: Push manifest
         run: |
           set -x
-          export DOCKER_BUILDKIT=1
 
           BASE_IMAGE="${{ env.GH_REPO }}:${{ env.RELEASE_VERSION }}"
           LATEST_IMAGE="${{ env.GH_REPO }}:latest"

--- a/scripts/build_aarch64_container.sh
+++ b/scripts/build_aarch64_container.sh
@@ -10,4 +10,4 @@ if [ "$#" -gt 0 ] && [ "$1" == "--skip-exe-build" ]; then
 else
     ./scripts/build_aarch64_executable.sh
 fi
-DOCKER_BUILDKIT=1 docker build -f container.Dockerfile -t gprofiler --build-arg ARCH=$ARCH . "$@"
+docker buildx build -f container.Dockerfile -t gprofiler --build-arg ARCH=$ARCH . "$@"

--- a/scripts/build_x86_64_container.sh
+++ b/scripts/build_x86_64_container.sh
@@ -10,4 +10,4 @@ if [ "$#" -gt 0 ] && [ "$1" == "--skip-exe-build" ]; then
 else
     ./scripts/build_x86_64_executable.sh
 fi
-DOCKER_BUILDKIT=1 docker build -f container.Dockerfile -t gprofiler --build-arg ARCH=$ARCH . "$@"
+docker buildx build -f container.Dockerfile -t gprofiler --build-arg ARCH=$ARCH . "$@"

--- a/scripts/build_x86_64_executable.sh
+++ b/scripts/build_x86_64_executable.sh
@@ -40,7 +40,7 @@ GPROFILER_BUILDER=@sha256:0f4ec88e21daf75124b8a9e5ca03c37a5e937e0e108a255d890492
 NODE_PACKAGE_BUILDER_GLIBC=centos/devtoolset-7-toolchain-centos7@sha256:24d4c230cb1fe8e68cefe068458f52f69a1915dd6f6c3ad18aa37c2b8fa3e4e1
 
 mkdir -p build/x86_64
-DOCKER_BUILDKIT=1 docker build -f executable.Dockerfile --output type=local,dest=build/x86_64/ \
+docker buildx build -f executable.Dockerfile --output type=local,dest=build/x86_64/ \
     --build-arg RUST_BUILDER_VERSION=$RUST_BUILDER_VERSION \
     --build-arg PYPERF_BUILDER_UBUNTU=$UBUNTU_VERSION \
     --build-arg PERF_BUILDER_UBUNTU=$UBUNTU_VERSION_1604 \


### PR DESCRIPTION
1. to standardize - as some locations used `docker buildx` and some used `DOCKER_BUILDKIT`
2. In https://github.com/Granulate/gprofiler/actions/runs/5956037826/job/16158530773 it seems that `DOCKER_BUILDKIT=1` fails although in the same workflow `docker buildx` worked 🤷 