### PR TITLE
java: Add min JDK 21 version

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -917,6 +917,7 @@ class JavaProfiler(SpawningProcessProfilerBase):
         16: (Version("16"), 36),
         17: (Version("17"), 11),
         19: (Version("19.0.1"), 10),
+        21: (Version("21.0.1"), 12),
     }
 
     # extra timeout seconds to add to the duration itself.


### PR DESCRIPTION
Tested on `openjdk version "21.0.1" 2023-10-17 LTS OpenJDK Runtime Environment Corretto-21.0.1.12.1 (build 21.0.1+12-LTS) OpenJDK 64-Bit Server VM Corretto-21.0.1.12.1 (build 21.0.1+12-LTS, mixed mode, sharing)`.