### PR TITLE
Fix GitHub Actions test failures by replacing deprecated openjdk:11-jdk image

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -290,7 +290,7 @@ runtime_image_listing: Dict[str, Dict[str, Dict[str, Any]]] = {
     "java": {
         "": {},
         "hotspot-jdk-8": {},  # add for clarity when testing with multiple JDKs
-        "hotspot-jdk-11": dict(buildargs={"JAVA_BASE_IMAGE": "openjdk:11-jdk"}),
+        "hotspot-jdk-11": dict(buildargs={"JAVA_BASE_IMAGE": "eclipse-temurin:11-jdk"}),
         "j9": dict(buildargs={"JAVA_BASE_IMAGE": "adoptopenjdk/openjdk8-openj9"}),
         "eclipse-temurin-latest": dict(buildargs={"JAVA_BASE_IMAGE": "eclipse-temurin:latest"}),
         "zing": dict(dockerfile="zing.Dockerfile"),


### PR DESCRIPTION
## Summary

This PR fixes GitHub Actions test failures in the `test-container-x64` jobs (Python 3.10, 3.11, 3.12, 3.13) caused by the deprecated `openjdk:11-jdk` Docker image.

## Problem

The `openjdk:11-jdk` Docker image has been deprecated and removed from Docker Hub, causing build errors:
```
docker.errors.BuildError: manifest for openjdk:11-jdk not found: manifest unknown: manifest unknown
```

This affected the following tests:
- `test_collect_default_jvm_flags[hotspot-jdk-11-expected_flags1-True]`
- `test_collect_cmdline_and_env_jvm_flags[hotspot-jdk-11-expected_flags1-True--XX:SelfDestructTimer=5--XX:+PrintCodeCache]`

## Solution

Replace `openjdk:11-jdk` with `eclipse-temurin:11-jdk` in `tests/conftest.py:293`. Eclipse Temurin is the official successor to the OpenJDK Docker images and is actively maintained by the Eclipse Foundation.

This change is consistent with other JDK images already used in the test suite (e.g., `eclipse-temurin:latest`).

## Test Plan

- [ ] GitHub Actions `test-container-x64` jobs should now pass for all Python versions
- [ ] The two previously failing Java tests should now succeed
- [ ] No other tests should be affected by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)