### PR TITLE
Fixes build issue with CentOS7 and modified gitmodules to use https like parent repo for consistency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "granulate-utils"]
 	path = granulate-utils
-	url = https://github.com/Granulate/granulate-utils.git
+	url = git@github.com:Granulate/granulate-utils.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "granulate-utils"]
 	path = granulate-utils
-	url = git@github.com:Granulate/granulate-utils.git
+	url = https://github.com/Granulate/granulate-utils.git

--- a/executable.Dockerfile
+++ b/executable.Dockerfile
@@ -75,8 +75,8 @@ RUN ./phpspy_build.sh
 FROM centos${AP_BUILDER_CENTOS} AS async-profiler-builder-glibc
 WORKDIR /tmp
 # Workaround for CentOS7 EOL
-RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 
 COPY scripts/async_profiler_env_glibc.sh .
 RUN ./async_profiler_env_glibc.sh
@@ -150,9 +150,9 @@ RUN if grep -q "CentOS Linux 8" /etc/os-release ; then \
 
 # update libmodulemd to fix https://bugzilla.redhat.com/show_bug.cgi?id=2004853
 # Workaround for CentOS7 EOL
-RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
-RUN yum install -y epel-release && \
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
+    yum install -y epel-release && \
     yum install -y libmodulemd && \
     yum clean all
 
@@ -207,8 +207,8 @@ FROM ${NODE_PACKAGE_BUILDER_GLIBC} as node-package-builder-glibc
 USER 0
 WORKDIR /tmp
 # Workaround for CentOS7 EOL
-RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 
 COPY scripts/node_builder_glibc_env.sh .
 RUN ./node_builder_glibc_env.sh

--- a/executable.Dockerfile
+++ b/executable.Dockerfile
@@ -74,6 +74,9 @@ RUN ./phpspy_build.sh
 # async-profiler glibc
 FROM centos${AP_BUILDER_CENTOS} AS async-profiler-builder-glibc
 WORKDIR /tmp
+# Workaround for CentOS7 EOL
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 
 COPY scripts/async_profiler_env_glibc.sh .
 RUN ./async_profiler_env_glibc.sh
@@ -146,6 +149,9 @@ RUN if grep -q "CentOS Linux 8" /etc/os-release ; then \
     fi
 
 # update libmodulemd to fix https://bugzilla.redhat.com/show_bug.cgi?id=2004853
+# Workaround for CentOS7 EOL
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 RUN yum install -y epel-release && \
     yum install -y libmodulemd && \
     yum clean all
@@ -200,6 +206,10 @@ RUN python3 -m pip install --no-cache-dir --upgrade pip
 FROM ${NODE_PACKAGE_BUILDER_GLIBC} as node-package-builder-glibc
 USER 0
 WORKDIR /tmp
+# Workaround for CentOS7 EOL
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 COPY scripts/node_builder_glibc_env.sh .
 RUN ./node_builder_glibc_env.sh
 COPY scripts/build_node_package.sh .


### PR DESCRIPTION
Fix for executable and docker builds that fail due to CentOS7 EOL

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
1. Fix for build issue https://github.com/Granulate/gprofiler/issues/913 with solution as found in https://stackoverflow.com/a/78693402
2. git submodules use ssh, changed to https for consistency.

## Related Issue
<!--- If there's an issue related, please link it here -->
<!--- If suggesting a new feature or a medium/big change, please discuss it in an issue first. -->
<!--- For small changes, it's okay to open a PR immediately. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What does it improve? -->
Allows for the project to build. Ideally should change th eunderlying images to newer ones.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your changes are tested by the CI, you can just write that.-->
Tested on-prem and AWS system on Ubuntu 22.04.

## Screenshots
<!--- (if appropriate) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read the **CONTRIBUTING** document.
- [x ] I have updated the relevant documentation.
- [x ] I have added tests for new logic.
