### PR TITLE
build: node: Pin node-gyp==^9.4.1

### DIFF
--- a/scripts/build_node_package.sh
+++ b/scripts/build_node_package.sh
@@ -10,7 +10,7 @@ git clone https://github.com/mmarchini-oss/node-linux-perf.git $MODULE_PATH
 cd $MODULE_PATH
 git reset --hard $GIT_REV
 
-npm install -g node-gyp
+npm install -g node-gyp@^9.4.1  # pinned, as 10.x.x was broken, see my commit message
 curl -L https://github.com/nodejs/nan/archive/refs/tags/v2.16.0.tar.gz -o nan.tar.gz
 tar -vxzf nan.tar.gz -C /tmp
 NAN_PATH=$(realpath /tmp/nan-*)


### PR DESCRIPTION
node-gyp 10.x.x was released recently, and our build started failing with this error:

	16.93 gyp ERR! configure error
	16.93 gyp ERR! stack TypeError: Cannot read property 'pipeline' of undefined

Pinning to 9.x.x helps.

I saw it asked online - https://stackoverflow.com/questions/77401392/unable-to-install-node-using-nvm - but no response so far 🤷 