### PR TITLE
build: Upgrade to zlib 1.3.1

### DIFF
--- a/scripts/prepare_machine-unknown-linux-musl.sh
+++ b/scripts/prepare_machine-unknown-linux-musl.sh
@@ -23,7 +23,7 @@ apk add --no-cache musl-dev make git curl  # git & curl used by next scripts
 
 mkdir builds && cd builds
 
-ZLIB_VERSION=1.3
+ZLIB_VERSION="1.3.1"
 ZLIB_FILE="zlib-$ZLIB_VERSION.tar.xz"
 wget "https://zlib.net/$ZLIB_FILE"
 tar -xf "$ZLIB_FILE"


### PR DESCRIPTION
As usual, zlib is upgraded and the old version is removed from the server. The best way to have your users pull security fixes