### PR TITLE
PythonProfiler: expose `--python-pyspy-process`

### DIFF
--- a/gprofiler/gprofiler_types.py
+++ b/gprofiler/gprofiler_types.py
@@ -89,12 +89,12 @@ def nonnegative_integer(value_str: str) -> int:
 
 def integers_list(value_str: str) -> List[int]:
     try:
-        pids = [int(pid) for pid in value_str.split(",")]
+        values = [int(value) for value in value_str.split(",")]
     except ValueError:
         raise configargparse.ArgumentTypeError(
             "Integer list should be a single integer, or comma separated list of integers f.e. 13,452,2388"
         )
-    return pids
+    return values
 
 
 def integer_range(min_range: int, max_range: int) -> Callable[[str], int]:

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from subprocess import CompletedProcess
 from typing import Any, Dict, List, Match, Optional, cast
 
+from gprofiler_types import integers_list
 from granulate_utils.linux.elf import get_elf_id
 from granulate_utils.linux.ns import get_process_nspid, run_in_ns
 from granulate_utils.linux.process import (
@@ -345,8 +346,9 @@ class PySpyProfiler(SpawningProcessProfilerBase):
         ProfilerArgument(
             name="--python-pyspy-processes",
             dest="python_pyspy_processes",
-            nargs="+",
-            type=int,
+            action="extend",
+            default=[],
+            type=integers_list,
             help="List of processes (by PID) to profile with py-spy."
             " This option forces gProfiler to profile given processes with py-spy, even if"
             " they are not recognized by gProfiler as Python processes."

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -21,7 +21,6 @@ from pathlib import Path
 from subprocess import CompletedProcess
 from typing import Any, Dict, List, Match, Optional, cast
 
-from gprofiler_types import integers_list
 from granulate_utils.linux.elf import get_elf_id
 from granulate_utils.linux.ns import get_process_nspid, run_in_ns
 from granulate_utils.linux.process import (
@@ -44,6 +43,7 @@ from gprofiler.gprofiler_types import (
     ProcessToStackSampleCounters,
     ProfileData,
     StackToSampleCount,
+    integers_list,
     nonnegative_integer,
 )
 from gprofiler.log import get_logger_adapter

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -276,6 +276,7 @@ class PySpyProfiler(SpawningProcessProfilerBase):
                 pass
             except Exception:
                 logger.exception(f"Couldn't add pid {process.pid} to list")
+
         return filtered_procs + [Process(pid) for pid in self._python_pyspy_processes]
 
     def _should_profile_process(self, process: Process) -> bool:

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -348,9 +348,9 @@ class PySpyProfiler(SpawningProcessProfilerBase):
             nargs="+",
             type=int,
             help="List of processes (by PID) to profile with py-spy."
-            "This option forces gProfiler to profile given processes with py-spy, even if"
-            "they are not recognized by gProfiler as Python processes."
-            "Note - gProfiler assumes that the given processes are alive and running forever.",
+            " This option forces gProfiler to profile given processes with py-spy, even if"
+            " they are not recognized by gProfiler as Python processes."
+            " Note - gProfiler assumes that the given processes are kept running as long as gProfiler runs.",
         ),
     ],
     supported_profiling_modes=["cpu"],

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -186,12 +186,12 @@ class PySpyProfiler(SpawningProcessProfilerBase):
         profiler_state: ProfilerState,
         *,
         add_versions: bool,
-        python_pyspy_processes: List[int],
+        python_pyspy_process: List[int],
     ):
         super().__init__(frequency, duration, profiler_state)
         self.add_versions = add_versions
         self._metadata = PythonMetadata(self._profiler_state.stop_event)
-        self._python_pyspy_processes = python_pyspy_processes
+        self._python_pyspy_process = python_pyspy_process
 
     def _make_command(self, pid: int, output_path: str, duration: int) -> List[str]:
         command = [
@@ -278,7 +278,7 @@ class PySpyProfiler(SpawningProcessProfilerBase):
             except Exception:
                 logger.exception(f"Couldn't add pid {process.pid} to list")
 
-        return filtered_procs + [Process(pid) for pid in self._python_pyspy_processes]
+        return filtered_procs + [Process(pid) for pid in self._python_pyspy_process]
 
     def _should_profile_process(self, process: Process) -> bool:
         return search_proc_maps(process, DETECTED_PYTHON_PROCESSES_REGEX) is not None and not self._should_skip_process(
@@ -344,12 +344,12 @@ class PySpyProfiler(SpawningProcessProfilerBase):
             help="Enable PyPerf in verbose mode (max verbosity)",
         ),
         ProfilerArgument(
-            name="--python-pyspy-processes",
-            dest="python_pyspy_processes",
+            name="--python-pyspy-process",
+            dest="python_pyspy_process",
             action="extend",
             default=[],
             type=integers_list,
-            help="List of processes (by PID) to profile with py-spy."
+            help="PID to profile with py-spy."
             " This option forces gProfiler to profile given processes with py-spy, even if"
             " they are not recognized by gProfiler as Python processes."
             " Note - gProfiler assumes that the given processes are kept running as long as gProfiler runs.",
@@ -372,7 +372,7 @@ class PythonProfiler(ProfilerInterface):
         python_add_versions: bool,
         python_pyperf_user_stacks_pages: Optional[int],
         python_pyperf_verbose: bool,
-        python_pyspy_processes: List[int],
+        python_pyspy_process: List[int],
     ):
         if python_mode == "py-spy":
             python_mode = "pyspy"
@@ -402,7 +402,7 @@ class PythonProfiler(ProfilerInterface):
                 duration,
                 profiler_state,
                 add_versions=python_add_versions,
-                python_pyspy_processes=python_pyspy_processes,
+                python_pyspy_process=python_pyspy_process,
             )
         else:
             self._pyspy_profiler = None

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -347,7 +347,9 @@ class PySpyProfiler(SpawningProcessProfilerBase):
             dest="python_pyspy_processes",
             nargs="+",
             type=int,
-            help="List of processes (by PID) to profile with py-spy." "This option forces gProfiler to ",
+            help="List of processes (by PID) to profile with py-spy."
+            "This option forces gProfiler to profile these processes with py-spy, "
+            "even if they are not detected as Python processes.",
         ),
     ],
     supported_profiling_modes=["cpu"],

--- a/gprofiler/profilers/python.py
+++ b/gprofiler/profilers/python.py
@@ -348,8 +348,9 @@ class PySpyProfiler(SpawningProcessProfilerBase):
             nargs="+",
             type=int,
             help="List of processes (by PID) to profile with py-spy."
-            "This option forces gProfiler to profile these processes with py-spy, "
-            "even if they are not detected as Python processes.",
+            "This option forces gProfiler to profile given processes with py-spy, even if"
+            "they are not recognized by gProfiler as Python processes."
+            "Note - gProfiler assumes that the given processes are alive and running forever.",
         ),
     ],
     supported_profiling_modes=["cpu"],

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -50,7 +50,7 @@ def test_python_select_by_libpython(
     We expect to select these because they have "libpython" in their "/proc/pid/maps".
     This test runs a Python named "shmython".
     """
-    with PythonProfiler(1000, 1, profiler_state, "pyspy", True, None, False, python_pyspy_processes=[]) as profiler:
+    with PythonProfiler(1000, 1, profiler_state, "pyspy", True, None, False, python_pyspy_process=[]) as profiler:
         process_collapsed = snapshot_pid_collapsed(profiler, application_pid)
     assert_collapsed(process_collapsed)
     assert all(stack.startswith("shmython") for stack in process_collapsed.keys())
@@ -110,9 +110,7 @@ def test_python_matrix(
         if python_version in ["3.7", "3.8", "3.9", "3.10", "3.11"] and profiler_type == "py-spy" and libc == "musl":
             pytest.xfail("This combination fails, see https://github.com/Granulate/gprofiler/issues/714")
 
-    with PythonProfiler(
-        1000, 2, profiler_state, profiler_type, True, None, False, python_pyspy_processes=[]
-    ) as profiler:
+    with PythonProfiler(1000, 2, profiler_state, profiler_type, True, None, False, python_pyspy_process=[]) as profiler:
         profile = snapshot_pid_profile(profiler, application_pid)
 
     collapsed = profile.stacks
@@ -169,9 +167,7 @@ def test_dso_name_in_pyperf_profile(
             "PyPerf doesn't support aarch64 architecture, see https://github.com/Granulate/gprofiler/issues/499"
         )
 
-    with PythonProfiler(
-        1000, 2, profiler_state, profiler_type, True, None, False, python_pyspy_processes=[]
-    ) as profiler:
+    with PythonProfiler(1000, 2, profiler_state, profiler_type, True, None, False, python_pyspy_process=[]) as profiler:
         profile = snapshot_pid_profile(profiler, application_pid)
     python_version, _, _ = application_image_tag.split("-")
     interpreter_frame = "PyEval_EvalFrameEx" if python_version == "2.7" else "_PyEval_EvalFrameDefault"

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -50,7 +50,7 @@ def test_python_select_by_libpython(
     We expect to select these because they have "libpython" in their "/proc/pid/maps".
     This test runs a Python named "shmython".
     """
-    with PythonProfiler(1000, 1, profiler_state, "pyspy", True, None, False) as profiler:
+    with PythonProfiler(1000, 1, profiler_state, "pyspy", True, None, False, python_pyspy_processes=[]) as profiler:
         process_collapsed = snapshot_pid_collapsed(profiler, application_pid)
     assert_collapsed(process_collapsed)
     assert all(stack.startswith("shmython") for stack in process_collapsed.keys())
@@ -110,7 +110,9 @@ def test_python_matrix(
         if python_version in ["3.7", "3.8", "3.9", "3.10", "3.11"] and profiler_type == "py-spy" and libc == "musl":
             pytest.xfail("This combination fails, see https://github.com/Granulate/gprofiler/issues/714")
 
-    with PythonProfiler(1000, 2, profiler_state, profiler_type, True, None, False) as profiler:
+    with PythonProfiler(
+        1000, 2, profiler_state, profiler_type, True, None, False, python_pyspy_processes=[]
+    ) as profiler:
         profile = snapshot_pid_profile(profiler, application_pid)
 
     collapsed = profile.stacks
@@ -167,7 +169,9 @@ def test_dso_name_in_pyperf_profile(
             "PyPerf doesn't support aarch64 architecture, see https://github.com/Granulate/gprofiler/issues/499"
         )
 
-    with PythonProfiler(1000, 2, profiler_state, profiler_type, True, None, False) as profiler:
+    with PythonProfiler(
+        1000, 2, profiler_state, profiler_type, True, None, False, python_pyspy_processes=[]
+    ) as profiler:
         profile = snapshot_pid_profile(profiler, application_pid)
     python_version, _, _ = application_image_tag.split("-")
     interpreter_frame = "PyEval_EvalFrameEx" if python_version == "2.7" else "_PyEval_EvalFrameDefault"

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -76,7 +76,7 @@ def test_pyspy(
     profiler_state: ProfilerState,
 ) -> None:
     _ = assert_app_id  # Required for mypy unused argument warning
-    with PySpyProfiler(1000, 3, profiler_state, add_versions=True) as profiler:
+    with PySpyProfiler(1000, 3, profiler_state, add_versions=True, python_pyspy_processes=[]) as profiler:
         # not using snapshot_one_collapsed because there are multiple Python processes running usually.
         process_collapsed = snapshot_pid_collapsed(profiler, application_pid)
         assert_collapsed(process_collapsed)

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -76,7 +76,7 @@ def test_pyspy(
     profiler_state: ProfilerState,
 ) -> None:
     _ = assert_app_id  # Required for mypy unused argument warning
-    with PySpyProfiler(1000, 3, profiler_state, add_versions=True, python_pyspy_processes=[]) as profiler:
+    with PySpyProfiler(1000, 3, profiler_state, add_versions=True, python_pyspy_process=[]) as profiler:
         # not using snapshot_one_collapsed because there are multiple Python processes running usually.
         process_collapsed = snapshot_pid_collapsed(profiler, application_pid)
         assert_collapsed(process_collapsed)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Expose py-spy specific flag that forces gProfiler to profile given processes.

## Related Issue
<!--- If there's an issue related, please link it here -->
<!--- If suggesting a new feature or a medium/big change, please discuss it in an issue first. -->
<!--- For small changes, it's okay to open a PR immediately. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What does it improve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your changes are tested by the CI, you can just write that.-->

## Screenshots
<!--- (if appropriate) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
