### PR TITLE
Update pytest to 9.0.3 to fix CVE-2025-71176

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-pytest==8.3.5
+pytest==9.0.3
 pytest-rerunfailures==15.0
 flake8==7.2.0
 black==26.3.1


### PR DESCRIPTION
## Summary
- Updates pytest from 8.3.5 to 9.0.3 to fix CVE-2025-71176 (vulnerable tmpdir handling)
- Updates granulate-utils submodule with pytest-asyncio 1.3.0 for pytest 9.x compatibility

## CVE Details
- **CVE-2025-71176**: pytest through 9.0.2 on UNIX relies on directories with the `/tmp/pytest-of-{user}` name pattern, which allows local users to cause a denial of service or possibly gain privileges
- **Severity**: Medium (CVSS 6.8)
- **Fix**: Upgrade to pytest 9.0.3+

## Test plan
- [x] gprofiler tests pass (17 passed)
- [x] granulate-utils tests pass (48 passed)

## Dependencies
- Requires merging granulate-utils PR first: https://github.com/intel/granulate-utils/pull/276

🤖 Generated with [Claude Code](https://claude.com/claude-code)