### PR TITLE
profilers/python_ebpf.py: specifying newly TMPDIR on each instance of PyPerf

### DIFF
--- a/gprofiler/profilers/python_ebpf.py
+++ b/gprofiler/profilers/python_ebpf.py
@@ -188,11 +188,11 @@ class PythonEbpfProfiler(ProfilerBase):
             poll_process(process, self._POLL_TIMEOUT, self._profiler_state.stop_event)
         except TimeoutError:
             process.kill()
-            self._staticx_cleanup()
             raise
         else:
-            self._staticx_cleanup()
             self._check_output(process, self.output_path)
+        finally:
+            self._staticx_cleanup()
 
     def start(self) -> None:
         logger.info("Starting profiling of Python processes with PyPerf")

--- a/gprofiler/profilers/python_ebpf.py
+++ b/gprofiler/profilers/python_ebpf.py
@@ -90,7 +90,7 @@ class PythonEbpfProfiler(ProfilerBase):
         self._pyperf_staticx_tmpdir: Optional[Path] = None
         if os.environ.get("TMPDIR", None) is not None:
             # We want to create a new level of hirerachy in our current staticx tempdir.
-            self._pyperf_staticx_tmpdir = Path(os.environ["TMPDIR"]) / "pyperf_" + random_prefix()
+            self._pyperf_staticx_tmpdir = Path(os.environ["TMPDIR"]) / ("pyperf_" + random_prefix())
 
     @classmethod
     def _check_output(cls, process: Popen, output_path: Path) -> None:

--- a/gprofiler/profilers/python_ebpf.py
+++ b/gprofiler/profilers/python_ebpf.py
@@ -162,7 +162,7 @@ class PythonEbpfProfiler(ProfilerBase):
         """
         We experienced issues with PyPerf's staticx'd directory, so we want to clean it up on termination.
         """
-        assert not self.is_running(), "_cleanup is impossible while PyPerf is running"
+        assert not self.is_running(), "_staticx_cleanup is impossible while PyPerf is running"
         if self._pyperf_staticx_tmpdir is not None and self._pyperf_staticx_tmpdir.exists():
             shutil.rmtree(self._pyperf_staticx_tmpdir.as_posix())
 

--- a/gprofiler/profilers/python_ebpf.py
+++ b/gprofiler/profilers/python_ebpf.py
@@ -90,7 +90,7 @@ class PythonEbpfProfiler(ProfilerBase):
         self._pyperf_staticx_tmpdir: Optional[Path] = None
         if os.environ.get("TMPDIR", None) is not None:
             # We want to create a new level of hirerachy in our current staticx tempdir.
-            self._pyperf_staticx_tmpdir = Path(os.environ["TMPDIR"]) / random_prefix()
+            self._pyperf_staticx_tmpdir = Path(os.environ["TMPDIR"]) / "pyperf_" + random_prefix()
 
     @classmethod
     def _check_output(cls, process: Popen, output_path: Path) -> None:

--- a/gprofiler/profilers/python_ebpf.py
+++ b/gprofiler/profilers/python_ebpf.py
@@ -17,10 +17,11 @@ import glob
 import os
 import resource
 import selectors
+import shutil
 import signal
 from pathlib import Path
 from subprocess import Popen
-from typing import Dict, List, Optional, Tuple, cast
+from typing import Dict, List, Optional, Tuple, Union, cast
 
 from granulate_utils.linux.ns import is_running_in_init_pid
 from psutil import NoSuchProcess, Process
@@ -86,6 +87,10 @@ class PythonEbpfProfiler(ProfilerBase):
         self._kernel_offsets: Dict[str, int] = {}
         self._metadata = python.PythonMetadata(self._profiler_state.stop_event)
         self._verbose = verbose
+        self._pyperf_staticx_tmpdir: Optional[Path] = None
+        if os.environ.get("TMPDIR", None) is not None:
+            # We want to create a new level of hirerachy in our current staticx tempdir.
+            self._pyperf_staticx_tmpdir = Path(os.environ["TMPDIR"]) / random_prefix()
 
     @classmethod
     def _check_output(cls, process: Popen, output_path: Path) -> None:
@@ -153,6 +158,14 @@ class PythonEbpfProfiler(ProfilerBase):
             cmd.extend(["-v", "4"])
         return cmd
 
+    def _staticx_cleanup(self) -> None:
+        """
+        We experienced issues with PyPerf's staticx'd directory, so we want to clean it up on termination.
+        """
+        assert not self.is_running(), "_cleanup is impossible while PyPerf is running"
+        if self._pyperf_staticx_tmpdir is not None and self._pyperf_staticx_tmpdir.exists():
+            shutil.rmtree(self._pyperf_staticx_tmpdir.as_posix())
+
     def test(self) -> None:
         self._ebpf_environment()
 
@@ -170,13 +183,15 @@ class PythonEbpfProfiler(ProfilerBase):
             "--duration",
             "1",
         ]
-        process = start_process(cmd)
+        process = start_process(cmd, tmpdir=self._pyperf_staticx_tmpdir)
         try:
             poll_process(process, self._POLL_TIMEOUT, self._profiler_state.stop_event)
         except TimeoutError:
             process.kill()
+            self._staticx_cleanup()
             raise
         else:
+            self._staticx_cleanup()
             self._check_output(process, self.output_path)
 
     def start(self) -> None:
@@ -201,7 +216,7 @@ class PythonEbpfProfiler(ProfilerBase):
         for f in glob.glob(f"{str(self.output_path)}.*"):
             os.unlink(f)
 
-        process = start_process(cmd)
+        process = start_process(cmd, tmpdir=self._pyperf_staticx_tmpdir)
         # wait until the transient data file appears - because once returning from here, PyPerf may
         # be polled via snapshot() and we need it to finish installing its signal handler.
         try:
@@ -212,6 +227,7 @@ class PythonEbpfProfiler(ProfilerBase):
             stdout = process.stdout.read()
             stderr = process.stderr.read()
             logger.error("PyPerf failed to start", stdout=stdout, stderr=stderr)
+            self._staticx_cleanup()
             raise
         else:
             self.process = process
@@ -303,16 +319,23 @@ class PythonEbpfProfiler(ProfilerBase):
         return profiles
 
     def _terminate(self) -> Tuple[Optional[int], str, str]:
+        exit_status: Optional[int] = None
+        stdout: Union[str, bytes] = ""
+        stderr: Union[str, bytes] = ""
+
         self._unregister_process_selectors()
         if self.is_running():
             assert self.process is not None  # for mypy
             self.process.terminate()  # okay to call even if process is already dead
             exit_status, stdout, stderr = reap_process(self.process)
             self.process = None
-            return exit_status, stdout.decode(), stderr.decode()
+
+        stdout = stdout.decode() if isinstance(stdout, bytes) else stdout
+        stderr = stderr.decode() if isinstance(stderr, bytes) else stderr
 
         assert self.process is None  # means we're not running
-        return None, "", ""
+        self._staticx_cleanup()
+        return exit_status, stdout, stderr
 
     def stop(self) -> None:
         exit_status, stdout, stderr = self._terminate()

--- a/gprofiler/utils/__init__.py
+++ b/gprofiler/utils/__init__.py
@@ -127,7 +127,11 @@ def wrap_callbacks(callbacks: List[Callable]) -> Callable:
 
 
 def start_process(
-    cmd: Union[str, List[str]], via_staticx: bool = False, term_on_parent_death: bool = True, **kwargs: Any
+    cmd: Union[str, List[str]],
+    via_staticx: bool = False,
+    term_on_parent_death: bool = True,
+    tmpdir: Optional[Path] = None,
+    **kwargs: Any,
 ) -> Popen:
     if isinstance(cmd, str):
         cmd = [cmd]
@@ -149,6 +153,8 @@ def start_process(
             # explicitly remove our directory from LD_LIBRARY_PATH
             env = env if env is not None else os.environ.copy()
             env.update({"LD_LIBRARY_PATH": ""})
+            if tmpdir is not None:
+                env.update({"TMPDIR": tmpdir})
 
     if is_windows():
         cur_preexec_fn = None  # preexec_fn is not supported on Windows platforms. subprocess.py reports this.

--- a/gprofiler/utils/__init__.py
+++ b/gprofiler/utils/__init__.py
@@ -154,6 +154,7 @@ def start_process(
             env = env if env is not None else os.environ.copy()
             env.update({"LD_LIBRARY_PATH": ""})
             if tmpdir is not None:
+                tmpdir.mkdir(exist_ok=True)
                 env.update({"TMPDIR": tmpdir})
 
     if is_windows():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
cleanup each instance of PyPerf staticx directories on termination.

## Related Issue
We experienced where there were a-lot of staticx tempdirs leftovers.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What does it improve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your changes are tested by the CI, you can just write that.-->

## Screenshots
<!--- (if appropriate) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
