### PR TITLE
CI: use actions/upload-artifact@v4 and actions/download-artifact@v4

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -90,7 +90,7 @@ jobs:
           submodules: true
 
       - name: Download the executable from previous job
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: gprofiler_x86_64
           path: dist/
@@ -155,13 +155,13 @@ jobs:
         run: ./scripts/verify_tag.sh
 
       - name: Download x86_64 executable from a previous job
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: gprofiler_x86_64
           path: output/
 
       - name: Download aarch64 executable from a previous job
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: gprofiler_aarch64
           path: output/
@@ -189,7 +189,7 @@ jobs:
         fetch-depth: 0
 
     - name: Download executables from the previous job
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: gprofiler_x86_64
         path: output/
@@ -250,13 +250,13 @@ jobs:
         submodules: true
 
     - name: Download the executable from previous job
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: gprofiler_x86_64
         path: output/
 
     - name: Download the image from previous job
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: gprofiler_x86_64.img
         path: output/
@@ -309,7 +309,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Download executables from the previous job
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: gprofiler_aarch64
           path: output/
@@ -347,7 +347,7 @@ jobs:
       # build-container-aarch64 has pushed the image to DockerHub, so we'll pull it later when creating
       # the manifest.
       - name: Download the x86_64 image from previous job
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: gprofiler_x86_64.img
           path: output/

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -35,7 +35,7 @@ jobs:
         cp output/gprofiler_x86_64 output/gprofiler  # for backwards compatibility, we upload both with arch suffix and without
 
      - name: Upload the executables as job artifacts
-       uses: actions/upload-artifact@v2
+       uses: actions/upload-artifact@v3
        with:
          name: gprofiler_x86_64
          path: output/
@@ -130,7 +130,7 @@ jobs:
          mv build/aarch64/gprofiler output/gprofiler_aarch64
 
      - name: Upload the executables as job artifacts
-       uses: actions/upload-artifact@v2
+       uses: actions/upload-artifact@v3
        with:
          name: gprofiler_aarch64
          path: output/
@@ -205,7 +205,7 @@ jobs:
       run: mkdir -p output && docker image save gprofiler_x86_64 > output/gprofiler_x86_64.img
 
     - name: Upload the image artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: gprofiler_x86_64.img
         path: output/

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -35,7 +35,7 @@ jobs:
         cp output/gprofiler_x86_64 output/gprofiler  # for backwards compatibility, we upload both with arch suffix and without
 
      - name: Upload the executables as job artifacts
-       uses: actions/upload-artifact@v3
+       uses: actions/upload-artifact@v4
        with:
          name: gprofiler_x86_64
          path: output/
@@ -90,7 +90,7 @@ jobs:
           submodules: true
 
       - name: Download the executable from previous job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: gprofiler_x86_64
           path: dist/
@@ -130,7 +130,7 @@ jobs:
          mv build/aarch64/gprofiler output/gprofiler_aarch64
 
      - name: Upload the executables as job artifacts
-       uses: actions/upload-artifact@v3
+       uses: actions/upload-artifact@v4
        with:
          name: gprofiler_aarch64
          path: output/
@@ -155,13 +155,13 @@ jobs:
         run: ./scripts/verify_tag.sh
 
       - name: Download x86_64 executable from a previous job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: gprofiler_x86_64
           path: output/
 
       - name: Download aarch64 executable from a previous job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: gprofiler_aarch64
           path: output/
@@ -189,7 +189,7 @@ jobs:
         fetch-depth: 0
 
     - name: Download executables from the previous job
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: gprofiler_x86_64
         path: output/
@@ -205,7 +205,7 @@ jobs:
       run: mkdir -p output && docker image save gprofiler_x86_64 > output/gprofiler_x86_64.img
 
     - name: Upload the image artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: gprofiler_x86_64.img
         path: output/
@@ -250,13 +250,13 @@ jobs:
         submodules: true
 
     - name: Download the executable from previous job
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: gprofiler_x86_64
         path: output/
 
     - name: Download the image from previous job
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: gprofiler_x86_64.img
         path: output/
@@ -309,7 +309,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Download executables from the previous job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: gprofiler_aarch64
           path: output/
@@ -347,7 +347,7 @@ jobs:
       # build-container-aarch64 has pushed the image to DockerHub, so we'll pull it later when creating
       # the manifest.
       - name: Download the x86_64 image from previous job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: gprofiler_x86_64.img
           path: output/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
GH have deprecated `actions/upload-artifact: v2` and `actions/download-artifact: v2` ([further reading](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/))
This makes our CI to fail. [see here](https://github.com/Granulate/gprofiler/actions/runs/10885795220/job/30204253014?pr=921#step:1:36)

## Related Issue
<!--- If there's an issue related, please link it here -->
<!--- If suggesting a new feature or a medium/big change, please discuss it in an issue first. -->
<!--- For small changes, it's okay to open a PR immediately. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What does it improve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your changes are tested by the CI, you can just write that.-->

## Screenshots
<!--- (if appropriate) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
