### PR TITLE
java: Fix regression _find_rw_exec_dir() failing to handle ro dirs

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -2,6 +2,7 @@
 # Copyright (c) Granulate. All rights reserved.
 # Licensed under the AGPL3 License. See LICENSE.md in the project root for license information.
 #
+import errno
 import functools
 import json
 import os
@@ -540,7 +541,13 @@ class AsyncProfiledProcess:
             if not is_owned_by_root(full_dir.parent):
                 continue  # the parent needs to be owned by root
 
-            mkdir_owned_root(full_dir)
+            try:
+                mkdir_owned_root(full_dir)
+            except OSError as e:
+                # dir is not r/w, try next one
+                if e.errno == errno.EROFS:
+                    continue
+                raise
 
             if is_rw_exec_dir(full_dir):
                 return str(full_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -649,7 +649,8 @@ def python_version(in_container: bool, application_docker_container: Container) 
 
 
 @fixture
-def noexec_tmp_dir(in_container: bool, tmp_path: Path) -> Iterator[str]:
+def noexec_or_ro_tmp_dir(in_container: bool, tmp_path: Path, noexec_or_ro: str) -> Iterator[str]:
+    assert noexec_or_ro in ("noexec", "ro")
     if in_container:
         # only needed for non-container tests
         yield ""
@@ -658,7 +659,7 @@ def noexec_tmp_dir(in_container: bool, tmp_path: Path) -> Iterator[str]:
     tmpfs_path = tmp_path / "tmpfs"
     tmpfs_path.mkdir(0o755, exist_ok=True)
     try:
-        subprocess.run(["mount", "-t", "tmpfs", "-o", "noexec", "none", str(tmpfs_path)], check=True)
+        subprocess.run(["mount", "-t", "tmpfs", "-o", noexec_or_ro, "none", str(tmpfs_path)], check=True)
         yield str(tmpfs_path)
     finally:
         subprocess.run(["umount", str(tmpfs_path)], check=True)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -408,3 +408,10 @@ def log_record_extra(r: LogRecord) -> Dict[Any, Any]:
     Gets the "extra" attached to a LogRecord
     """
     return getattr(r, "extra", {})
+
+
+def str_removesuffix(s: str, suffix: str, assert_suffixed: bool = True) -> str:
+    suffixed = s.endswith(suffix)
+    if assert_suffixed:
+        assert suffixed
+    return s[: -len(suffix)] if suffixed else s


### PR DESCRIPTION
Fixes a regression from https://github.com/Granulate/gprofiler/commit/6360449252793ad59802a3c09fde297646529b7d, and improves the tests
so we'd catch it next time :)