### PR TITLE
WIP: Spark --app-id as container name

### DIFF
--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -36,7 +36,7 @@ from gprofiler.client import (
     ProfilerAPIClient,
 )
 from gprofiler.consts import CPU_PROFILING_MODE
-from gprofiler.containers_client import ContainerNamesClient
+from gprofiler.containers_client import SparkContainerNamesClient
 from gprofiler.diagnostics import log_diagnostics, set_diagnostics
 from gprofiler.exceptions import APIError, NoProfilersEnabledError
 from gprofiler.gprofiler_types import ProcessToProfileData, UserArgs, integers_list, positive_integer
@@ -147,7 +147,8 @@ class GProfiler:
         # 2. accessible only by us.
         # the latter can be root only. the former can not. we should do this separation so we don't expose
         # files unnecessarily.
-        container_names_client = ContainerNamesClient() if self._enrichment_options.container_names else None
+        # container_names_client = ContainerNamesClient() if self._enrichment_options.container_names else None
+        container_names_client = SparkContainerNamesClient() if self._enrichment_options.container_names else None
         self._profiler_state = ProfilerState(
             stop_event=Event(),
             storage_dir=TEMPORARY_STORAGE_PATH,

--- a/gprofiler/merge.py
+++ b/gprofiler/merge.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from granulate_utils.metadata import Metadata
 
-from gprofiler.containers_client import ContainerNamesClient
+from gprofiler.containers_client import ContainerNamesClientBase
 from gprofiler.gprofiler_types import ProcessToProfileData, ProfileData, ProfilingErrorStack, StackToSampleCount
 from gprofiler.log import get_logger_adapter
 from gprofiler.metadata.enrichment import EnrichmentOptions
@@ -39,7 +39,7 @@ def scale_sample_counts(stacks: StackToSampleCount, ratio: float) -> StackToSamp
 
 
 def _make_profile_metadata(
-    container_names_client: Optional[ContainerNamesClient],
+    container_names_client: Optional[ContainerNamesClientBase],
     add_container_names: bool,
     metadata: Metadata,
     metrics: Metrics,
@@ -175,7 +175,7 @@ def concatenate_from_external_file(
 
 def concatenate_profiles(
     process_profiles: ProcessToProfileData,
-    container_names_client: Optional[ContainerNamesClient],
+    container_names_client: Optional[ContainerNamesClientBase],
     enrichment_options: EnrichmentOptions,
     metadata: Metadata,
     metrics: Metrics,
@@ -211,7 +211,7 @@ def concatenate_profiles(
 def merge_profiles(
     perf_pid_to_profiles: ProcessToProfileData,
     process_profiles: ProcessToProfileData,
-    container_names_client: Optional[ContainerNamesClient],
+    container_names_client: Optional[ContainerNamesClientBase],
     enrichment_options: EnrichmentOptions,
     metadata: Metadata,
     metrics: Metrics,

--- a/gprofiler/profiler_state.py
+++ b/gprofiler/profiler_state.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 from psutil import Process
 
-from gprofiler.containers_client import ContainerNamesClient
+from gprofiler.containers_client import ContainerNamesClientBase
 from gprofiler.utils import TemporaryDirectoryWithMode
 
 
@@ -19,7 +19,7 @@ class ProfilerState:
     profile_spawned_processes: bool
     insert_dso_name: bool
     profiling_mode: str
-    container_names_client: Optional[ContainerNamesClient]
+    container_names_client: Optional[ContainerNamesClientBase]
     processes_to_profile: Optional[List[Process]]
 
     def __post_init__(self) -> None:


### PR DESCRIPTION
## Description
This is a redo of the branch `spark-app-id-as-container-name` (from cf74924629b4db32c2a9d78abb89e1151037a5e6).

The idea is to allow using Spark application IDs as "container names" collected by gProfiler. Logically, a "container name" is just an identifier describing a process or a set of processes across (potentially) multiple nodes. For Docker/k8s/ecs etc, container names are logical. In Spark/YARN, application IDs or YARN application names can be used instead.

I turned `ContainerNamesClient` to a generic base `ContainerNamesClientBase` which is implemented by `ContainerNamesClient` (the old) and `SparkContainerNamesClient` (the new).

## Related Issue
https://github.com/Granulate/gprofiler/issues/869

## How Has This Been Tested?
T.B.D
