### PR TITLE
Bump version to 1.57.1 and update Alpine to 3.24.1

### DIFF
--- a/container.Dockerfile
+++ b/container.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23.3 AS gprofiler
+FROM alpine:3.24.1 AS gprofiler
 
 ARG ARCH
 ARG EXE_PATH=build/${ARCH}/gprofiler

--- a/gprofiler/__init__.py
+++ b/gprofiler/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "1.57.0"
+__version__ = "1.57.1"


### PR DESCRIPTION
## Summary
- Update Alpine base image from 3.23.3 to 3.24.1 (latest stable)
- Bump gProfiler version from 1.57.0 to 1.57.1

## Test plan
- [ ] Verify container builds successfully with new Alpine base
- [ ] Run basic profiling tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)