### PR TITLE
Update requests to 2.33.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 psutil==7.0.0
-requests==2.32.4
+requests==2.33.0
 ConfigArgParse==1.7
 distro==1.9.0
 setuptools==78.1.1  # For pkg_resources


### PR DESCRIPTION
## Summary
- Updates `requests` dependency from 2.32.4 to 2.33.0 in both gprofiler and granulate-utils submodule
- Updates `black` from 25.1.0 to 26.3.1 in granulate-utils

## Changes
- Main repo: `requirements.txt` - requests 2.32.4 → 2.33.0
- Submodule: `granulate-utils/requirements.txt` - requests 2.32.4 → 2.33.0
- Submodule: `granulate-utils/dev-requirements.txt` - black 25.1.0 → 26.3.1

## Test plan
- [ ] Verify dependency installation works correctly
- [ ] Run existing tests to ensure compatibility
- [ ] Check for any breaking changes in requests 2.33.0 release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)