### PR TITLE
Fix PerfSpect failing in containerized environments due to missing sudo

### DIFF
--- a/gprofiler/hw_metrics.py
+++ b/gprofiler/hw_metrics.py
@@ -93,6 +93,7 @@ class HWMetricsMonitor(HWMetricsMonitorBase):
             str(self._perfspect_duration),
             "--output",
             PERFSPECT_DATA_DIRECTORY,
+            "--noroot",
         ]
 
         # Add --debug if verbose is enabled


### PR DESCRIPTION
# Fix PerfSpect failing in containerized environments due to missing sudo

## Problem

When running gProfiler with hardware metrics collection enabled inside a container, PerfSpect was becoming a zombie/defunct process and failing to collect any metrics. Investigation revealed that PerfSpect was attempting to use `sudo` to elevate privileges for running `perf stat` commands, but `sudo` is typically not available in container environments.

### Error observed:
```json
{"level":"ERROR","msg":"error from perf","error":"failed to run command (sudo bash /root/perfspect_temp/perfspect.tmp.3437908981/perf_stat.sh): exec: \"sudo\": executable file not found in $PATH"}
```

This caused PerfSpect to terminate immediately, resulting in:
- Zombie/defunct processes visible in `ps aux`
- No hardware metrics being collected
- Silent failure with minimal error logging

## Solution

Added the `--noroot` flag to the PerfSpect command invocation in `hw_metrics.py`. This flag prevents PerfSpect from attempting privilege elevation via `sudo`, which is unnecessary when:
- Running inside containers (typically already running as root)
- gProfiler already has sufficient privileges for system-wide monitoring
- The environment doesn't have `sudo` installed

## Changes

### `gprofiler/hw_metrics.py`
- Added `--noroot` flag to PerfSpect metrics command
- This allows PerfSpect to run with current privileges without attempting to use `sudo`

## Testing

- ✅ Tested in containerized environment where issue was originally observed
- ✅ Verified PerfSpect no longer attempts to use `sudo`
- ✅ Confirmed hardware metrics are now collected successfully
- ✅ No more zombie/defunct PerfSpect processes

## Impact

- **Containers**: Hardware metrics collection now works properly in containerized environments
- **Non-container deployments**: No impact, as the flag simply prevents unnecessary privilege escalation attempts
- **Backwards compatibility**: The `--noroot` flag is available in recent PerfSpect versions

## Related Issues

This fix addresses the zombie process issue discovered during container testing where PerfSpect would fail immediately with "sudo: command not found" errors.
