### PR TITLE
Add implement-from-spec skill for architecture-aware feature work

### DIFF
--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -7,105 +7,75 @@ user-invocable: true
 
 ## gProfiler Architecture Overview
 
-### High-Level Architecture
+gProfiler now has two important paths:
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│                      gprofiler/main.py                       │
-│                    (Orchestration Layer)                     │
-├─────────────────────────────────────────────────────────────┤
-│  ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌────────┐│
-│  │  perf   │ │  Java   │ │ Python  │ │  Ruby   │ │  .NET  ││
-│  │profiler │ │profiler │ │profiler │ │profiler │ │profiler││
-│  └────┬────┘ └────┬────┘ └────┬────┘ └────┬────┘ └───┬────┘│
-│       └──────────┴──────────┴──────────┴───────────┘      │
-│                         ▼                                   │
-│              gprofiler/merge.py                             │
-│           (Profile Data Aggregation)                        │
-├─────────────────────────────────────────────────────────────┤
-│                    Output Layer                              │
-│  ┌─────────────┐  ┌─────────────┐  ┌─────────────────────┐ │
-│  │ Flamegraph  │  │   Upload    │  │   Local Output      │ │
-│  │   (HTML)    │  │  (Studio)   │  │   (collapsed)       │ │
-│  └─────────────┘  └─────────────┘  └─────────────────────┘ │
-└─────────────────────────────────────────────────────────────┘
-```
+1. **Classic profiling path**: discover processes -> select profilers -> collect samples -> merge -> output/upload
+2. **Dynamic profiling control path**: heartbeat with backend -> receive commands -> queue/prioritize -> run continuous or ad-hoc profiling -> report completion
 
-### Key Components
+When answering architecture questions, identify which path the request touches before reading or editing code.
 
-#### 1. Profiler Registry (`gprofiler/profilers/registry.py`)
-- Decorator-based profiler registration
-- Runtime discovery of available profilers
-- Configuration-based profiler selection
+### Main architecture areas
 
-#### 2. Profiler Base (`gprofiler/profilers/profiler_base.py`)
-- Abstract base class for all profilers
-- Lifecycle: `start()` → `snapshot()` → `stop()`
-- Common utilities for process discovery
+| Area | Primary files | What belongs here |
+|------|---------------|-------------------|
+| CLI + orchestration | `gprofiler/main.py` (~1546) | Argument parsing, runtime wiring, top-level orchestration. Treat as a hotspot; avoid broad edits if a narrower seam exists. |
+| Profiler registration + lifecycle | `gprofiler/profilers/registry.py`, `gprofiler/profilers/profiler_base.py` | Registration, mode selection, `start()` / `snapshot()` / `stop()` lifecycle. |
+| Runtime profilers | `gprofiler/profilers/*.py` | Runtime/tool-specific logic: process discovery, sampling, stack parsing, cleanup. |
+| Merge/output | `gprofiler/merge.py` (~330) | Stack aggregation, symbol handling, output shaping. |
+| Metadata enrichment | `gprofiler/metadata/` | Application identifiers and host/system metadata. |
+| Dynamic profiling command control | `gprofiler/dynamic_profiling_management/heartbeat.py` (~354), `command_control.py` (~233), `continuous.py` (~68), `ad_hoc.py` (~76) | Heartbeat polling, command parsing, queue priority, pause/resume, execution routing. |
+| Shared test infrastructure | `tests/conftest.py` (~708) | Docker fixtures, runtime builders, cleanup. Shared and regression-sensitive. |
 
-#### 3. Individual Profilers (`gprofiler/profilers/*.py`)
+### Runtime profilers
 
-| Profiler | Backend Tool | Key Features |
-|----------|--------------|--------------|
-| `perf.py` | Linux perf | System-wide, kernel stacks |
-| `java.py` | async-profiler | JVM attach, allocation profiling |
-| `python.py` | py-spy | No instrumentation needed |
-| `python_ebpf.py` | PyPerf | eBPF-based, lower overhead |
+| Profiler | Backend tool | Notes |
+|----------|--------------|-------|
+| `perf.py` | Linux perf | System-wide profiling, kernel/user stacks |
+| `java.py` | async-profiler | JVM attach, allocation profiling, large hotspot (~1555 lines) |
+| `python.py` | py-spy | Python sampling without instrumentation |
+| `python_ebpf.py` | PyPerf | eBPF-based Python profiling |
 | `ruby.py` | rbspy | Ruby VM sampling |
 | `php.py` | phpspy | PHP process profiling |
-| `dotnet.py` | dotnet-trace | .NET Core/5+ support |
-| `node.py` | perf | V8 JavaScript profiling |
+| `dotnet.py` | dotnet-trace | .NET support |
+| `node.py` | perf | Node/V8 profiling |
 
-#### 4. Merge Layer (`gprofiler/merge.py`)
-- Combines samples from multiple profilers
-- Handles symbol resolution
-- Produces unified stack traces
+### Classic profiling data flow
 
-#### 5. Metadata Collection (`gprofiler/metadata/`)
-- `application_identifiers.py` - Extracts app names from processes
-- `system_metadata.py` - Collects host information
-- Enriches profiles with context
-
-### Data Flow
-
-```
-1. Process Discovery
-   └── Scan /proc for target processes
-
-2. Profiler Selection
-   └── Match processes to appropriate profilers
-
-3. Sampling
-   └── Each profiler collects stacks independently
-
-4. Aggregation
-   └── merge.py combines all samples
-
-5. Output
-   └── Generate flamegraph or upload to Studio
+```text
+1. Discover target processes
+2. Select profilers / modes
+3. Each profiler samples independently
+4. merge.py aggregates results
+5. Output collapsed stacks, flamegraph data, or upload results
 ```
 
-### Key Files to Understand
+### Dynamic profiling control flow
 
-| File | Lines | Purpose |
-|------|-------|---------|
-| `main.py` | ~1500 | Entry point, CLI, orchestration |
-| `profilers/perf.py` | ~500 | Core perf integration |
-| `profilers/java.py` | ~1800 | Complex JVM profiling |
-| `merge.py` | ~400 | Profile aggregation |
-| `utils/perf_process.py` | ~200 | perf subprocess management |
+```text
+1. Backend receives profiling request
+2. Agent heartbeat polls for work
+3. heartbeat.py parses command payload
+4. command_control.py enqueues by priority
+5. continuous.py or ad_hoc.py executes the command
+6. Agent reports command completion
+```
 
-### Extension Points
+Priority is `stop > adhoc > continuous`. Do not describe or implement a parallel control path unless the existing heartbeat/queue system is truly insufficient.
 
-1. **Add new profiler**: Implement `ProfilerBase`, use `@register_profiler`
-2. **Add metadata**: Extend `application_identifiers.py`
-3. **New output format**: Modify `main.py` output handling
-4. **New deployment**: Add to `deploy/` directory
+### Where to make changes
 
-### Instructions
+- **Add a new profiler**: new file under `gprofiler/profilers/`, register via `@register_profiler`, add targeted tests.
+- **Change profiler behavior**: edit the specific profiler first; avoid `main.py` unless CLI/wiring must change.
+- **Change merge or output**: start in `gprofiler/merge.py`.
+- **Change heartbeat / dynamic profiling**: start in `gprofiler/dynamic_profiling_management/`.
+- **Change shared test behavior**: touch `tests/conftest.py` only when multiple tests need new shared infra.
 
-When user asks about architecture:
-1. Start with high-level overview above
-2. Dive into specific component if asked
-3. Reference actual code files with line numbers
-4. Explain data flow through the system
+### Guidance when answering users
+
+1. Start with the smallest relevant architecture slice, not the whole repo.
+2. If the request is about command-driven profiling, include the heartbeat + queue modules, not just `main.py`.
+3. Call out hotspot files when relevant:
+   - `gprofiler/main.py` (~1546)
+   - `gprofiler/profilers/java.py` (~1555)
+   - `tests/conftest.py` (~708)
+4. Prefer concrete file references over generic descriptions.

--- a/.claude/skills/heartbeat/SKILL.md
+++ b/.claude/skills/heartbeat/SKILL.md
@@ -38,18 +38,33 @@ export GPROFILER_SERVICE="your-service-name"
 export GPROFILER_SERVER="http://localhost:8080"
 
 /opt/gprofiler/gprofiler \
+  --enable-heartbeat-server \
   -u \
   --token=$GPROFILER_TOKEN \
   --service-name=$GPROFILER_SERVICE \
-  --server-host $GPROFILER_SERVER \
+  --api-server $GPROFILER_SERVER \
   --dont-send-logs \
   --server-upload-timeout 10 \
   -c \
   --disable-metrics-collection \
   --java-safemode= \
+  --heartbeat-interval 30 \
   -d 60 \
   --java-no-version-check
 ```
+
+`--server-host` still exists as a deprecated alias, but prefer `--api-server`.
+
+### Required flags
+
+Current `main.py` validation requires heartbeat mode to include:
+
+- `--enable-heartbeat-server`
+- `--upload-results`
+- `--token`
+- `--service-name`
+
+Use the skill to explain or debug this mode only in terms of the current flags above.
 
 ### Command Flow
 
@@ -80,6 +95,8 @@ export GPROFILER_SERVER="http://localhost:8080"
 | `continuous_queue` | Long-running start commands | 1 |
 
 Priority: `stop > adhoc > continuous`
+
+The current implementation lives under `gprofiler/dynamic_profiling_management/`. Do not refer users to `gprofiler/command_control.py`; that path is stale.
 
 ### API Endpoints
 
@@ -133,10 +150,34 @@ Requirements:
 ### Key Files
 
 ```
-gprofiler/main.py              # Heartbeat integration
-gprofiler/command_control.py   # CommandManager class
-docs/HEARTBEAT_SYSTEM_README.md # Full documentation
+gprofiler/main.py                                       # CLI + heartbeat flag validation
+gprofiler/dynamic_profiling_management/heartbeat.py     # Polling and command handling
+gprofiler/dynamic_profiling_management/command_control.py # Queue logic and priority
+gprofiler/dynamic_profiling_management/continuous.py    # Continuous slot
+gprofiler/dynamic_profiling_management/ad_hoc.py        # Ad-hoc slot
+tests/test_heartbeat_system.py                          # Heartbeat flow validation
+docs/HEARTBEAT_SYSTEM_README.md                         # Full documentation
 ```
+
+### Testing heartbeat changes
+
+Use the smallest useful validation first:
+
+```bash
+# Focused heartbeat test
+sudo python3 -m pytest -v tests/test_heartbeat_system.py
+
+# Lightweight broader regression
+sudo ./tests/test.sh --executable
+```
+
+For local end-to-end testing against a backend, the repo docs describe this sequence:
+
+1. Start the Performance Studio backend.
+2. Run `python tests/run_heartbeat_agent.py`
+3. Submit commands with `python tests/test_heartbeat_system.py --live`
+
+Prefer the existing docs/test scripts over inventing custom heartbeat harnesses.
 
 ### Troubleshooting
 
@@ -161,6 +202,7 @@ docs/HEARTBEAT_SYSTEM_README.md # Full documentation
 --enable-heartbeat-server     # Enable heartbeat mode
 --heartbeat-interval 30       # Heartbeat frequency (seconds)
 --api-server URL              # Backend server URL
+--server-host URL             # Deprecated alias for --api-server
 --upload-results              # Required for heartbeat mode
 --token TOKEN                 # Authentication token
 --service-name NAME           # Service identifier
@@ -168,15 +210,9 @@ docs/HEARTBEAT_SYSTEM_README.md # Full documentation
 --perfspect-path PATH         # PerfSpect binary path
 ```
 
----
+### Review points for heartbeat work
 
-## TODO: Skill Content to Add
-
-- [ ] **Add complete API reference** - All heartbeat API endpoints with examples
-- [ ] **Add command_control.py documentation** - CommandManager class details
-- [ ] **Add authentication flow** - Token validation and refresh
-- [ ] **Add error response codes** - All possible error responses
-- [ ] **Add deployment examples** - K8s, Docker Compose, systemd configs
-- [ ] **Add PerfSpect output examples** - Sample hardware metrics output
-- [ ] **Add monitoring integration** - How to monitor heartbeat health
-- [ ] **Add scaling guidance** - Multi-agent deployment patterns
+- Preserve queue semantics: `stop > adhoc > continuous`
+- Preserve idempotency; do not allow the same command to execute twice
+- Avoid moving heartbeat logic into `main.py` if `dynamic_profiling_management/` is sufficient
+- Add targeted heartbeat tests before broader regression runs

--- a/.claude/skills/implement-from-spec/SKILL.md
+++ b/.claude/skills/implement-from-spec/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: implement-from-spec
+description: Implement gProfiler changes from a design spec. Use when the user asks to build a feature, modify behavior, or turn an architecture/design proposal into code with local setup, targeted unit/e2e tests, and regression-aware review.
+context: fork
+user-invocable: true
+---
+
+## Implementing gProfiler Changes From a Design Spec
+
+Use this skill when the task is not just "edit code", but "map a spec onto the current gProfiler architecture, implement it with the smallest safe change, and prove it locally."
+
+## Workflow
+
+1. Read the design spec and classify the change before editing code.
+2. Map the request onto the current architecture and choose the smallest existing flow that already solves most of the problem.
+3. Prefer extending an existing path over inventing a parallel one.
+4. Make focused edits first, then run the smallest test set that exercises the changed path.
+5. Expand to broader regression coverage only after targeted tests pass.
+6. Do an architecture-aware review before handing off.
+
+## Architecture map
+
+| Area | Primary files | Notes |
+|------|---------------|-------|
+| CLI + orchestration | `gprofiler/main.py` (~1546 lines) | Entry point, wiring, runtime args. High-risk hotspot; avoid broad rewrites. |
+| Dynamic profiling command control | `gprofiler/dynamic_profiling_management/command_control.py` (~233), `heartbeat.py` (~354), `continuous.py` (~68), `ad_hoc.py` (~76) | Best place for heartbeat polling, queueing, start/stop handling, pause/resume semantics. |
+| Runtime profilers | `gprofiler/profilers/*.py` | Extend the profiler-specific module before touching orchestration. Large hotspots include `java.py` (~1555) and `perf.py` (~441). |
+| Merge/output | `gprofiler/merge.py` (~330) | Use for stack merging and output shaping, not profiler lifecycle changes. |
+| Test harness | `tests/conftest.py` (~708), `tests/test_heartbeat_system.py` (~362), targeted `tests/test_*.py` | `conftest.py` is shared infra and regression-sensitive. Change it only when the spec truly needs new shared fixtures/behaviors. |
+
+## Choose the right existing flow
+
+### If the spec changes command-driven profiling
+
+Prefer this flow:
+
+1. Heartbeat poll / response handling in `gprofiler/dynamic_profiling_management/heartbeat.py`
+2. Queueing / priority rules in `gprofiler/dynamic_profiling_management/command_control.py`
+3. Execution routing in `continuous.py` or `ad_hoc.py`
+4. Completion / status propagation back through the heartbeat path
+5. Tests in `tests/test_heartbeat_system.py` plus any targeted profiler tests
+
+Do **not** add a second control path if the existing heartbeat + `CommandManager` path can be extended.
+
+### If the spec changes sampling or profiler behavior
+
+Prefer:
+
+1. Update the specific profiler in `gprofiler/profilers/`
+2. Keep lifecycle behavior compatible with `ProfilerBase`
+3. Only touch `main.py` if the change needs new CLI wiring or orchestration
+4. Add/adjust profiler-specific tests before broad test-suite runs
+
+### If the spec changes stack merging, metadata, or output
+
+Prefer:
+
+1. `gprofiler/merge.py` for aggregation/output semantics
+2. `gprofiler/metadata/` for metadata enrichment
+3. README/help text only if the change is user-visible
+
+## Command-control example
+
+For a design such as "add new targeting metadata to heartbeat and make command dispatch use it":
+
+1. Start with `docs/HEARTBEAT_SYSTEM_README.md` to understand the current protocol.
+2. Check `heartbeat.py` for payload creation/parsing.
+3. Check `command_control.py` for queue semantics:
+   - stop commands stay highest priority
+   - ad-hoc commands outrank continuous commands
+   - continuous commands may be paused/resumed
+4. Keep idempotency intact. Do not create a path that can enqueue or execute the same command twice.
+5. Validate with `tests/test_heartbeat_system.py` and then broader tests if shared behavior changed.
+
+## Local setup and test bootstrap
+
+Prefer the repo's existing test harness over ad-hoc local setup. It already knows how to install dependencies and spin up runtime resources.
+
+### First-time setup
+
+```bash
+git submodule update --init
+python3 -m pip install -r requirements.txt -r dev-requirements.txt
+sudo python3 -m pip install -r requirements.txt -r dev-requirements.txt
+./scripts/copy_resources_from_image.sh
+```
+
+### Fastest way to bootstrap the test stack
+
+```bash
+sudo ./tests/test.sh --executable
+```
+
+Use this first when you need a quick sanity check without the full container/resource-heavy suite.
+
+### Full local validation
+
+```bash
+sudo ./tests/test.sh
+```
+
+Notes:
+
+- `tests/test.sh` can auto-install missing apt packages and Docker dependencies unless `NO_APT_INSTALL` is set.
+- The pytest infrastructure and `tests/conftest.py` spin up the needed runtime containers/resources for many tests. Prefer that over writing one-off setup scripts.
+- If `gprofiler/resources/perf` is missing, extract resources first rather than patching tests around it.
+
+## Test selection matrix
+
+Run the narrowest useful test first, then widen.
+
+| Change type | First tests | Then |
+|-------------|-------------|------|
+| Dynamic profiling / heartbeat / queue behavior | `sudo python3 -m pytest -v tests/test_heartbeat_system.py` | `sudo ./tests/test.sh --executable`, then `sudo ./tests/test.sh` if shared behavior changed |
+| Specific profiler behavior | Target that file, for example `sudo python3 -m pytest -v tests/test_perf.py` or `tests/test_java.py` | Full suite if lifecycle/shared fixtures changed |
+| Merge/output/metadata | Targeted `tests/test_merge.py`, `tests/test_app_metadata.py`, `tests/test_appids.py` | `sudo ./tests/test.sh --executable` or full suite depending on scope |
+| Shared fixtures / `main.py` / cross-cutting changes | Start with the most relevant targeted tests | Always finish with `sudo ./tests/test.sh` before handoff |
+
+For debugging:
+
+```bash
+cd tests && sudo python3 -m pytest -v -s --tb=long -k "test_name"
+docker ps -a
+```
+
+## Regression-aware implementation rules
+
+- Extend the current flow before adding a new abstraction.
+- Keep behavior compatible with existing queue priority and cancellation semantics.
+- Preserve cleanup paths for spawned profilers/processes.
+- Respect root-only / privileged behavior in tests and runtime code.
+- Avoid changing `tests/conftest.py` unless multiple tests truly need the new fixture or environment behavior.
+- If you touch a large hotspot file, explain why a smaller module was not sufficient.
+
+## Architecture-aware review checklist
+
+- [ ] The spec was mapped to an existing flow before code was added.
+- [ ] No duplicate control path was introduced for heartbeat/command handling.
+- [ ] `CommandManager` priority still behaves as `stop > adhoc > continuous`.
+- [ ] Idempotency and completion reporting still make sense.
+- [ ] New code uses the smallest reasonable seam instead of broad rewrites in `main.py`, `java.py`, or `conftest.py`.
+- [ ] User-visible changes update docs/help text if needed.
+- [ ] Targeted tests were run first, and broader regression coverage was added when the change touched shared code.
+- [ ] The final test plan clearly separates unit-ish targeted tests from heavier end-to-end validation.
+
+## When to stop and rethink
+
+Stop and revisit the plan if:
+
+- the design spec seems to require a new control path even though heartbeat/queueing already covers it
+- the change starts spreading across `main.py`, multiple profilers, and `conftest.py` at once
+- the only way to make progress is to skip the repo's existing test harness
+- targeted tests cannot be identified from the changed architecture area
+
+In those cases, narrow the design, split the change, or document why a larger refactor is unavoidable.

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -9,6 +9,20 @@ description: Review code changes against gProfiler coding standards. Use when th
 
 !`git diff --stat HEAD 2>/dev/null || echo "No git changes"`
 
+### Hotspots to review carefully
+
+Large shared files deserve extra skepticism because regressions spread quickly:
+
+| File | Approx. lines | Review concern |
+|------|---------------|----------------|
+| `gprofiler/main.py` | ~1546 | Broad orchestration / CLI changes can affect many runtimes |
+| `gprofiler/profilers/java.py` | ~1555 | Complex runtime-specific behavior |
+| `tests/conftest.py` | ~708 | Shared fixtures; small changes can break many tests |
+| `gprofiler/dynamic_profiling_management/heartbeat.py` | ~354 | Command-control behavior and backend contract |
+| `gprofiler/dynamic_profiling_management/command_control.py` | ~233 | Queue semantics and execution ordering |
+
+Ask whether the change could have been made in a smaller seam before accepting edits to these files.
+
 ### Coding Standards
 
 #### Python Style
@@ -30,10 +44,20 @@ description: Review code changes against gProfiler coding standards. Use when th
 - [ ] Respects `stop_event` for cancellation
 - [ ] Handles missing/unavailable profiler tools
 
+#### Architecture-Aware Checks
+- [ ] The change extends an existing flow instead of creating a parallel one
+- [ ] Dynamic profiling work stays in `gprofiler/dynamic_profiling_management/` unless `main.py` wiring is truly required
+- [ ] `CommandManager` behavior still preserves `stop > adhoc > continuous`
+- [ ] Idempotency / completion semantics still make sense for command-driven changes
+- [ ] Shared fixtures in `tests/conftest.py` changed only if multiple tests truly need new shared infra
+- [ ] User-visible CLI or runtime behavior stays backward-compatible unless the change explicitly intends a break
+
 #### Testing
 - [ ] Tests added for new functionality
-- [ ] Tests run with root privileges considered
-- [ ] Docker fixtures used for runtime testing
+- [ ] The smallest relevant targeted tests were run first
+- [ ] Root privileges and runtime requirements were considered
+- [ ] Broader regression coverage was added when shared code changed
+- [ ] Docker fixtures / existing test harness were used instead of ad-hoc setup
 
 #### Documentation
 - [ ] README updated for user-facing changes
@@ -50,16 +74,16 @@ description: Review code changes against gProfiler coding standards. Use when th
    - Unclosed file handles or processes
    - Missing cleanup in exception paths
    - Hardcoded paths that should be configurable
+5. If command-control files changed, explicitly review:
+   - queue priority
+   - pause/resume behavior
+   - duplicate-command protection
+   - completion / failure reporting
+6. If `main.py` or `tests/conftest.py` changed, ask whether a smaller module could have absorbed the change
 
----
+### Common regression traps
 
-## TODO: Skill Content to Add
-
-- [ ] **Add code pattern examples** - Good vs bad code patterns
-- [ ] **Add profiler-specific review rules** - Per-profiler considerations
-- [ ] **Add performance review criteria** - Overhead and efficiency checks
-- [ ] **Add security checklist expansion** - More security review items
-- [ ] **Add test coverage requirements** - Minimum coverage expectations
-- [ ] **Add backwards compatibility checks** - CLI and API stability
-- [ ] **Add resource cleanup patterns** - File handle and process cleanup
-- [ ] **Add logging review guidelines** - What and how to log
+- Putting runtime-specific logic into `main.py` instead of the relevant profiler or dynamic-profiling module
+- Introducing a second control path instead of extending heartbeat + queue handling
+- Editing shared fixtures for a single test case
+- Adding heavyweight full-suite expectations when a narrower targeted test would have validated the change first

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -8,6 +8,17 @@ allowed-tools: Bash(sudo *) Bash(pytest *) Bash(python3 -m pytest *) Bash(./test
 
 **Important:** Tests require root privileges (sudo) for profiling system resources.
 
+### First-time local setup
+
+```bash
+git submodule update --init
+python3 -m pip install -r requirements.txt -r dev-requirements.txt
+sudo python3 -m pip install -r requirements.txt -r dev-requirements.txt
+./scripts/copy_resources_from_image.sh
+```
+
+Prefer the repo's existing harness over custom setup scripts. `tests/test.sh` already installs missing apt packages unless `NO_APT_INSTALL` is set, checks required resources, and runs pytest with the expected environment.
+
 ### Quick Commands
 
 ```bash
@@ -26,6 +37,19 @@ cd tests && sudo python3 -m pytest -v -k "test_java_profiling"
 # Run with verbose output
 cd tests && sudo python3 -m pytest -v -s test_sanity.py
 ```
+
+### Staged test strategy
+
+Run the narrowest useful tests first, then widen:
+
+| Change type | First tests | Then |
+|-------------|-------------|------|
+| Heartbeat / dynamic profiling / queue logic | `sudo python3 -m pytest -v tests/test_heartbeat_system.py` | `sudo ./tests/test.sh --executable`, then `sudo ./tests/test.sh` if shared code changed |
+| Specific profiler | Target that profiler's test file | `sudo ./tests/test.sh --executable` or full suite if lifecycle/shared infra changed |
+| Merge / metadata / output | `tests/test_merge.py`, `tests/test_app_metadata.py`, `tests/test_appids.py` | Broader regression depending on touched files |
+| `main.py`, `tests/conftest.py`, or cross-cutting changes | Most relevant targeted tests first | Always end with `sudo ./tests/test.sh` |
+
+This staged approach reduces regression risk without paying full-suite cost for every small change.
 
 ### Test Categories
 
@@ -68,6 +92,8 @@ cd tests && sudo python3 -m pytest -v -s test_sanity.py
 - `pytest-rerunfailures` - Retry flaky tests
 - `pytest-timeout` - Prevent hanging tests
 
+Treat `tests/conftest.py` as shared infrastructure. Only change it when multiple tests need new common behavior.
+
 ### Running Tests for Specific Profilers
 
 ```bash
@@ -104,16 +130,24 @@ cd tests && sudo python3 -m pytest -v --ignore=test_bigdata.py
 
 ### Test Environment Setup
 
+For most contributors, the setup above plus `sudo ./tests/test.sh --executable` is the fastest way to prove the local test stack is healthy.
+
+### Heartbeat / local e2e testing
+
+For command-driven profiling changes:
+
 ```bash
-# Install dev dependencies
-pip3 install -r dev-requirements.txt
-
-# Ensure root has same packages
-sudo pip3 install -r dev-requirements.txt
-
-# Copy resources (if testing from source)
-./scripts/copy_resources_from_image.sh
+# Focused heartbeat validation
+sudo python3 -m pytest -v tests/test_heartbeat_system.py
 ```
+
+For a live backend flow, the heartbeat docs describe:
+
+1. Start Performance Studio backend
+2. Run `python tests/run_heartbeat_agent.py`
+3. Submit commands with `python tests/test_heartbeat_system.py --live`
+
+Use the existing scripts above instead of writing a one-off harness.
 
 ### Debugging Test Failures
 
@@ -138,15 +172,9 @@ docker logs <container_id>
 4. Run container tests
 5. Deploy on tag push
 
----
+### Validation checklist
 
-## TODO: Skill Content to Add
-
-- [ ] **Add test fixture documentation** - Explain each conftest.py fixture in detail
-- [ ] **Add example test patterns** - Copy-paste templates for new profiler tests
-- [ ] **Add Docker test image list** - Complete list of runtime test images
-- [ ] **Add test environment variables** - Document all test-related env vars
-- [ ] **Add local test setup guide** - Step-by-step for first-time test runners
-- [ ] **Add test output interpretation** - How to read test results and logs
-- [ ] **Add flaky test retry patterns** - Document retry decorator usage
-- [ ] **Add CI test matrix details** - What tests run on which platforms
+- [ ] Choose targeted tests based on the changed architecture area
+- [ ] Use `sudo ./tests/test.sh --executable` as the default broader sanity pass
+- [ ] Run full `sudo ./tests/test.sh` after shared-fixture or cross-cutting changes
+- [ ] Reuse existing test harness/scripts instead of ad-hoc local setup


### PR DESCRIPTION
## Summary

This stacks on top of #1042 by adding a new `.claude` skill focused on the end-to-end workflow we want AI agents to follow when implementing gProfiler changes from a design spec.

The new `implement-from-spec` skill teaches the agent to:

- map a design spec onto the current gProfiler architecture before editing code
- prefer extending the smallest existing flow instead of creating a parallel path
- use the current dynamic profiling / command-control path (`heartbeat.py`, `command_control.py`, `continuous.py`, `ad_hoc.py`) as the default seam for command-driven changes
- bootstrap local validation with the repo's existing harness (`./tests/test.sh`, `./scripts/copy_resources_from_image.sh`) instead of inventing custom setup
- choose targeted tests first, then broaden to executable / full regression runs only when the scope requires it
- review changes against today's architecture and shared hotspots such as `main.py`, `tests/conftest.py`, and queue-priority semantics

## Why a new skill

The draft skills in #1042 already cover architecture, testing, review, and heartbeat individually, but they do not yet give an agent one clear workflow for:

1. implementing from a spec
2. selecting the correct existing code path
3. validating locally with the repo-native setup
4. avoiding regressions in shared orchestration / test infrastructure

This skill fills that gap without making the existing draft skills much longer.

## Test plan

- [x] Keep the new skill concise (`SKILL.md` is 155 lines)
- [x] Cross-check file references and line counts against the current repo
- [x] Confirm local setup and test commands match `CONTRIBUTING.md` and `tests/test.sh`
- [x] Confirm command-control guidance matches the current dynamic profiling files and heartbeat tests

Made with [Cursor](https://cursor.com)